### PR TITLE
frontend: don't depend on flask-restful

### DIFF
--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -92,7 +92,6 @@ BuildRequires: python3-flask-caching
 BuildRequires: python3-flask-cache
 %endif
 BuildRequires: python3-flask-openid
-BuildRequires: python3-flask-restful
 BuildRequires: python3-flask-sqlalchemy
 BuildRequires: python3-flask-whooshee
 BuildRequires: python3-flask-wtf
@@ -150,7 +149,6 @@ Requires: python3-flask-caching
 Requires: python3-flask-cache
 %endif
 Requires: python3-flask-openid
-Requires: python3-flask-restful
 Requires: python3-flask-sqlalchemy
 Requires: python3-flask-whooshee
 Requires: python3-flask-wtf

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -13,13 +13,11 @@ pydns # pyLibravatar uses this
 python-dateutil
 netaddr
 alembic
-flask-restful
 marshmallow
 redis
 python-openid-teams
 requests
 psycopg2
-# flask-restful-swagger # -- nice to have, but probably later
 decorator
 flexmock
 mock


### PR DESCRIPTION
This is not needed since we removed APIv2 354441eaeeff929720d584df7e07e32892c1eb06.