### PR TITLE
frontend: allow uploading artificial payload in custom webhook

### DIFF
--- a/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
+++ b/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
@@ -223,14 +223,14 @@ class HookContentStorage(object):
     tmp = None
 
     def __init__(self):
-        if not flask.request.json:
+        if not flask.request.get_data():
             return
         self.tmp = tempfile.mkdtemp(dir=app.config["STORAGE_DIR"])
         log.debug("storing hook content under %s", self.tmp)
         try:
             with open(os.path.join(self.tmp, 'hook_payload'), "wb") as f:
                 # Do we need to dump http headers, too?
-                f.write(flask.request.data)
+                f.write(flask.request.get_data())
 
         except Exception:
             log.exception('can not store hook payload')


### PR DESCRIPTION
It turns out non-json payload was never actually handed-over to a custom script.  This was caused by the artificial request.json check in the HookContentStorage.__init__ method.  But with the previous Flask versions we were at at least able to successfully submit the custom webhook build even with an empty payload without specified content type.

After the migration to F37 with new Flask the check for request.json started raising the exception 400 for empty payloads (causing #2416):

    Did not attempt to load JSON data because the request Content-Type
    was not 'application/json'

The JSON check is now replaced with request.get_data() which is a safe call in any case (form submitted, json data, uploaded file).

Fixes: #2416