### PR TITLE
frontend: fix the "Modules:" form widget

### DIFF
--- a/frontend/coprs_frontend/coprs/forms.py
+++ b/frontend/coprs_frontend/coprs/forms.py
@@ -1437,7 +1437,7 @@ class AbstractSeparatedListField(wtforms.Field):
     # boilerplate stuff for the web-UI rendering
     widget = wtforms.widgets.TextInput()
     def _value(self):
-        return ', '.join(self.data or [])
+        return self.data or ""
 
     def process_formdata(self, valuelist: list):
         """


### PR DESCRIPTION
The value is actually a string taken from database, there's no need to use ", ".join().