### PR TITLE
fix: pod strategy set to recreate as attached volume is ReadWriteOnce

### DIFF
--- a/kubernetes/kustomize/resalloc.yaml
+++ b/kubernetes/kustomize/resalloc.yaml
@@ -4,6 +4,8 @@ metadata:
   name: copr-resalloc
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       component: copr-resalloc


### PR DESCRIPTION
The new pod will hangs in attaching the pvs since the old one still holding it.

Signed-off-by: lichaoran <pkwarcraft@gmail.com>