### PR TITLE
Revert "Add badges for LGTM.com"

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@ python-copr-common | [![badge](https://copr.fedorainfracloud.org/coprs/g/copr/co
 
 [//]: # (Please generate this table by ./build_aux/generate-build-status-table)
 
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/fedora-copr/copr.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/fedora-copr/copr/context:python)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/fedora-copr/copr.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/fedora-copr/copr/alerts/)
-
 ## Local Testing Environment
 You can use [Docker](https://docs.docker.com/) to run your local test environment. You need to install `docker-compose` tool for this to work.
 


### PR DESCRIPTION
This reverts commit ebfa21d5cc038136cb8f05da3dc36e2a99916083.

Because of https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/ LGTM has been replaced code scanning feature directly in GH.