### PR TITLE
Submitting packages with URL encoded characters

### DIFF
--- a/backend/copr_backend/actions.py
+++ b/backend/copr_backend/actions.py
@@ -123,8 +123,8 @@ class Createrepo(Action):
         done_count = 0
         for project_dirname in project_dirnames:
             for chroot in chroots:
-                self.log.info("Creating repo for: {}/{}/{}"
-                              .format(ownername, project_dirname, chroot))
+                self.log.info("Creating repo for: %s/%s/%s",
+                              ownername, project_dirname, chroot)
                 repo = os.path.join(self.destdir, ownername,
                                     project_dirname, chroot)
                 try:
@@ -290,7 +290,7 @@ class DeleteProject(Delete):
                 continue
             path = os.path.join(self.destdir, ownername, dirname)
             if os.path.exists(path):
-                self.log.info("Removing copr dir {}".format(path))
+                self.log.info("Removing copr dir %s", path)
                 shutil.rmtree(path)
         return result
 

--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -739,7 +739,8 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
             self.job.update(build_details)
             self.job.validate()
             self._add_pubkey()
-        except:
+        except Exception as ex:
+            self.log.error("Build failed: %s", ex)
             failed = True
             raise
         finally:

--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -59,10 +59,10 @@ def pyconffile(filename):
 
 
 def cmd_debug(cmd, rc, out, err, log):
-    log.info("cmd: {}".format(cmd))
-    log.info("rc: {}".format(rc))
-    log.info("stdout: {}".format(out))
-    log.info("stderr: {}".format(err))
+    log.info("cmd: %s", cmd)
+    log.info("rc: %s", rc)
+    log.info("stdout: %s", out)
+    log.info("stderr: %s", err)
 
 
 class CommandException(Exception):
@@ -165,7 +165,7 @@ def wait_log(log, reason="I don't know why.", timeout=5):
     """
     if not log:
         return
-    log.warning("I'm waiting {0}s because: {1}".format(timeout, reason))
+    log.warning("I'm waiting %ss because: %s", timeout, reason)
     time.sleep(timeout)
 
 

--- a/backend/copr_backend/msgbus.py
+++ b/backend/copr_backend/msgbus.py
@@ -264,8 +264,8 @@ class MsgBusStomp(MsgBus):
         cacert = getattr(self.opts, 'cacert', None)
 
         if (ssl_key, ssl_crt, cacert) != (None, None, None):
-            self.log.debug("ssl: key = {0}, crt = {1}, cacert = {2}".format(
-                ssl_key, ssl_crt, cacert))
+            self.log.debug("ssl: key = %s, crt = %s, cacert = %s",
+                ssl_key, ssl_crt, cacert)
 
             self.conn.set_ssl(
                 for_hosts=hosts,

--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -172,10 +172,10 @@ def sign_rpms_in_dir(username, projectname, path, chroot, opts, log):
         try:
             _sign_one(rpm, create_gpg_email(username, projectname),
                       hashtype, log)
-            log.info("signed rpm: {}".format(rpm))
+            log.info("signed rpm: %s", rpm)
 
         except CoprSignError as e:
-            log.exception("failed to sign rpm: {}".format(rpm))
+            log.exception("failed to sign rpm: %s", rpm)
             errors.append((rpm, e))
 
     if errors:
@@ -254,10 +254,10 @@ def unsign_rpms_in_dir(path, opts, log):
     for rpm in rpm_list:
         try:
             _unsign_one(rpm)
-            log.info("unsigned rpm: {}".format(rpm))
+            log.info("unsigned rpm: %s", rpm)
 
         except CoprSignError as e:
-            log.exception("failed to unsign rpm: {}".format(rpm))
+            log.exception("failed to unsign rpm: %s", rpm)
             errors.append((rpm, e))
 
     if errors:

--- a/backend/run/copr_sign_unsigned.py
+++ b/backend/run/copr_sign_unsigned.py
@@ -30,7 +30,7 @@ def check_signed_rpms_in_pkg_dir(pkg_dir, user, project, opts, chroot_dir, devel
                                 "/tmp/copr_check_signed_rpms.log")
     try:
         sign_rpms_in_dir(user, project, pkg_dir, chroot_dir, opts, log=logger)
-        log.info("running createrepo for {}".format(pkg_dir))
+        log.info("running createrepo for %s", pkg_dir)
         call_copr_repo(directory=chroot_dir, devel=devel, logger=log)
     except Exception as err:
         success = False
@@ -53,7 +53,7 @@ def check_signed_rpms(project_dir, user, project, opts, devel):
         if not os.path.isdir(chroot_path):
             continue
 
-        log.debug("> Checking chroot `{}` in dir `{}`".format(chroot, project_dir))
+        log.debug("> Checking chroot `%s` in dir `%s`", chroot, project_dir)
 
         for mb_pkg in os.listdir(chroot_path):
             if mb_pkg in ["repodata", "devel"]:
@@ -62,7 +62,7 @@ def check_signed_rpms(project_dir, user, project, opts, devel):
             if not os.path.isdir(mb_pkg_path):
                 continue
 
-            log.debug(">> Stepping into package: {}".format(mb_pkg_path))
+            log.debug(">> Stepping into package: %s", mb_pkg_path)
 
             if not check_signed_rpms_in_pkg_dir(mb_pkg_path, user, project,
                                                 opts, chroot_path,
@@ -77,10 +77,10 @@ def check_pubkey(pubkey_path, user, project, opts):
     Ensure that pubkey.gpg presented in project/dir
     """
     if os.path.exists(pubkey_path):
