### PR TITLE
frontend: fix batches race logic by adding locks

### DIFF
--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -113,6 +113,7 @@ BuildRequires: python3-redis
 BuildRequires: python3-requests
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinxcontrib-httpdomain
+BuildRequires: python3-sqlalchemy-utils
 BuildRequires: python3-whoosh
 BuildRequires: python3-wtforms >= 2.2.1
 BuildRequires: python3-ldap
@@ -170,6 +171,7 @@ Requires: python3-pylibravatar
 Requires: python3-pytz
 Requires: python3-redis
 Requires: python3-requests
+Requires: python3-sqlalchemy-utils
 Requires: python3-templated-dictionary
 Requires: python3-wtforms >= 2.2.1
 Requires: python3-zmq

--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -117,6 +117,7 @@ BuildRequires: python3-whoosh
 BuildRequires: python3-wtforms >= 2.2.1
 BuildRequires: python3-ldap
 BuildRequires: python3-yaml
+BuildRequires: python3-backoff
 BuildRequires: redis
 BuildRequires: modulemd-tools >= 0.6
 %endif
@@ -173,6 +174,7 @@ Requires: python3-templated-dictionary
 Requires: python3-wtforms >= 2.2.1
 Requires: python3-zmq
 Requires: python3-ldap
+Requires: python3-backoff
 Requires: xstatic-bootstrap-scss-common
 Requires: xstatic-datatables-common
 Requires: js-jquery-ui


### PR DESCRIPTION
Fix #2107

The said reproducer didn't work for me. I used this one:

    parallel copr build-package @copr/foo --nowait --background \
        --after-build-id 123  --name \
        ::: $(for i in {1..50}; do echo "copr-cli"; done)