### PR TITLE
Use OpenPGP v4 signatures for signing packages

### DIFF
--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -65,7 +65,7 @@ def get_pubkey(username, projectname, log, outfile=None):
     :raises CoprSignNoKeyError: if there are no such user in keyring
     """
     usermail = create_gpg_email(username, projectname)
-    cmd = [SIGN_BINARY, "-u", usermail, "-p"]
+    cmd = [SIGN_BINARY, "-u", usermail, "-p", "-4"]
 
     returncode, stdout, stderr = call_sign_bin(cmd, log)
     if returncode != 0:


### PR DESCRIPTION
v3 signatures which obs-signd currently creates by default were obsolete in 1998 already, but needed for interoperability in the early millennium. Everything from the last 15 years supports v4 signatures, lets get on with the times.

This requires at obs-signd 2.5.2 (released in 2018) or newer. Perhaps worth noting that the -4 switch is undocumented in obs-sign man pages.

For more background, see https://bugzilla.redhat.com/show_bug.cgi?id=2141686 and https://github.com/openSUSE/obs-sign/issues/43