### PR TITLE
backend (mockremote): improve chroot_setup_cmd replacement for EL-5

### DIFF
--- a/backend/backend/mockremote/builder.py
+++ b/backend/backend/mockremote/builder.py
@@ -147,8 +147,9 @@ class Builder(object):
         }
         buildroot_cmd = (
             "dest=/etc/mock/{chroot}.cfg"
-            " line=\"config_opts['chroot_setup_cmd'] = 'install @buildsys-build {pkgs}'\""
-            " regexp=\"^.*chroot_setup_cmd.*$\""
+            " line=\"config_opts['chroot_setup_cmd'] = 'install \1 {pkgs}'\""
+            " regexp=\"^.*chroot_setup_cmd.*(@buildsys-build|buildsys-build buildsys-macros).*$\""
+            " backrefs=yes"
         )
 
         disable_networking_cmd = (


### PR DESCRIPTION
The buildsys-build group in epel-5 does not install the buildsys-macros
package.  This prevents macros like %{rhel} from being defined, which is
commonly used in spec files to properly handle older releases.

Using backreferences in the regex allows the replacement to handle both
"@buildsys-build" and "buildsys-build buildsys-macros" used by
Fedora/EL-6+ and EL-5, respectively.

---

This is one of several ways such a change could be made.  Alternatives would be to specifically match `self.chroot.startswith('epel-5-')` and set a variable contaning the desired packages/groups to install (`@buildsys-build` by default or `buildsys-build buildsys-macros` for epel-5).  This could also be fixed in an ansible playbook for deployment.

I chose this method as it was more generic and would work for someone building for EL-5 with a differently-named chroot.

In testing, the backrefs did not work as expected with ansible-1.8.4, but that's fairly old and likely isn't something worth supporting.  I didn't extensively test what versions of ansible fix the issue, as I only had convenient acccess to 1.8.4 (on CentOS 6) and 1.9.4 (on Fedora 22).  The backrefs work as expected on 1.9.4.

I ran into this issue while attempting to setup a copr for building the git packages from rawhide for older releases.  That copr is [here](https://copr.fedorainfracloud.org/coprs/tmz/git/).  In the git spec file we use the `%{rhel}` macro to set a number of other globals enabling or disabling features.  One specific condition in the git.spec is `%if 0%{?rhel} && 0%{?rhel} <= 5`.

There are various work-arounds possible (using %{el5} is one), but with EL-5 support not expiring for nearly a full year, it would be convenient to be able to build the same packages which work in mock locally and in koji.