### PR TITLE
frontend, cli, python: disable appstream by default

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -1122,7 +1122,7 @@ def setup_parser():
               "the build itself."))
 
     parser_create.add_argument(
-        "--appstream", choices=["on", "off"], default="on",
+        "--appstream", choices=["on", "off"], default="off",
         help=("Generate AppStream metadata for this project. Generating "
               "metadata slows down the builds in large Copr projects."))
 
@@ -1180,7 +1180,7 @@ def setup_parser():
               "the build itself."))
 
     parser_modify.add_argument(
-        "--appstream", choices=["on", "off"], default="on",
+        "--appstream", choices=["on", "off"], default="off",
         help=("Generate AppStream metadata for this project. Generating "
               "metadata slows down the builds in large Copr projects."))
 

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -475,7 +475,7 @@ def test_create_project(config_from_file, project_proxy_add, capsys):
         "multilib": False,
         "module_hotfixes": False,
         "fedora_review": False,
-        "appstream": True,
+        "appstream": False,
         "runtime_dependencies": None,
         "packit_forge_projects_allowed": None,
     }
@@ -570,7 +570,7 @@ def test_create_multilib_project(config_from_file, project_proxy_add, capsys):
         "multilib": True,
         "module_hotfixes": False,
         "fedora_review": False,
-        "appstream": True,
+        "appstream": False,
         "runtime_dependencies": None,
         "packit_forge_projects_allowed": None,
     }

--- a/frontend/coprs_frontend/coprs/forms.py
+++ b/frontend/coprs_frontend/coprs/forms.py
@@ -649,7 +649,7 @@ class CoprForm(BaseForm):
             "Generate AppStream metadata",
             description="""Generate AppStream metadata for this project.
             Generating metadata slows down the builds in large Copr projects.""",
-            default=True, false_values=FALSE_VALUES)
+            default=False, false_values=FALSE_VALUES)
 
     packit_forge_projects_allowed = wtforms.TextAreaField(
         "Packit allowed forge projects",

--- a/frontend/coprs_frontend/coprs/logic/coprs_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/coprs_logic.py
@@ -273,7 +273,7 @@ class CoprsLogic(object):
     def add(cls, user, name, selected_chroots, repos=None, description=None,
             instructions=None, check_for_duplicates=False, group=None, persistent=False,
             auto_prune=True, bootstrap=None, follow_fedora_branching=False, isolation=None,
-            appstream=True, **kwargs):
+            appstream=False, **kwargs):
 
         if not flask.g.user.admin and flask.g.user != user:
             msg = ("You were authorized as '{0}' user without permissions to access "

--- a/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
+++ b/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
@@ -1161,7 +1161,7 @@ class TestCoprActionsGeneration(CoprsTestCase):
             "ownername": "user1",
             "projectname": "test",
             "project_dirnames": ["test"],
-            "appstream": True,
+            "appstream": False,
             "devel": False,
         }
         def _expected(action, chroots):

--- a/python/copr/v3/proxies/project.py
+++ b/python/copr/v3/proxies/project.py
@@ -71,7 +71,7 @@ class ProjectProxy(BaseProxy):
             auto_prune=True, use_bootstrap_container=None, devel_mode=False,
             delete_after_days=None, multilib=False, module_hotfixes=False,
             bootstrap=None, bootstrap_image=None, isolation=None,
-            fedora_review=None, appstream=True, runtime_dependencies=None, packit_forge_projects_allowed=None):
+            fedora_review=None, appstream=False, runtime_dependencies=None, packit_forge_projects_allowed=None):
         """
         Create a project
 


### PR DESCRIPTION
The appstream-builder (the utility used for modifying metadata) is very I/O demanding.  It is known to fail even for not really huge projects.

Related: https://github.com/hughsie/appstream-glib/issues/301

The tool is also about to be replaced by appstream-generator or alike: https://github.com/rpm-software-management/createrepo_c/issues/75

Relates: #2358
Fixes: #2419