### PR TITLE
keygen: fix validation for projects with dash in their name

### DIFF
--- a/keygen/src/copr_keygen/logic.py
+++ b/keygen/src/copr_keygen/logic.py
@@ -57,7 +57,7 @@ def validate_name_email(name_email):
     # validating email is too hardcore (see `wtforms.validators.Email`) and we
     # don't care anyway. We only want to make sure that no ilegal characters
     # were used.
-    if not re.match(r"^[\w.-@]+$", email):
+    if not re.match(r"^[-\w.@]+$", email):
         return False
 
     if not email.count("@") == 1:

--- a/keygen/tests/test_logic.py
+++ b/keygen/tests/test_logic.py
@@ -188,6 +188,8 @@ class TestGenKey(TestCase):
         assert logic.validate_name_email("frostyx#foo@copr.fedorahosted.org")
         assert logic.validate_name_email("@copr#foo@copr.fedorahosted.org")
         assert logic.validate_name_email("@db-sig#foo@copr.fedorahosted.org")
+        assert logic.validate_name_email("@copr#foo-bar@copr.fedorahosted.org")
+        assert logic.validate_name_email("frostyx#foo.bar@copr.fedorahosted.org")
 
         assert not logic.validate_name_email("foo")
         assert not logic.validate_name_email("user#invalid-email")


### PR DESCRIPTION
Beaker tests revealed some bugs in the keygen email validation. It
failed for projects with dashes and projects with dots in their
names.

The culprit was wrongly placed dash character in the regex, it needs
to be at the beginning otherwise it is interpreted as a range.