### PR TITLE
backend, distgit: require redis.service to be started

### DIFF
--- a/backend/units/copr-backend.target
+++ b/backend/units/copr-backend.target
@@ -1,7 +1,7 @@
 [Unit]
 Description=Copr Backend service
 After=syslog.target network.target auditd.service
-Requires=copr-backend-log.service copr-backend-build.service copr-backend-action.service
+Requires=copr-backend-log.service copr-backend-build.service copr-backend-action.service redis.service
 Wants=logrotate.timer
 
 [Install]

--- a/dist-git/copr-dist-git.service
+++ b/dist-git/copr-dist-git.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=copr aux service to import srpm into dist-git
-Requires=dist-git.socket
+Requires=dist-git.socket redis.service
 After=dist-git.socket
 Wants=logrotate.timer
 


### PR DESCRIPTION
Currently we do this in ansible

    service: name="{{ item }}" enabled=yes state=started
    with_items:
    - redis       # TODO: .service in copr-backend should depend on redis

which isn't the best solution.