### PR TITLE
fix for python-progress API

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -160,7 +160,7 @@ class Commands(object):
         progress_callback = None
 
         if os.path.exists(args.pkgs[0]):
-            bar = ProgressBar(maxval=os.path.getsize(args.pkgs[0]))
+            bar = ProgressBar(max=os.path.getsize(args.pkgs[0]))
 
             # pylint: disable=function-redefined
             def progress_callback(monitor):

--- a/cli/copr_cli/util.py
+++ b/cli/copr_cli/util.py
@@ -33,7 +33,7 @@ class ProgressMixin(object):
 
 
 class DummyBar(object):
-    def __init__(self, maxval=None):
+    def __init__(self, max=None):
         pass
 
     def next(self, n=None):


### PR DESCRIPTION
Revert "W: 36,23: Redefining built-in 'max' (redefined-builtin)"

This reverts commit 42c0942b759d58b22c2c2e5551eb67088cf5d9ac.

I'm rather doing pull request, because I'm not sure we are able to avoid this pylint warning.