### PR TITLE
fix database pvc path

### DIFF
--- a/kubernetes/kustomize/backend.yaml
+++ b/kubernetes/kustomize/backend.yaml
@@ -4,6 +4,8 @@ metadata:
   name: copr-backend
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: copr-backend

--- a/kubernetes/kustomize/database.yaml
+++ b/kubernetes/kustomize/database.yaml
@@ -4,6 +4,8 @@ metadata:
   name: copr-database
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: copr-database
@@ -53,7 +55,7 @@ spec:
                   key: database-name
                   name: copr-database
           volumeMounts:
-            - mountPath: /var/lib/pqsql/data
+            - mountPath: /var/lib/pgsql/data
               name: postgresql-data
       volumes:
         - name: postgresql-data

--- a/kubernetes/kustomize/distgit.yaml
+++ b/kubernetes/kustomize/distgit.yaml
@@ -4,6 +4,8 @@ metadata:
   name: copr-distgit
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: copr-distgit

--- a/kubernetes/kustomize/keygen.yaml
+++ b/kubernetes/kustomize/keygen.yaml
@@ -4,6 +4,8 @@ metadata:
   name: copr-keygen
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: copr-keygen

--- a/kubernetes/kustomize/redis.yaml
+++ b/kubernetes/kustomize/redis.yaml
@@ -4,6 +4,8 @@ metadata:
   name: copr-redis
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: copr-redis


### PR DESCRIPTION
fix database pvc path not match, change the pod restart strategy to recreate because the pvc is claim as ReadWriteOnce
also make nginx mark the log.gz can be shown directly

Signed-off-by: Li Chaoran <pkwarcraft@gmail.com>