### PR TITLE
frontend, backend, python: drop the unneeded marshmallow dep

### DIFF
--- a/backend/copr_backend/job.py
+++ b/backend/copr_backend/job.py
@@ -71,7 +71,7 @@ class BuildJob(object):
         self.results = None
         self.appstream = None
 
-        # TODO: validate update data, user marshmallow
+        # TODO: validate update data
         for key, val in task_data.items():
             key = str(key)
             setattr(self, key, val)

--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -102,7 +102,6 @@ BuildRequires: python3-humanize
 BuildRequires: python3-libmodulemd1 >= 1.7.0
 BuildRequires: python3-lxml
 BuildRequires: python3-markdown
-BuildRequires: python3-marshmallow >= 2.0.0
 BuildRequires: python3-munch
 BuildRequires: python3-netaddr
 BuildRequires: python3-openid-teams
@@ -160,7 +159,6 @@ Requires: python3-humanize
 Requires: python3-libmodulemd1 >= 1.7.0
 Requires: python3-lxml
 Requires: python3-markdown
-Requires: python3-marshmallow
 Requires: python3-mod_wsgi
 Requires: python3-munch
 Requires: python3-netaddr

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -13,7 +13,6 @@ pydns # pyLibravatar uses this
 python-dateutil
 netaddr
 alembic
-marshmallow
 redis
 python-openid-teams
 requests

--- a/python/python-copr.spec
+++ b/python/python-copr.spec
@@ -31,7 +31,6 @@ BuildRequires: util-linux
 BuildRequires: python-setuptools
 BuildRequires: python-requests
 BuildRequires: python-requests-toolbelt
-BuildRequires: python-marshmallow
 BuildRequires: python-six >= 1.9.0
 BuildRequires: python-mock
 BuildRequires: python-munch
@@ -48,7 +47,6 @@ BuildRequires: python-docutils
 BuildRequires: python2-setuptools
 BuildRequires: python2-requests
 BuildRequires: python2-requests-toolbelt
-BuildRequires: python2-marshmallow
 BuildRequires: python2-six >= 1.9.0
 BuildRequires: python2-pytest
 BuildRequires: python2-devel
@@ -81,7 +79,6 @@ Summary: %summary
 
 %if 0%{?rhel} == 7
 Requires: python-configparser
-Requires: python-marshmallow
 Requires: python-munch
 Requires: python-filelock
 Requires: python-requests
@@ -92,7 +89,6 @@ Requires: python-six >= 1.9.0
 Requires: python-future
 %else
 Requires: python2-configparser
-Requires: python2-marshmallow
 Requires: python2-munch
 Requires: python2-filelock
 Requires: python2-requests
@@ -120,7 +116,6 @@ BuildRequires: python3-devel
 BuildRequires: python3-docutils
 BuildRequires: python3-munch
 BuildRequires: python3-filelock
-BuildRequires: python3-marshmallow
 BuildRequires: python3-pytest
 BuildRequires: python3-setuptools
 BuildRequires: python3-requests
@@ -130,7 +125,6 @@ BuildRequires: python3-sphinx
 BuildRequires: python3-requests-gssapi
 BuildRequires: python3-future
 
-Requires: python3-marshmallow
 Requires: python3-munch
 Requires: python3-filelock
 Requires: python3-requests

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,7 +15,6 @@ This part is a python client to the copr service."""
 
 requires = [
     'filelock',
-    'marshmallow',
     'requests',
     'requests-toolbelt',
     'setuptools',


### PR DESCRIPTION
Since we dropped APIv1 and APIv2, we don't use marshmallow (at least not directly) now.  The explicit dependency on the lib was just a leftover.