### PR TITLE
backend_httpd: make textual file readable through browser

### DIFF
--- a/docker/backend_httpd/files/etc/nginx/conf.d/copr-be.conf
+++ b/docker/backend_httpd/files/etc/nginx/conf.d/copr-be.conf
@@ -1,14 +1,21 @@
 server {
-    listen      5002;
+	listen      5002;
 	listen [::]:5002;
 	server_tokens off;
+	access_log /dev/stdout;
+	error_log /dev/stdout;
 
+	server_name localhost;
 	charset     utf-8;
 
 	root /var/lib/copr/public_html/;
-
+	default_type text/plain;
 	location / {
 		port_in_redirect off;
 		autoindex on;
+	}
+
+	location ~* .*\.gz$  {
+		add_header  Content-Encoding  gzip;
 	}
 }

--- a/kubernetes/kustomize/backend.yaml
+++ b/kubernetes/kustomize/backend.yaml
@@ -44,9 +44,6 @@ spec:
             - containerPort: 5002
               protocol: TCP
           volumeMounts:
-            - mountPath: /opt/app-root/etc/nginx.d/copr-be.conf
-              name: copr-backend
-              subPath: nginx.conf
             - mountPath: /var/lib/copr/public_html/results
               name: copr-backend-data
         - image: copr_backend-log:latest
@@ -98,9 +95,6 @@ spec:
             - mountPath: /etc/sign.conf
               name: copr-backend
               subPath: sign.conf
-            - mountPath: /etc/nginx/conf.d/copr-be.conf
-              name: copr-backend
-              subPath: nginx.conf
             - mountPath: /home/copr/.ssh/builder_config
               name: copr-backend
               subPath: builder_config

--- a/kubernetes/kustomize/kustomization.yaml
+++ b/kubernetes/kustomize/kustomization.yaml
@@ -36,7 +36,6 @@ configMapGenerator:
   - id_rsa=config/backend/.ssh/id_rsa
   name: copr-resalloc
 - files:
-  - nginx.conf=config/backend/nginx.conf
   - copr-be.conf=config/backend/copr-be.conf
   - builder_config=config/backend/.ssh/builder_config
   - id_rsa=config/backend/.ssh/id_rsa


### PR DESCRIPTION
Since the centos-nginx server's default mine type is `octet-stream`, this PR will make the `backend-httpd` container works more likely offical copr instance, all textual file include `.log`, `.log.gz`, `.json`, `.spec` etc, can be displayed in browser directly.
Signed-off-by: lichaoran <pkwarcraft@gmail.com>