### PR TITLE
[frontend] Add flags for Zypper to accept copr repositories

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/coprs/copr.repo
+++ b/frontend/coprs_frontend/coprs/templates/coprs/copr.repo
@@ -5,5 +5,6 @@ type=rpm-md
 skip_if_unavailable=True
 gpgcheck={{ config.REPO_GPGCHECK | default("1")}}
 gpgkey={{ pubkey_url | fix_url_https_backend  }}
+repo_gpgcheck=0
 enabled=1
 enabled_metadata=1

--- a/frontend/coprs_frontend/coprs/templates/coprs/copr.repo
+++ b/frontend/coprs_frontend/coprs/templates/coprs/copr.repo
@@ -1,6 +1,7 @@
 [{{ copr.repo_id }}]
 name=Copr repo for {{ copr.name }} owned by {{ copr.owner_name }}
 baseurl={{ url | fix_url_https_backend }}
+type=rpm-md
 skip_if_unavailable=True
 gpgcheck={{ config.REPO_GPGCHECK | default("1")}}
 gpgkey={{ pubkey_url | fix_url_https_backend  }}


### PR DESCRIPTION
When using Zypper with copr repos, this needs to be added so that Zypper can properly consume the repository metadata.