### PR TITLE
Backend: Fix chroot_setup_cmd regex for custom chroot

### DIFF
--- a/backend/backend/mockremote/builder.py
+++ b/backend/backend/mockremote/builder.py
@@ -188,8 +188,7 @@ class Builder(object):
         buildroot_custom_cmd = (
             "dest={cfg_path}"
             " line=\"config_opts['chroot_setup_cmd'] = 'install {pkgs}'\""
-            " regexp=\"config_opts['chroot_setup_cmd'] = ''$\""
-            " backrefs=yes"
+            " regexp=\"config_opts\\['chroot_setup_cmd'\\] = ''$\""
         )
         set_networking_cmd = (
             "dest={cfg_path}"


### PR DESCRIPTION
Braces need to be escaped in order not to be interpreted as character
class by Ansible.

CC @msimacek