### PR TITLE
backend, dist-git: start services after redis.service

### DIFF
--- a/backend/units/copr-backend-log.service
+++ b/backend/units/copr-backend-log.service
@@ -1,8 +1,9 @@
 [Unit]
 Description=Copr Backend service, Log Handler component
-After=syslog.target network.target auditd.service
+After=syslog.target network.target auditd.service redis.service
 PartOf=copr-backend.target
 Before=copr-backend-build.service copr-backend-action.service
+Requires=redis.service
 Wants=logrotate.timer
 
 [Service]

--- a/backend/units/copr-backend.target
+++ b/backend/units/copr-backend.target
@@ -1,7 +1,7 @@
 [Unit]
 Description=Copr Backend service
 After=syslog.target network.target auditd.service
-Requires=copr-backend-log.service copr-backend-build.service copr-backend-action.service redis.service
+Requires=copr-backend-log.service copr-backend-build.service copr-backend-action.service
 Wants=logrotate.timer
 
 [Install]

--- a/dist-git/copr-dist-git.service
+++ b/dist-git/copr-dist-git.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=copr aux service to import srpm into dist-git
 Requires=dist-git.socket redis.service
-After=dist-git.socket
+After=dist-git.socket redis.service
 Wants=logrotate.timer
 
 [Service]


### PR DESCRIPTION
On top of Requires=, we need also After= so redis is started first. Long term (for the OpenShift scenario) we should make the Redis client connections resilient against the temporary Redis server outages.

The copr-backend.target depends on three services which have the dependency resolved between each other (actions/builds depend on log, log depends on redis).

With copr-dist-git.service it is much simpler, we just depend on redis.service.