### PR TITLE
rpmbuild: add runtime dependency for python-backoff

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -66,6 +66,7 @@ Requires: %{python_pfx}-jinja2
 Requires: %{python_pfx}-munch
 Requires: %{python}-requests
 Requires: %{python_pfx}-simplejson
+Requires: %{python}-backoff
 
 Requires: mock >= 2.0
 Requires: git


### PR DESCRIPTION
SSIA