### PR TITLE
Fork even dist-git data (RhBug: 1368458)

### DIFF
--- a/dist-git/dist_git/dist_git_importer.py
+++ b/dist-git/dist_git/dist_git_importer.py
@@ -429,9 +429,7 @@ class ForkProvider(GitProvider):
         cmd = ["fedpkg", "--dist", self.task.branch, "--path", self.git_dir, "srpm"]
         log.debug(" ".join(cmd))
 
-        # @TODO use VM.run(...)
-        proc = Popen(cmd, stdout=PIPE, stderr=PIPE, cwd=self.tmp)
-        output, error = proc.communicate()
+        output, error = VM.run(cmd, self.git_dir, name=self.task.task_id, cwd=self.tmp)
         log.info(output)
         log.info(error)
 

--- a/frontend/coprs_frontend/coprs/helpers.py
+++ b/frontend/coprs_frontend/coprs/helpers.py
@@ -90,7 +90,7 @@ class StatusEnum(with_metaclass(EnumType, object)):
             "skipped": 5,  # if there was this package built already
             "starting": 6,  # build picked by worker but no VM initialized
             "importing": 7, # SRPM is being imported to dist-git
-            "forked": 8, # build(-chroot) was forked
+            "forking": 8, # build(-chroot) was forked
            }
 
 

--- a/frontend/coprs_frontend/coprs/helpers.py
+++ b/frontend/coprs_frontend/coprs/helpers.py
@@ -102,6 +102,7 @@ class BuildSourceEnum(with_metaclass(EnumType, object)):
             "mock_scm": 4, # scm_type, scm_url, spec, scm_branch
             "pypi": 5, # package_name, version, python_versions
             "rubygems": 6, # gem_name
+            "fork": 7,  # old_dist_git_url old_git_hash
            }
 
 

--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -80,7 +80,7 @@ class BuildsLogic(object):
         query = (models.BuildChroot.query.join(models.Build)
                  .filter(models.Build.canceled == false())
                  .filter(models.BuildChroot.status.in_([helpers.StatusEnum("importing"),
-                                                        helpers.StatusEnum("forked")])))
+                                                        helpers.StatusEnum("forking")])))
         query = query.order_by(models.BuildChroot.build_id.asc())
         return query
 

--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -79,7 +79,8 @@ class BuildsLogic(object):
         """
         query = (models.BuildChroot.query.join(models.Build)
                  .filter(models.Build.canceled == false())
-                 .filter(models.BuildChroot.status == helpers.StatusEnum("importing")))
+                 .filter(models.BuildChroot.status.in_([helpers.StatusEnum("importing"),
+                                                        helpers.StatusEnum("forked")])))
         query = query.order_by(models.BuildChroot.build_id.asc())
         return query
 

--- a/frontend/coprs_frontend/coprs/logic/complex_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/complex_logic.py
@@ -224,7 +224,7 @@ class ProjectForking(object):
         fbuild = self.create_object(models.Build, build, exclude=["id", "copr_id", "package_id"])
         fbuild.copr = fcopr
         fbuild.package = fpackage
-        fbuild.build_chroots = [self.create_object(models.BuildChroot, c, exclude=["id", "build_id"]) for c in build.build_chroots]
+        fbuild.build_chroots = [self.create_object(models.BuildChroot, c, exclude=["id", "build_id", "git_hash"]) for c in build.build_chroots]
         for chroot in fbuild.build_chroots:
             chroot.status = StatusEnum("forking")
         db.session.add(fbuild)

--- a/frontend/coprs_frontend/coprs/logic/complex_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/complex_logic.py
@@ -226,7 +226,7 @@ class ProjectForking(object):
         fbuild.package = fpackage
         fbuild.build_chroots = [self.create_object(models.BuildChroot, c, exclude=["id", "build_id"]) for c in build.build_chroots]
         for chroot in fbuild.build_chroots:
-            chroot.status = StatusEnum("forked")
+            chroot.status = StatusEnum("forking")
         db.session.add(fbuild)
         db.session.commit()
         return fbuild

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -920,12 +920,8 @@ class BuildChroot(db.Model, helpers.Serializer):
     @property
     def dist_git_url(self):
         if app.config["DIST_GIT_URL"]:
-            if self.state == "forking":
-                coprname = self.build.copr.forked_from.full_name
-            else:
-                coprname = self.build.copr.full_name
             return "{}/{}/{}.git/commit/?id={}".format(app.config["DIST_GIT_URL"],
-                                                coprname,
+                                                self.build.copr.full_name,
                                                 self.build.package.name,
                                                 self.git_hash)
         return None

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -660,7 +660,7 @@ class Build(db.Model, helpers.Serializer):
         if self.canceled:
             return StatusEnum("canceled")
 
-        for state in ["running", "starting", "importing", "pending", "failed", "succeeded", "skipped", "forking"]:
+        for state in ["running", "starting", "importing", "pending", "forking", "failed", "succeeded", "skipped"]:
             if StatusEnum(state) in self.chroot_states:
                 return StatusEnum(state)
 

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -965,6 +965,14 @@ class BuildChroot(db.Model, helpers.Serializer):
 
         return os.path.join(*parts)
 
+    @property
+    def forked_from(self):
+        query = (BuildChroot.query.join(Build, Package, Copr)
+                             .filter(Package.name == self.build.package.name)
+                             .filter(Copr.id == self.build.copr.forked_from_id)
+                             .filter(BuildChroot.mock_chroot_id == self.mock_chroot_id))
+        return query.first()
+
     def __str__(self):
         return "<BuildChroot: {}>".format(self.to_dict())
 

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -660,7 +660,7 @@ class Build(db.Model, helpers.Serializer):
         if self.canceled:
             return StatusEnum("canceled")
 
-        for state in ["running", "starting", "importing", "pending", "failed", "succeeded", "skipped", "forked"]:
+        for state in ["running", "starting", "importing", "pending", "failed", "succeeded", "skipped", "forking"]:
             if StatusEnum(state) in self.chroot_states:
                 return StatusEnum(state)
 
@@ -696,7 +696,7 @@ class Build(db.Model, helpers.Serializer):
         return self.status not in [StatusEnum("pending"),
                                    StatusEnum("starting"),
                                    StatusEnum("running"),
-                                   StatusEnum("forked")]
+                                   StatusEnum("forking")]
 
     @property
     def finished(self):
@@ -705,7 +705,7 @@ class Build(db.Model, helpers.Serializer):
 
         Build is finished only if all its build_chroots are in finished state.
         """
