### PR TITLE
backend, common, dist-git: correct background worker start

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -6,7 +6,7 @@
 %global tests_version 2
 %global tests_tar test-data-copr-backend
 
-%global copr_common_version 0.16.2.dev
+%global copr_common_version 0.16.4.dev
 
 Name:       copr-backend
 Version:    1.161

--- a/backend/copr_backend/background_worker.py
+++ b/backend/copr_backend/background_worker.py
@@ -30,9 +30,6 @@ class BackendBackgroundWorker(BackgroundWorker):
                                               try_indefinitely=True)
 
     def _switch_logger_to_redis(self):
-        if not self.has_wm:
-            return
-
         logger_name = '{}.{}.pid-{}'.format(
             sys.argv[0],
             'managed' if self.args.worker_id else 'manual',
@@ -46,11 +43,6 @@ class BackendBackgroundWorker(BackgroundWorker):
             # print something to stderr as well
             self.log.addHandler(logging.StreamHandler())
 
-    def _daemonized_part(self):
-        # notify WorkerManager first, to minimize race window
-        self._wm_started()
-
+    def preparations_for_manager(self):
         # setup logging early, to have as complete logs as possible
         self._switch_logger_to_redis()
-
-        super()._daemonized_part()

--- a/common/copr_common/background_worker.py
+++ b/common/copr_common/background_worker.py
@@ -137,7 +137,19 @@ class BackgroundWorker:
         # anything else than concurrent run of multiple workers in such case.
         return True
 
+    def preparations_for_manager(self):
+        """
+        Hook called right after creating the worker process (daemonized,
+        if requested) and after successful notification to Manager that
+        worker started.  For manual runs (no --worker-id specified) this
+        hook isn't called at all.
+        """
+
     def _daemonized_part(self):
+        # notify WorkerManager first, to minimize race window
+        self._wm_started()
+        if self.has_wm:
+            self.preparations_for_manager()
         try:
             self.handle_task()
         except Exception as exc:  # pylint: disable=W0703

--- a/common/python-copr-common.spec
+++ b/common/python-copr-common.spec
@@ -16,7 +16,7 @@
 %endif
 
 Name:       python-copr-common
-Version:    0.16.3.dev
+Version:    0.16.4.dev
 Release:    1%{?dist}
 Summary:    Python code used by Copr
 

--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -1,4 +1,4 @@
-%global copr_common_version 0.16.2.dev
+%global copr_common_version 0.16.4.dev
 
 Name:       copr-dist-git
 Version:    0.57


### PR DESCRIPTION
By always calling the self._wm_started() method.  This needs to be done in the parent BackgroundWorker class so we don't forget about it in inheriting classes -> and it needs to be done ASAP.  To keep the order of things to be done (first call _wm_started(), then redirect logs to redis for the backend side, and then handle_task()) - there's now a new method preparations_for_manager() which is called after _wm_started() but before handle_task().