### PR TITLE
docker: add keygen-httpd service to docker-compose.shell.yaml

### DIFF
--- a/docker-compose.shell.yaml
+++ b/docker-compose.shell.yaml
@@ -23,3 +23,6 @@ services:
 
   distgit:
     command: /bin/bash
+
+  keygen-httpd:
+    command: /bin/bash


### PR DESCRIPTION
Here is how I use it
http://frostyx.cz/posts/copr-docker-compose-without-supervisord#keygen