### PR TITLE
[copr-dist-git] Don't assume the SCM repo has the same name as the package

### DIFF
--- a/dist-git/dist_git/dist_git_importer.py
+++ b/dist-git/dist_git/dist_git_importer.py
@@ -324,9 +324,9 @@ class MockScmProvider(SrpmBuilderProvider):
 
     def scm_option_get(self):
         return {
-            "git": "git_get='git clone --depth 1 {}'",
-            "svn": "git_get='git svn clone {}'"
-        }[self.task.mock_scm_type].format(self.task.mock_scm_url)
+            "git": "git_get='git clone --depth 1 {} {}'",
+            "svn": "git_get='git svn clone {} {}'"
+        }[self.task.mock_scm_type].format(self.task.mock_scm_url, self.task.package_name)
 
 
 class PyPIProvider(SrpmBuilderProvider):


### PR DESCRIPTION
Mock(-scm) expects the cloned directory to has the same name as the package
it's building. To make sure it is so we explicitly pass the package name to
git clone as a destination directory name.

This allows (amont other things) to have a single git repo for multiple spec
files.