### PR TITLE
backend: list the built RPMs with rpm --nosignature

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -644,7 +644,7 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         cmd = (
             "builtin cd {0} && "
             "for f in `ls *.rpm | grep -v \"src.rpm$\"`; do"
-            "   rpm -qp --qf \"%{{NAME}} %{{VERSION}}\n\" $f; "
+            "   rpm --nosignature -qp --qf \"%{{NAME}} %{{VERSION}}\n\" $f; "
             "done".format(shlex.quote(job.results_dir))
         )
 


### PR DESCRIPTION
There's no need to fail the build on this place, with a weird error message users wouldn't anyway understand.

If the packages had wrong signatures, following builds would at least find this problem anyway very quickly because the repos have gpgcheck=1.

Fixes: #2388