### PR TITLE
frontend, backend: fix traceback for non-existing tasks

### DIFF
--- a/backend/copr_backend/frontend.py
+++ b/backend/copr_backend/frontend.py
@@ -8,7 +8,8 @@ import logging
 from copr_common.request import SafeRequest, RequestError
 from copr_backend.exceptions import FrontendClientException
 
-MIN_FE_BE_API = 4
+# The frontend counterpart is in `backend_general:send_frontend_version`
+MIN_FE_BE_API = 5
 
 class FrontendClient:
     """
@@ -75,7 +76,7 @@ class FrontendClient:
             response = request.send(url, method=method, data=data)
             return response
         except RequestError as ex:
-            raise FrontendClientException from ex
+            raise FrontendClientException(str(ex)) from ex
 
     def update(self, data):
         """

--- a/frontend/coprs_frontend/coprs/exceptions.py
+++ b/frontend/coprs_frontend/coprs/exceptions.py
@@ -73,7 +73,7 @@ class InsufficientStorage(CoprHttpException):
     _code = 500
 
 
-class MalformedArgumentException(ValueError):
+class MalformedArgumentException(CoprHttpException, ValueError):
     pass
 
 


### PR DESCRIPTION
Fix #2390

First, take a look at the frontend change. The
`BuildsLogic.get_srpm_build_task` never raises an exception. It returns `None` for non-existing tasks instead. The route therefore returns 200 status code even for non-existing tasks, and simply returns `nil`. I am changing this to return 404 instead.

This prompted the backend changes because exceptions started appearing.