### PR TITLE
frontend: update alembic migration template

### DIFF
--- a/frontend/coprs_frontend/alembic/script.py.mako
+++ b/frontend/coprs_frontend/alembic/script.py.mako
@@ -2,19 +2,24 @@
 ${message}
 
 Revision ID: ${up_revision}
-Revises: ${down_revision}
+Revises: ${down_revision | comma,n}
 Create Date: ${create_date}
 """
 
-import sqlalchemy as sa
 from alembic import op
+import sqlalchemy as sa
 ${imports if imports else ""}
 
+# revision identifiers, used by Alembic.
 revision = ${repr(up_revision)}
 down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
 
 def upgrade():
     ${upgrades if upgrades else "pass"}
+
 
 def downgrade():
     ${downgrades if downgrades else "pass"}


### PR DESCRIPTION
I remember seeing pylint errors in newly generated migration scripts. I am copy-pasting the template installed from `python3-alembic-1.7.7-3.fc37.noarch`.