### PR TITLE
Separate logfile paths

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -175,7 +175,7 @@ Vagrant.configure(2) do |config|
 
     # ..
     frontend.vm.provision "shell",
-      inline: "sudo chown -R copr-fe:copr-fe /var/log/copr-frontend
+      inline: "sudo chown -R copr-fe:copr-fe /var/log/copr-frontend"
 
     # ..
     frontend.vm.provision "shell",

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -175,7 +175,7 @@ Vagrant.configure(2) do |config|
 
     # ..
     frontend.vm.provision "shell",
-      inline: "sudo chown -R copr-fe:copr-fe /var/log/copr"
+      inline: "sudo chown -R copr-fe:copr-fe /var/log/copr-frontend
 
     # ..
     frontend.vm.provision "shell",

--- a/backend/backend/helpers.py
+++ b/backend/backend/helpers.py
@@ -226,7 +226,7 @@ class BackendConfigReader(object):
             cp, "builder", "consecutive_failure_threshold",
             DEF_CONSECUTIVE_FAILURE_THRESHOLD, mode="int")
         opts.log_dir = _get_conf(
-            cp, "backend", "log_dir", "/var/log/copr/")
+            cp, "backend", "log_dir", "/var/log/copr-backend/")
         opts.log_level = _get_conf(
             cp, "backend", "log_level", "info")
         opts.verbose = _get_conf(

--- a/backend/conf/copr-be.conf.example
+++ b/backend/conf/copr-be.conf.example
@@ -85,7 +85,7 @@ sleeptime=30
 prune_days=14
 
 # logging settings
-# log_dir=/var/log/copr/
+# log_dir=/var/log/copr-backend/
 # log_level=info
 
 # verbose=False

--- a/backend/conf/logrotate/copr-backend
+++ b/backend/conf/logrotate/copr-backend
@@ -1,6 +1,6 @@
 # logrotation file for Copr backend
 
-/var/log/copr/*.log {
+/var/log/copr-backend/*.log {
     weekly
     rotate 5
     copytruncate
@@ -10,7 +10,7 @@
     create 640 copr copr
 }
 
-/var/log/copr/workers/worker-*.log {
+/var/log/copr-backend/workers/worker-*.log {
     weekly
     rotate 5
     copytruncate

--- a/backend/conf/logstash/copr_backend.conf
+++ b/backend/conf/logstash/copr_backend.conf
@@ -1,10 +1,10 @@
 input {
   #file {
-  #  path => "/var/log/copr/backend.log"
+  #  path => "/var/log/copr-backend/backend.log"
   #  type => "copr.backend.main"
   #}
   file {
-    path => "/var/log/lighttpd/access.log"
+    path => "/var/log/lighttpd/copr-backend.access.log"
     type => "lighttpd-access"
   }
 }
@@ -52,7 +52,7 @@ output {
       }
 
       file {
-        path => "/var/log/logstash/published.log"
+        path => "/var/log/logstash/copr-backend.published.log"
         codec => "rubydebug"
       }
   }

--- a/backend/conf/nginx.conf
+++ b/backend/conf/nginx.conf
@@ -1,9 +1,9 @@
 user  nginx;
 worker_processes  8;
 
-error_log  /var/log/nginx/error.log;
-#error_log  /var/log/nginx/error.log  notice;
-#error_log  /var/log/nginx/error.log  info;
+error_log  /var/log/nginx/copr-backend.error.log;
+#error_log  /var/log/nginx/copr-backend.error.log  notice;
+#error_log  /var/log/nginx/copr-backend.error.log  info;
 
 pid        /run/nginx.pid;
 
@@ -18,7 +18,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /var/log/nginx/copr-backend.access.log  main;
 
     sendfile        on;
     #tcp_nopush     on;

--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -222,6 +222,7 @@ useradd -r -g copr -G lighttpd -s /bin/bash -c "COPR user" copr
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/public_html/
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/public_html/results
 %dir %attr(0755, copr, copr) %{_var}/run/copr-backend
+%dir %attr(0755, copr, copr) %{_var}/log/copr-backend
 
 %ghost %{_var}/log/copr-backend/*.log
 %ghost %{_var}/run/copr-backend/copr-be.pid

--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -3,8 +3,8 @@
 %endif
 
 Name:       copr-backend
-Version:    1.87
-Release:    2%{?dist}
+Version:    1.90
+Release:    1%{?dist}
 Summary:    Backend for Copr
 
 Group:      Applications/Productivity
@@ -51,11 +51,11 @@ BuildRequires: pytz
 # BuildRequires: wget -- ???
 
 %if 0%{?fedora} >= 24
-BuildRequires: ansible1.9
-Requires:   ansible1.9
-%else
 BuildRequires: ansible
 Requires:   ansible
+%else
+BuildRequires: ansible1.9
+Requires:   ansible1.9
 %endif
 
 #for doc package
@@ -92,7 +92,7 @@ Requires:   prunerepo
 Requires:   python-paramiko
 Requires:   python-lockfile
 # Requires:   python-ipdb
-Requires:   logstash
+Suggests:   logstash
 Requires:   libappstream-glib-builder >= 0.4.0
 # Requires:   python-plumbum
 Requires:   rpm-sign
@@ -136,12 +136,13 @@ popd
 install -d %{buildroot}%{_sharedstatedir}/copr
 install -d %{buildroot}%{_sharedstatedir}/copr/jobs
 install -d %{buildroot}%{_sharedstatedir}/copr/public_html/results
-install -d %{buildroot}%{_var}/log/copr-backend
+install -d %{buildroot}%{_var}/log/copr
 install -d %{buildroot}%{_pkgdocdir}/lighttpd/
 install -d %{buildroot}%{_datadir}/copr/backend
 install -d %{buildroot}%{_sysconfdir}/copr
 install -d %{buildroot}%{_sysconfdir}/logrotate.d/
 install -d %{buildroot}%{_unitdir}
+install -d %{buildroot}/%{_var}/log/copr-backend
 install -d %{buildroot}/%{_var}/run/copr-backend/
 install -d %{buildroot}/%{_tmpfilesdir}
 install -d %{buildroot}/%{_sbindir}
@@ -161,8 +162,8 @@ cp -a conf/logrotate/* %{buildroot}%{_sysconfdir}/logrotate.d/
 cp -a conf/tmpfiles.d/* %{buildroot}/%{_tmpfilesdir}
 
 # for ghost files
-touch %{buildroot}%{_var}/log/copr-backend/copr.log
-touch %{buildroot}%{_var}/log/copr-backend/prune_old.log
+touch %{buildroot}%{_var}/log/copr/copr.log
+touch %{buildroot}%{_var}/log/copr/prune_old.log
 
 touch %{buildroot}%{_var}/run/copr-backend/copr-be.pid
 
@@ -221,10 +222,10 @@ useradd -r -g copr -G lighttpd -s /bin/bash -c "COPR user" copr
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/jobs/
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/public_html/
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/public_html/results
+%dir %attr(0755, copr, copr) %{_var}/log/copr
 %dir %attr(0755, copr, copr) %{_var}/run/copr-backend
-%dir %attr(0755, copr, copr) %{_var}/log/copr-backend
 
-%ghost %{_var}/log/copr-backend/*.log
+%ghost %{_var}/log/copr/*.log
 %ghost %{_var}/run/copr-backend/copr-be.pid
 
 %config(noreplace) %{_sysconfdir}/logrotate.d/copr-backend
@@ -253,8 +254,15 @@ useradd -r -g copr -G lighttpd -s /bin/bash -c "COPR user" copr
 %exclude %{_pkgdocdir}/playbooks
 
 %changelog
-* Sun May 29 2016 Pete Travis <me@petetravis.com> - 1.87-2
-- Change log file paths to /var/log/copr-backend/
+* Fri May 27 2016 Miroslav Suchý <msuchy@redhat.com> 1.90-1
+- do not use --log-dir in appstream-builder
+
+* Tue May 24 2016 Miroslav Suchý <miroslav@suchy.cz> 1.89-1
+- use correct conditional in requires
+
+* Mon May 23 2016 Miroslav Suchý <msuchy@redhat.com> 1.88-1
+- backend: change logstash requires to soft requires
+- 1336360 - allow custom chroots
 
 * Fri May 13 2016 Miroslav Suchý <msuchy@redhat.com> 1.87-1
 - workaround for BZ 1334200

--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -4,7 +4,7 @@
 
 Name:       copr-backend
 Version:    1.87
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Backend for Copr
 
 Group:      Applications/Productivity
@@ -136,13 +136,12 @@ popd
 install -d %{buildroot}%{_sharedstatedir}/copr
 install -d %{buildroot}%{_sharedstatedir}/copr/jobs
 install -d %{buildroot}%{_sharedstatedir}/copr/public_html/results
-install -d %{buildroot}%{_var}/log/copr
+install -d %{buildroot}%{_var}/log/copr-backend
 install -d %{buildroot}%{_pkgdocdir}/lighttpd/
 install -d %{buildroot}%{_datadir}/copr/backend
 install -d %{buildroot}%{_sysconfdir}/copr
 install -d %{buildroot}%{_sysconfdir}/logrotate.d/
 install -d %{buildroot}%{_unitdir}
-install -d %{buildroot}/%{_var}/log/copr-backend
 install -d %{buildroot}/%{_var}/run/copr-backend/
 install -d %{buildroot}/%{_tmpfilesdir}
 install -d %{buildroot}/%{_sbindir}
@@ -162,8 +161,8 @@ cp -a conf/logrotate/* %{buildroot}%{_sysconfdir}/logrotate.d/
 cp -a conf/tmpfiles.d/* %{buildroot}/%{_tmpfilesdir}
 
 # for ghost files
-touch %{buildroot}%{_var}/log/copr/copr.log
-touch %{buildroot}%{_var}/log/copr/prune_old.log
+touch %{buildroot}%{_var}/log/copr-backend/copr.log
+touch %{buildroot}%{_var}/log/copr-backend/prune_old.log
 
 touch %{buildroot}%{_var}/run/copr-backend/copr-be.pid
 
@@ -222,10 +221,9 @@ useradd -r -g copr -G lighttpd -s /bin/bash -c "COPR user" copr
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/jobs/
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/public_html/
 %dir %attr(0755, copr, copr) %{_sharedstatedir}/copr/public_html/results
-%dir %attr(0755, copr, copr) %{_var}/log/copr
 %dir %attr(0755, copr, copr) %{_var}/run/copr-backend
 
-%ghost %{_var}/log/copr/*.log
+%ghost %{_var}/log/copr-backend/*.log
 %ghost %{_var}/run/copr-backend/copr-be.pid
 
 %config(noreplace) %{_sysconfdir}/logrotate.d/copr-backend
@@ -254,6 +252,9 @@ useradd -r -g copr -G lighttpd -s /bin/bash -c "COPR user" copr
 %exclude %{_pkgdocdir}/playbooks
 
 %changelog
+* Sun May 29 2016 Pete Travis <me@petetravis.com> - 1.87-2
+- Change log file paths to /var/log/copr-backend/
+
 * Fri May 13 2016 Miroslav Suchý <msuchy@redhat.com> 1.87-1
 - workaround for BZ 1334200
 - more info in logs by default

--- a/backend/docker/files/etc/copr/copr-be.conf
+++ b/backend/docker/files/etc/copr/copr-be.conf
@@ -90,7 +90,7 @@ sleeptime=30
 prune_days=14
 
 # logging settings
-# log_dir=/var/log/copr/
+# log_dir=/var/log/copr-backend/
 # log_level=info
 
 # verbose=False

--- a/backend/docker/files/root/.bashrc
+++ b/backend/docker/files/root/.bashrc
@@ -69,6 +69,6 @@ alias p3packs='cd /usr/lib/python2.7/site-packages'
 export p2packs=/usr/lib/python2.7/site-packages
 export p3packs=/usr/lib/python3.4/site-packages
 
-alias cdlog='cd /var/log/copr'
+alias cdlog='cd /var/log/copr-backend'
 
 source ~/.alias_autocomplete.sh

--- a/backend/run/cleanup_vm_nova.py
+++ b/backend/run/cleanup_vm_nova.py
@@ -130,7 +130,7 @@ class Cleaner(object):
 
 if __name__ == "__main__":
     logging.basicConfig(
-        filename="/var/log/copr/cleanup_vms.log",
+        filename="/var/log/copr-backend/cleanup_vms.log",
         # filename="/tmp/cleanup_vms.log",
         # stream=sys.stdout,
         format='[%(asctime)s][%(thread)s][%(levelname)6s]: %(message)s',

--- a/backend/run/copr_createrepo.py
+++ b/backend/run/copr_createrepo.py
@@ -8,7 +8,7 @@ import sys
 import pwd
 
 logging.basicConfig(
-    filename="/var/log/copr/copr_createrepo.log",
+    filename="/var/log/copr-backend/copr_createrepo.log",
     format='[%(asctime)s][%(levelname)6s]: %(message)s',
     level=logging.INFO)
 log = logging.getLogger(__name__)

--- a/backend/run/copr_fix_gpg.py
+++ b/backend/run/copr_fix_gpg.py
@@ -18,7 +18,7 @@ from backend.sign import get_pubkey, unsign_rpms_in_dir, sign_rpms_in_dir, creat
 from backend.createrepo import createrepo_unsafe, add_appdata
 
 logging.basicConfig(
-    filename="/var/log/copr/fix_gpg.log",
+    filename="/var/log/copr-backend/fix_gpg.log",
     format='[%(asctime)s][%(levelname)6s]: %(message)s',
     level=logging.DEBUG)
 log = logging.getLogger(__name__)

--- a/backend/run/copr_prune_results.py
+++ b/backend/run/copr_prune_results.py
@@ -125,7 +125,7 @@ if __name__ == "__main__":
         sys.exit(1)
     else:
         logging.basicConfig(
-            filename="/var/log/copr/copr_prune_results.log",
+            filename="/var/log/copr-backend/copr_prune_results.log",
             format='[%(asctime)s][%(levelname)6s]: %(message)s',
             level=logging.INFO)
         main()

--- a/backend/run/copr_sign_unsigned.py
+++ b/backend/run/copr_sign_unsigned.py
@@ -17,7 +17,7 @@ import pwd
 
 
 logging.basicConfig(
-    filename="/var/log/copr/onetime_signer.log",
+    filename="/var/log/copr-backend/onetime_signer.log",
     format='[%(asctime)s][%(levelname)6s]: %(message)s',
     level=logging.DEBUG)
 log = logging.getLogger(__name__)

--- a/frontend/conf/logrotate
+++ b/frontend/conf/logrotate
@@ -1,6 +1,6 @@
 # logrotation file for Copr frontend
 
-/var/log/copr/*.log {
+/var/log/copr-frontend/*.log {
     weekly
     rotate 5
     copytruncate

--- a/frontend/conf/logstash.conf
+++ b/frontend/conf/logstash.conf
@@ -1,10 +1,10 @@
 input {
   file {
-    path => "/var/log/httpd/access_log"
+    path => "/var/log/httpd/copr-frontend.access_log"
     type => "httpd-access"
   }
   # file {
-  #  path => "/var/log/httpd/error_log"
+  #  path => "/var/log/httpd/copr-frontend.error_log"
   #  type => "httpd-error"
   # }
 }

--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -6,7 +6,7 @@
 
 Name:       copr-frontend
 Version:    1.92
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Frontend for Copr
 
 Group:      Applications/Productivity
@@ -205,12 +205,12 @@ mv %{buildroot}%{_datadir}/copr/coprs_frontend/config/* %{buildroot}%{_sysconfdi
 rm %{buildroot}%{_datadir}/copr/coprs_frontend/CONTRIBUTION_GUIDELINES
 touch %{buildroot}%{_sharedstatedir}/copr/data/copr.db
 
-install -d %{buildroot}%{_var}/log/copr
+install -d %{buildroot}%{_var}/log/copr-frontend
 install -d %{buildroot}%{_sysconfdir}/logrotate.d
 install -d %{buildroot}%{_sysconfdir}/logstash.d
 cp -a conf/logrotate %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
 cp -a conf/logstash.conf %{buildroot}%{_sysconfdir}/logstash.d/copr_frontend.conf
-touch %{buildroot}%{_var}/log/copr/frontend.log
+touch %{buildroot}%{_var}/log/copr-frontend/frontend.log
 
 %check
 %if %{with_test} && "%{_arch}" == "x86_64"
@@ -254,8 +254,8 @@ service logstash condrestart
 %ghost %{_sharedstatedir}/copr/data/copr.db
 
 %defattr(644, copr-fe, copr-fe, 755)
-%dir %{_var}/log/copr
-%ghost %{_var}/log/copr/*.log
+%dir %{_var}/log/copr-frontend
+%ghost %{_var}/log/copr-frontend/*.log
 
 %defattr(600, copr-fe, copr-fe, 700)
 %config(noreplace)  %{_sysconfdir}/copr/copr.conf
@@ -269,6 +269,9 @@ service logstash condrestart
 #%doc documentation/python-doc
 
 %changelog
+* Sun May 29 2016 Pete Travis <me@petetravis.com> - 1.92-2
+- Change log file paths to /var/log/copr-frontend/
+
 * Wed May 04 2016 Miroslav Suchý <msuchy@redhat.com> 1.92-1
 - load group.id before we commit the session
 

--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -5,8 +5,8 @@
 %endif
 
 Name:       copr-frontend
-Version:    1.92
-Release:    2%{?dist}
+Version:    1.93
+Release:    1%{?dist}
 Summary:    Frontend for Copr
 
 Group:      Applications/Productivity
@@ -205,12 +205,12 @@ mv %{buildroot}%{_datadir}/copr/coprs_frontend/config/* %{buildroot}%{_sysconfdi
 rm %{buildroot}%{_datadir}/copr/coprs_frontend/CONTRIBUTION_GUIDELINES
 touch %{buildroot}%{_sharedstatedir}/copr/data/copr.db
 
-install -d %{buildroot}%{_var}/log/copr-frontend
+install -d %{buildroot}%{_var}/log/copr
 install -d %{buildroot}%{_sysconfdir}/logrotate.d
 install -d %{buildroot}%{_sysconfdir}/logstash.d
 cp -a conf/logrotate %{buildroot}%{_sysconfdir}/logrotate.d/%{name}
 cp -a conf/logstash.conf %{buildroot}%{_sysconfdir}/logstash.d/copr_frontend.conf
-touch %{buildroot}%{_var}/log/copr-frontend/frontend.log
+touch %{buildroot}%{_var}/log/copr/frontend.log
 
 %check
 %if %{with_test} && "%{_arch}" == "x86_64"
@@ -254,8 +254,8 @@ service logstash condrestart
 %ghost %{_sharedstatedir}/copr/data/copr.db
 
 %defattr(644, copr-fe, copr-fe, 755)
-%dir %{_var}/log/copr-frontend
-%ghost %{_var}/log/copr-frontend/*.log
+%dir %{_var}/log/copr
+%ghost %{_var}/log/copr/*.log
 
 %defattr(600, copr-fe, copr-fe, 700)
 %config(noreplace)  %{_sysconfdir}/copr/copr.conf
@@ -269,8 +269,29 @@ service logstash condrestart
 #%doc documentation/python-doc
 
 %changelog
-* Sun May 29 2016 Pete Travis <me@petetravis.com> - 1.92-2
-- Change log file paths to /var/log/copr-frontend/
+* Thu May 26 2016 clime <clime@redhat.com> 1.93-1
+- added source_type to URL and Upload UI build forms
+- support for creating/editing/deleting/listing packages implemented
+- Bug 1337446 - Broken links to builds in package tab
+- action to create gpg key is now always sent
+- added tests for projects forking
+- building via url and pypi refactoring; see df6ad16
+- Bug 1336360 - reverse naming for custom and mageia chroots
+- Rubygems building support with Anitya autorebuilds
+- ./manage.py mark_as_failed command added
+- build timeout increased to 24 hours
+- added missing group insert/update hooks into CoprWhoosheer
+- added package names into search index + field boosts tweaking
+- fixed search for just a group name
+- Bug 1333792 - do not count group projects
+- Bug 1334625 - Search for coprs owned by a group does not work
+- Bug 1334575 - Missing package name in "Recent builds" tab for
+  upload/url builds
+- Bug 1334390 - Bad link in Recent Builds for group project
+- reset button also sets source_json to {}
+- speeding up of Packages view
+- enable other group users to edit the project settings
+- Bug 1333082 - Disable createrepo does not work on group project
 
 * Wed May 04 2016 Miroslav Suchý <msuchy@redhat.com> 1.92-1
 - load group.id before we commit the session

--- a/frontend/coprs_frontend/config/copr.conf
+++ b/frontend/coprs_frontend/config/copr.conf
@@ -83,7 +83,7 @@ DIST_GIT_URL = "http://copr-dist-git-dev.fedorainfracloud.org/cgit"
 COPR_DIST_GIT_LOGS_URL = "http://copr-dist-git-dev.fedorainfracloud.org/per-task-logs"
 
 # primary
-LOG_FILENAME = "/var/log/copr/frontend.log"
+LOG_FILENAME = "/var/log/copr-frontend/frontend.log"
 
 # Internal network, used to accept statistics without auth
 # list of IP or subnet

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -45,7 +45,7 @@ class Config(object):
     COPR_DIST_GIT_LOGS_URL = None
 
     # primary log file
-    LOG_FILENAME = "/var/log/copr/frontend.log"
+    LOG_FILENAME = "/var/log/copr-frontend/frontend.log"
 
     INTRANET_IPS = ["127.0.0.1"]
     DEBUG = True

--- a/frontend/coprs_frontend/run/check_for_anitya_version_updates.py
+++ b/frontend/coprs_frontend/run/check_for_anitya_version_updates.py
@@ -20,7 +20,7 @@ from coprs.logic.builds_logic import BuildsLogic
 from coprs.logic.coprs_logic import CoprsLogic
 
 logging.basicConfig(
-    filename="/var/log/copr/check_for_anitya_version_updates.log",
+    filename="/var/log/copr-frontend/check_for_anitya_version_updates.log",
     format='[%(asctime)s][%(levelname)6s]: %(message)s',
     level=logging.DEBUG)
 log = logging.getLogger(__name__)

--- a/frontend/coprs_frontend/run/generate_repo_packages.py
+++ b/frontend/coprs_frontend/run/generate_repo_packages.py
@@ -35,7 +35,7 @@ FRONTEND_URL = "{}://{}".format(scheme, hostname)
 FRONTEND_DIR = os.path.dirname(here)
 PACKAGES_DIR = os.path.join(app.config["DATA_DIR"], "repo-rpm-packages")
 RPMBUILD = os.path.join(os.path.expanduser("~"), "rpmbuild")
-LOG_FILE = "/var/log/copr/repo-packages.log"
+LOG_FILE = "/var/log/copr-frontend/repo-packages.log"
 
 VERSION = 1
 RELEASE = 1

--- a/prunerepo/prunerepo
+++ b/prunerepo/prunerepo
@@ -114,8 +114,8 @@ def prune_packages():
     to_remove_rpms = set(all_rpms) - set(latest_rpms)
     for rpm in to_remove_rpms:
         if time.time() - get_package_build_time(rpm) > args.days * 24 * 3600:
-            rm_file(rpm)
             rm_srpm(rpm)
+            rm_file(rpm)
 
 
 def recreate_repo():

--- a/selinux/copr-selinux.spec
+++ b/selinux/copr-selinux.spec
@@ -9,7 +9,7 @@
 
 Name:       copr-selinux
 Version:    1.40
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    SELinux module for COPR
 
 Group:      Applications/Productivity
@@ -111,6 +111,9 @@ fi
 %dir %{_datadir}/selinux/mls
 
 %changelog
+* Sun May 29 2016 Pete Travis <me@petetravis.com> - 1.40-2
+- separate log file paths for backend and frontend
+
 * Mon Mar 14 2016 Miroslav Suchý <miroslav@suchy.cz> 1.40-1
 - add missing types to requires section
 

--- a/selinux/copr-selinux.spec
+++ b/selinux/copr-selinux.spec
@@ -9,7 +9,7 @@
 
 Name:       copr-selinux
 Version:    1.40
-Release:    2%{?dist}
+Release:    1%{?dist}
 Summary:    SELinux module for COPR
 
 Group:      Applications/Productivity
@@ -111,9 +111,6 @@ fi
 %dir %{_datadir}/selinux/mls
 
 %changelog
-* Sun May 29 2016 Pete Travis <me@petetravis.com> - 1.40-2
-- separate log file paths for backend and frontend
-
 * Mon Mar 14 2016 Miroslav Suchý <miroslav@suchy.cz> 1.40-1
 - add missing types to requires section
 

--- a/selinux/copr.fc
+++ b/selinux/copr.fc
@@ -1,6 +1,7 @@
 
 /var/lib/copr(/.*)? gen_context(system_u:object_r:copr_data_t,s0)
-/var/log/copr(/.*)? gen_context(system_u:object_r:copr_httpd_log_t,s0)
+/var/log/copr-backend(/.*)? gen_context(system_u:object_r:copr_httpd_log_t,s0)
+/var/log/copr-frontend(/.*)? gen_context(system_u:object_r:copr_httpd_log_t,s0)
 /var/lib/dist-git/git/rpms(/.*)? gen_context(system_u:object_r:git_user_content_t,s0)
 /usr/libexec/git-core/git-http-backend gen_context(system_u:object_r:git_script_exec_t,s0)
 /var/lib/copr-keygen/gnupg/trustdb.gpg gen_context(system_u:object_r:httpd_var_lib_t,s0)


### PR DESCRIPTION
I wanted to install copr-backend and copr-frontend on the same instance, for testing, and there was a file ownership conflict for /var/log/copr.  Since the packages have been separated, and there are seemingly no other technical reasons for these packages to conflict, this set of commits enables copr-backend and copr-frontend to have their own, unshared paths in /var/log.