### PR TITLE
frontend: add hover for table rows

### DIFF
--- a/frontend/coprs_frontend/coprs/static/copr.css
+++ b/frontend/coprs_frontend/coprs/static/copr.css
@@ -14,6 +14,10 @@ h2.section-heading {
     margin-bottom: 20px;
 }
 
+tr:hover td {
+    background-color: #ECECEC;
+}
+
 div.panel-monitor-menu {
     margin-bottom: 0;
     border-bottom: 0;


### PR DESCRIPTION
Fix RHBZ 2152268

Our v3 bootstrap supports `.table-hover` class for tables but its has a blue color which is too inconsistent with the rest of our colorscheme. I am adding the hover via CSS and using the gray color that is used by bootstrap v4.