-        return all([(chroot.state in ["succeeded", "forked", "canceled", "skipped", "failed"]) for chroot in self.build_chroots])
+        return all([(chroot.state in ["succeeded", "forking", "canceled", "skipped", "failed"]) for chroot in self.build_chroots])
 
     @property
     def persistent(self):
@@ -920,7 +920,7 @@ class BuildChroot(db.Model, helpers.Serializer):
     @property
     def dist_git_url(self):
         if app.config["DIST_GIT_URL"]:
-            if self.state == "forked":
+            if self.state == "forking":
                 coprname = self.build.copr.forked_from.full_name
             else:
                 coprname = self.build.copr.full_name

--- a/frontend/coprs_frontend/coprs/static/copr.css
+++ b/frontend/coprs_frontend/coprs/static/copr.css
@@ -149,8 +149,8 @@ div.breadcrumb-panel ol.breadcrumb {
   color: #272;
 }
 
-.build-forked,.build-forked>a {
-  color: #272;
+.build-forking,.build-forking>a {
+  color: #55b;
 }
 
 .build-skipped,.build-skipped>a {

--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -110,8 +110,8 @@
     <span class="pficon pficon-running"></span> {{ state }}
   {% elif state == "succeeded" %}
     <span class="pficon pficon-ok"></span> {{ state }}
-  {% elif state == "forked" %}
-    <span class="pficon pficon-ok"></span> {{ state }}
+  {% elif state == "forking" %}
+    <span class="pficon pficon-running"></span> {{ state }}
   {% elif state == "skipped" %}
     <span class="pficon pficon-ok"></span> {{ state }}
   {% elif state == "failed" %}

--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -45,7 +45,7 @@ def dist_git_importing_queue():
             "source_type": task.build.source_type,
             "source_json": task.build.source_json,
         }
-        if task.status == helpers.StatusEnum("forked"):
+        if task.status == helpers.StatusEnum("forking"):
             task_dict["source_type"] = helpers.BuildSourceEnum("fork")
             task_dict["source_json"] = json.dumps({
                 "old_dist_git_url": task.forked_from.build.package.dist_git_url,
@@ -101,7 +101,7 @@ def dist_git_upload_completed():
             for ch in build_chroots:
                 state_map = {
                     "importing": "pending",
-                    "forked": "succeeded",  # We can afford it since we fork only succeeded builds
+                    "forking": "succeeded",  # We can afford it since we fork only succeeded builds
                 }
                 ch.status = helpers.StatusEnum(state_map.get(ch.state, ch.state))
                 ch.git_hash = git_hash


### PR DESCRIPTION
I have re-implemented the forking of build data on dist-git - based on FrostyX/copr@1e73866 and also on feodra-copr/copr@5b22368 so I could get rid of abusing `Action` and all the over-factoring around that.

This PR will also fix [RhBug 1368458](https://bugzilla.redhat.com/show_bug.cgi?id=1368458)
