### PR TITLE
frontend: fix homepage user count

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/users_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/users_logic.py
@@ -28,7 +28,7 @@ class UsersLogic(object):
         Return all users that have at least one project (deleted projects
         counts as well)
         """
-        return User.query.filter(~User.coprs.any())
+        return User.query.filter(User.coprs.any())
 
     @classmethod
     def raise_if_cant_update_copr(cls, user, copr, message):


### PR DESCRIPTION
Fix #2448

The tilde doesn't make any sense, it had to be a copy-paste error or something. According to the documentation
https://docs.sqlalchemy.org/en/20/core/operators.html tilde means `NOT`, so we were returning users without projects, not users with projects.