### PR TITLE
backend: use OpenPGP v4 signatures

### DIFF
--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -88,7 +88,7 @@ def get_pubkey(username, projectname, log, outfile=None):
 
 
 def _sign_one(path, email, hashtype, log):
-    cmd = [SIGN_BINARY, "-h", hashtype, "-u", email, "-r", path]
+    cmd = [SIGN_BINARY, "-4", "-h", hashtype, "-u", email, "-r", path]
     returncode, stdout, stderr = call_sign_bin(cmd, log)
     if returncode != 0:
         raise CoprSignError(

--- a/backend/tests/test_sign.py
+++ b/backend/tests/test_sign.py
@@ -126,7 +126,7 @@ class TestSign(object):
         result = _sign_one(fake_path, self.usermail, "sha1", MagicMock())
         assert STDOUT, STDERR == result
 
-        expected_cmd = ['/bin/sign', "-h", "sha1", "-u", self.usermail,
+        expected_cmd = ['/bin/sign', "-4", "-h", "sha1", "-u", self.usermail,
                         "-r", fake_path]
         assert mc_popen.call_args[0][0] == expected_cmd
 


### PR DESCRIPTION
From Panu's statement in #2379:
v3 signatures which obs-signd currently creates by default were obsolete in 1998 already, but needed for interoperability in the early millennium.  Everything from the last 15 years supports v4 signatures, lets get on with the times.

This requires at obs-signd 2.5.2 (released in 2018) or newer. Perhaps worth noting that the -4 switch is undocumented in obs-sign man pages.

For more background, see
https://bugzilla.redhat.com/show_bug.cgi?id=2141686 and openSUSE/obs-sign#43

Closes: #2379
Closes: #2383