### PR TITLE
frontend: customizable group link to FAS

### DIFF
--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -74,6 +74,11 @@ class Config(object):
         'user_desc': 'fas'
     }
 
+    GROUP_INFO = {
+        'link': 'https://accounts.fedoraproject.org/group/{name}/',
+        'desc': 'FAS details',
+    }
+
     # Optional, news box shows only when both variables are configured
     NEWS_URL = "https://fedora-copr.github.io/"
     NEWS_FEED_URL = "https://fedora-copr.github.io/feed.xml"

--- a/frontend/coprs_frontend/coprs/templates/coprs/show/group.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/show/group.html
@@ -18,8 +18,13 @@
 <div id="profile">
   <h1>@{{group.name}} Group</h1>
   <p>
-    <a href="https://accounts.fedoraproject.org/group/{{ group.fas_name }}" title="{{ group.fas_name }}'s FAS details" target="_blank">FAS details</a> |
-    <a href="https://accounts.fedoraproject.org/group/{{ group.fas_name }}" title="{{ group.fas_name }}'s Members" target="_blank">View Members</a>
+    <a href="{{ config.GROUP_INFO.link.format(name=group.fas_name) }}"
+       title="{{ group.fas_name }}'s {{ config.GROUP_INFO.desc }}"
+       target="_blank">{{ config.GROUP_INFO.desc }}</a> |
+
+    <a href="{{ config.GROUP_INFO.link.format(name=group.fas_name) }}"
+       title="{{ group.fas_name }}'s Members"
+       target="_blank">View Members</a>
   </p>
 </div>
 {% endblock %}


### PR DESCRIPTION
Other Copr instances might want to point somewhere else then FAS.