### PR TITLE
Define some copr-specific environment variables for custom method

### DIFF
--- a/doc/custom_source_method.rst
+++ b/doc/custom_source_method.rst
@@ -85,6 +85,19 @@ directory. We cannot process SRC.RPM. Because some chroots can use technology
 which our server cannot recognize. E.g., in the past `rpm` changed compression and
 checksum algorithm and rpm from RHEL was unable to process packages from Fedora.
 
+Environment variables
+---------------------
+
+On top of the standard environment variables, Copr defines also:
+
+- ``COPR_OWNER`` - Owner of the project. It may be a user or group name
+- ``COPR_PROJECT`` - Name of the project
+- ``COPR_PACKAGE`` - Name of the package that is currently being
+  built. It may not be known, in such case, this variable contains an
+  empty string.
+- ``COPR_RESULTDIR`` - See the optional parameter **resultdir**
+
+
 Examples
 --------
 

--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -225,6 +225,7 @@ def get_srpm_build_record(task, for_backend=False):
             "submitter": task.submitter[0],
             "project_name": task.copr_name,
             "project_dirname": task.copr_dirname,
+            "package_name": task.package.name if task.package else None,
             "appstream": bool(task.copr.appstream),
             "repos": BuildConfigLogic.get_additional_repo_views(repos, chroot),
         })

--- a/rpmbuild/bin/copr-sources-custom
+++ b/rpmbuild/bin/copr-sources-custom
@@ -51,6 +51,13 @@ parser.add_argument(
         help="execute the SCRIPT from with CWD=WORKDIR (within mock chroot)"
 )
 
+parser.add_argument(
+        "--env",
+        nargs="*",
+        action="extend",
+        help="Environment variables available within the SCRIPT",
+)
+
 
 def run_cmd(command, **kwargs):
     log.info("running command: " + ' '.join([shlex.quote(x) for x in command]))
@@ -98,9 +105,10 @@ if __name__ == "__main__":
                         os.path.join(workdir, 'hook_payload')])
         run_cmd(mock + ['--shell', 'chmod a+r ' + payload_file_inner])
 
+    env = args.env + ["COPR_RESULTDIR=" + shlex.quote(resultdir)]
     cmd = 'set -xe ; cd {workdir} ; {env} /script'.format(
         workdir=shlex.quote(workdir),
-        env='COPR_RESULTDIR=' + shlex.quote(resultdir),
+        env=" ".join(env)
     )
     cmd = shlex.quote(cmd)
 

--- a/rpmbuild/copr_rpmbuild/providers/custom.py
+++ b/rpmbuild/copr_rpmbuild/providers/custom.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import shutil
+import shlex
 
 from jinja2 import Environment, FileSystemLoader
 from copr_rpmbuild import helpers
@@ -82,6 +83,14 @@ class CustomProvider(Provider):
             cmd += ['--resultdir', self.inner_resultdir]
             inner_resultdir = os.path.normpath(os.path.join(
                 self.inner_workdir, self.inner_resultdir))
+
+        env = {
+            "COPR_OWNER": self.task["project_owner"],
+            "COPR_PROJECT": self.task["project_name"],
+            "COPR_PACKAGE": self.task["package_name"],
+        }
+        for k, v in env.items():
+            cmd += ['--env', '{0}={1}'.format(k, shlex.quote(v))]
 
         # prepare the sources
         process = helpers.GentlyTimeoutedPopen(cmd, timeout=self.timeout)


### PR DESCRIPTION
See #557

That RFE requested mainly package name, and additionally project name and owner name. I am adding only the last two. The package name will be hard to implement because we don't have its value in copr-rpmbuild. Moreover, we can't even send it from the frontend because when doing Packages > some package > Rebuild, we don't save the package <-> build relationship to the database. It is saved only after the SRPM is built.