-        log.info("Pubkey for {}/{} exists: {}".format(user, project, pubkey_path))
+        log.info("Pubkey for %s/%s exists: %s", user, project, pubkey_path)
         return True
     else:
-        log.info("Missing pubkey for {}/{}".format(user, project))
+        log.info("Missing pubkey for %s/%s", user, project)
         try:
             get_pubkey(user, project, log, pubkey_path)
             return True
@@ -100,27 +100,27 @@ def main():
         log.debug("error during read old users done")
 
     opts = BackendConfigReader().read()
-    log.info("Starting pubkey fill, destdir: {}".format(opts.destdir))
+    log.info("Starting pubkey fill, destdir: %s", opts.destdir)
 
-    log.debug("list dir: {}".format(os.listdir(opts.destdir)))
+    log.debug("list dir: %s", os.listdir(opts.destdir))
     for user_name in os.listdir(opts.destdir):
         if user_name in users_done_old:
-            log.info("skipping user: {}".format(user_name))
+            log.info("skipping user: %s", user_name)
             continue
 
         failed = False
-        log.info("Started processing user dir: {}".format(user_name))
+        log.info("Started processing user dir: %s", user_name)
         user_dir = os.path.join(opts.destdir, user_name)
 
         for project_name in os.listdir(user_dir):
-            log.info("Checking project dir: {}".format(project_name))
+            log.info("Checking project dir: %s", project_name)
 
             try:
                 get_pubkey(user_name, project_name, log)
-                log.info("Key-pair exists for {}/{}".format(user_name, project_name))
+                log.info("Key-pair exists for %s/%s", user_name, project_name)
             except CoprSignNoKeyError:
                 create_user_keys(user_name, project_name, opts)
-                log.info("Created new key-pair for {}/{}".format(user_name, project_name))
+                log.info("Created new key-pair for %s/%s", user_name, project_name)
             except Exception as err:
                 log.error("Failed to get pubkey for {}/{}, mark as failed, skipping")
                 log.exception(err)

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -39,7 +39,7 @@ class TestHelpers(object):
         try:
             raise BackendError("foobar")
         except Exception as err:
