### PR TITLE
re-try git clone when copr-dist-git is temporarily down

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -47,6 +47,7 @@ BuildRequires: %{python_pfx}-munch
 BuildRequires: %{python}-requests
 BuildRequires: %{python_pfx}-jinja2
 BuildRequires: %{python_pfx}-simplejson
+BuildRequires: %{python}-backoff
 
 %if 0%{?fedora} || 0%{?rhel} > 7
 BuildRequires: argparse-manpage

--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -10,6 +10,8 @@ import datetime
 import shlex
 from threading import Timer
 from collections import OrderedDict
+
+import backoff
 import rpm
 import munch
 
@@ -268,6 +270,10 @@ def git_clone_url_basepath(clone_url):
         return last_part[:-4]
     return last_part
 
+
+@backoff.on_exception(
+    wait_gen=backoff.expo, exception=RuntimeError, max_time=300, jitter=None
+)
 def git_clone_and_checkout(url, committish, repo_path, scm_type="git"):
     """
     Clone given URL (SCM_TYPE=svn/git) into REPO_PATH, and checkout the


### PR DESCRIPTION
how copr_rpmbiuld is run? If I throw there a sleep (as I does) do I stop building only for one VM (and one user) or for everybody?

Fix #2394