### PR TITLE
[doc] Fix a typo in HACKING

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -1,7 +1,7 @@
 
 * when you change models and you need to generate alembic upgrade file:
   cd /usr/share/copr
-  alembic --revision --autogenerate -m "describe the change"
+  alembic revision --autogenerate -m "describe the change"
 
 * upgrade schema:
   cd /usr/share/copr


### PR DESCRIPTION
There was a typo in alembic command invocation.