### PR TITLE
handlers: use list() after map() for chroots

### DIFF
--- a/python/copr/client_v2/handlers.py
+++ b/python/copr/client_v2/handlers.py
@@ -131,7 +131,7 @@ class BuildHandle(AbstractHandle):
         :rtype: :py:class:`~.resources.Build`
         """
 
-        chroots = map(str, chroots or list())
+        chroots = list(map(str, chroots or list()))
         content = {
             "project_id": int(project_id),
             "srpm_url": str(srpm_url),
@@ -167,7 +167,7 @@ class BuildHandle(AbstractHandle):
         :rtype: :py:class:`~.resources.Build`
         """
 
-        chroots = map(str, chroots or list())
+        chroots = list(map(str, chroots or list()))
         content = {
             "project_id": int(project_id),
             "chroots": chroots,


### PR DESCRIPTION
in python3 map() does not return list

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1327607
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>