-            log.exception("error occurred: {}".format(err))
+            log.exception("error occurred: %s", err)
 
         (_, raw_message) = self.rc.blpop([LOG_REDIS_FIFO])
         data = json.loads(raw_message)

--- a/rpmbuild/copr_rpmbuild/providers/spec.py
+++ b/rpmbuild/copr_rpmbuild/providers/spec.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse, unquote
 
 from copr_rpmbuild.providers.base import Provider
 
@@ -21,7 +21,7 @@ class UrlProvider(Provider):
         return path
 
     def download_srpm(self):
-        basename = os.path.basename(self.parsed_url.path)
+        basename = unquote(os.path.basename(self.parsed_url.path))
         filename = os.path.join(self.resultdir, basename)
         response = self.request.get(self.url, stream=True)
         if response.status_code != 200:


### PR DESCRIPTION
I found some builds that failed for a strange reason, e.g.

https://copr.fedorainfracloud.org/coprs/frostyx/fedora-review-2133080-python-nss/build/5198485/

Copy-pasting a relevant part from `backend.log`

```
[2023-01-03 22:45:58,230][  INFO][PID:4041220] Going to sign pkgs from source: 5198485 in chroot: /var/lib/copr/public_html/results/frostyx/fedora-review-2133080-python-nss/srpm-builds
[2023-01-03 22:45:58,230][  INFO][PID:4041220] Calling '/bin/sign -u frostyx#fedora-review-2133080-python-nss@copr.fedorahosted.org -p' (attempt #1)
[2023-01-03 22:45:58,240][WARNING][PID:4041220] Command '/bin/sign -u frostyx#fedora-review-2133080-python-nss@copr.fedorahosted.org -p' failed with: unknown key: frostyx#fedora-review-2133080-python-nss@copr.fedorahosted.org
[2023-01-03 22:45:58,240][WARNING][PID:4041220] Going to sleep 20s and re-try.
[2023-01-03 22:46:18,241][  INFO][PID:4041220] Calling '/bin/sign -u frostyx#fedora-review-2133080-python-nss@copr.fedorahosted.org -p' (attempt #2)
[2023-01-03 22:46:18,705][  INFO][PID:4041220] Calling '/bin/sign -4 -h sha256 -u frostyx#fedora-review-2133080-python-nss@copr.fedorahosted.org -r /var/lib/copr/public_html/results/frostyx/fedora-review-2133080-python-nss/srpm-builds/05198485/python-nss-1.0.1%5E20210803hg9de14a6f77e2-4.fc38.src.rpm' (attempt #1)
[2023-01-03 22:46:19,138][  INFO][PID:4041220] Finished build: id=5198485 failed=True timeout=108000 destdir=/var/lib/copr/public_html/results/frostyx/fedora-review-2133080-python-nss chroot=srpm-builds 
[2023-01-03 22:46:19,140][ ERROR][PID:4041220] Unexpected exception (in /usr/lib/python3.11/site-packages/copr_backend/helpers.py:511)
[2023-01-03 22:46:19,146][  INFO][PID:4041220] Worker failed build, took 23.063164234161377
[2023-01-03 22:46:19,206][  INFO][PID:4041220] Sending fedora-messaging bus message in build.end
```

Narrowed down to 

```
[2023-01-03 22:46:19,140][ ERROR][PID:4041220] Unexpected exception (in /usr/lib/python3.11/site-packages/copr_backend/helpers.py:511)
```

which is a non-helpful error pointing somewhere to `RedisPublishHandler`, which is completely unrelated. I am adding a better logging for such exceptions, so now it shows this instead 

```
[2023-01-05 00:44:58,394][ ERROR][PID:948] Build failed: not enough arguments for format string
```

Which originated in 

```python
log.info("signed rpm: {}".format(rpm))
```

because `log.info` got a string with `%` and therefore expected more arguments. So I changed all backend's logging that I found from `.format`.

And the last commit decodes the URL-encoded characters so that this doesn't happen in the first place (see the commit  message).