### PR TITLE
cli: use the --dirname parameter for copr-cli monitor

### DIFF
--- a/cli/copr_cli/monitor.py
+++ b/cli/copr_cli/monitor.py
@@ -56,6 +56,7 @@ def cli_monitor_action(commands, args):
 
     data = commands.client.monitor_proxy.monitor(
         ownername=ownername, projectname=projectname,
+        project_dirname=args.dirname,
         additional_fields=requested_fields,
     )
 


### PR DESCRIPTION
Fix #2341