### PR TITLE
beaker-tests: use F37 image for DockerTestEnv from Fedora registry

### DIFF
--- a/beaker-tests/DockerTestEnv/Dockerfile
+++ b/beaker-tests/DockerTestEnv/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM registry.fedoraproject.org/fedora:37
 ARG COPR_PACKAGES=devel
 MAINTAINER copr-devel@lists.fedorahosted.org
 ENV container docker


### PR DESCRIPTION
In order to be consistent with our docker-compose images. Also the image on dockerhub is not updated as frequently and currently, the F37 image points to F38 for some reason.