### PR TITLE
Make sure user can build in the project before uploading SRPM

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/build-spec.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/build-spec.sh
@@ -42,6 +42,13 @@ rlJournalStart
     rlPhaseStartTest
         rlRun "copr-cli create ${NAME_PREFIX}BuildSpec --enable-net on --chroot $CHROOT" 0
         rlRun "copr-cli build ${NAME_PREFIX}BuildSpec $HERE/files/vera.spec" 0
+
+        # Make sure we don't upload SRPM/Spec if user tries to build into
+        # a non-existing project (or project he doesn't have permissions to)
+        OUTPUT=`mktemp`
+        rlRun "copr-cli build --nowait ${NAME_PREFIX}NonExisting $HERE/files/vera.spec &> $OUTPUT" 1
+        rlAssertEquals "" `grep -r 'does not exist' $OUTPUT |wc -l` 1
+        rlAssertEquals "" `grep -r 'Uploading package' $OUTPUT |wc -l` 0
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -314,6 +314,13 @@ class Commands(object):
 
         username, projectname, project_dirname = self.parse_dirname(args.copr_repo)
 
+        # Before we start uploading potentially large source RPM file, make sure
+        # that the user can actually build in the project
+        if not self.client.project_proxy.can_build_in(username, projectname):
+            msg = ("User '{0}' is not allowed to build in '{1}/{2}'"
+                   .format(self.username, username, projectname))
+            raise CoprRequestException(msg)
+
         builds = []
         for pkg in args.pkgs:
             if os.path.exists(pkg):

--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -316,7 +316,9 @@ class Commands(object):
 
         # Before we start uploading potentially large source RPM file, make sure
         # that the user can actually build in the project
-        if not self.client.project_proxy.can_build_in(username, projectname):
+        can_build = self.client.project_proxy.can_build_in(
+            self.username, username, projectname)
+        if not can_build:
             msg = ("User '{0}' is not allowed to build in '{1}/{2}'"
                    .format(self.username, username, projectname))
             raise CoprRequestException(msg)

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -577,11 +577,14 @@ def test_create_multilib_project(config_from_file, project_proxy_add, capsys):
     assert stdout == "New project was successfully created: http://copr/coprs/jdoe/foo/\n"
 
 
+@mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+            return_value=True)
 @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
 @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
 @mock.patch('copr_cli.main.config_from_file', return_value=mock_config)
 @mock.patch('copr_cli.main.Commands._watch_builds')
-def test_create_build_no_wait_ok(watch_builds, config_from_file, create_from_url, auth_check, capsys):
+def test_create_build_no_wait_ok(watch_builds, config_from_file,
+                                 create_from_url, auth_check, _can_build_in, capsys):
     create_from_url.return_value = Munch(projectname="foo", id=123)
 
     main.main(argv=[
@@ -595,11 +598,15 @@ def test_create_build_no_wait_ok(watch_builds, config_from_file, create_from_url
     assert not watch_builds.called
 
 
+@mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+            return_value=True)
 @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
 @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
 @mock.patch('copr_cli.main.config_from_file', return_value=mock_config)
 @mock.patch('copr_cli.main.Commands._watch_builds')
-def test_create_build_no_wait_error(watch_builds, config_from_file,create_from_url, autch_check, capsys):
+def test_create_build_no_wait_error(watch_builds, config_from_file,
+                                    create_from_url, autch_check, _can_build_in,
+                                    capsys):
     response_message = "foobar"
     create_from_url.side_effect = copr.v3.CoprRequestException(response_message)
 
@@ -615,12 +622,15 @@ def test_create_build_no_wait_error(watch_builds, config_from_file,create_from_u
 
 
 @mock.patch('copr_cli.main.time')
+@mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+            return_value=True)
 @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
 @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
 @mock.patch('copr.v3.proxies.build.BuildProxy.get')
 @mock.patch('copr_cli.main.config_from_file', return_value=mock_config)
 def test_create_build_wait_succeeded_no_sleep(config_from_file, build_proxy_get,
-                                              create_from_url, auth_check, mock_time, capsys):
+                                              create_from_url, auth_check,
+                                              _can_build_in, mock_time, capsys):
     create_from_url.return_value = Munch(projectname="foo", id=123)
     build_proxy_get.return_value = Munch(state="succeeded")
     main.main(argv=[
@@ -634,11 +644,15 @@ def test_create_build_wait_succeeded_no_sleep(config_from_file, build_proxy_get,
     assert not mock_time.sleep.called
 
 
+@mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+            return_value=True)
 @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
 @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
 @mock.patch('copr.v3.proxies.build.BuildProxy.get')
 @mock.patch('copr_cli.main.config_from_file', return_value=mock_config)
-def test_create_build_wait_error_status(config_from_file, build_proxy_get, create_from_url, auth_check, capsys):
+def test_create_build_wait_error_status(config_from_file, build_proxy_get,
+                                        create_from_url, auth_check,
+                                        _can_build_in, capsys):
     create_from_url.return_value = Munch(projectname="foo", id=123)
     build_proxy_get.side_effect = copr.v3.CoprRequestException()
     with pytest.raises(SystemExit) as err:
@@ -653,11 +667,15 @@ def test_create_build_wait_error_status(config_from_file, build_proxy_get, creat
     assert "Watching build" in stdout
 
 
+@mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+            return_value=True)
 @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
 @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
 @mock.patch('copr.v3.proxies.build.BuildProxy.get')
 @mock.patch('copr_cli.main.config_from_file', return_value=mock_config)
-def test_create_build_wait_unknown_build_status(config_from_file, build_proxy_get, create_from_url, auth_check, capsys):
+def test_create_build_wait_unknown_build_status(config_from_file, build_proxy_get,
+                                                create_from_url, auth_check,
+                                                _can_build_in, capsys):
     create_from_url.return_value = Munch(projectname="foo", id=123)
     build_proxy_get.return_value = Munch(state="unknown")
     with pytest.raises(SystemExit) as err:
@@ -672,11 +690,15 @@ def test_create_build_wait_unknown_build_status(config_from_file, build_proxy_ge
     assert "Watching build" in stdout
 
 
+@mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+            return_value=True)
 @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
 @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
 @mock.patch('copr.v3.proxies.build.BuildProxy.get')
 @mock.patch('copr_cli.main.config_from_file', return_value=mock_config)
-def test_create_build_wait_keyboard_interrupt(config_from_file, build_proxy_get, create_from_url, autch_check, capsys):
+def test_create_build_wait_keyboard_interrupt(config_from_file, build_proxy_get,
+                                              create_from_url, autch_check,
+                                              _can_build_in, capsys):
     create_from_url.return_value = Munch(projectname="foo", id=123)
     build_proxy_get.side_effect = KeyboardInterrupt
 
@@ -694,11 +716,15 @@ def test_create_build_wait_keyboard_interrupt(config_from_file, build_proxy_get,
 @mock.patch('copr_cli.main.config_from_file', return_value=mock_config)
 class TestCreateBuild(object):
 
+    @mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+                return_value=True)
     @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
     @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
     @mock.patch('copr.v3.proxies.build.BuildProxy.get')
-    def test_create_build_wait_succeeded_complex(self, build_proxy_get, create_from_url, auth_check,
-                                                 config_from_file, mock_time, capsys):
+    def test_create_build_wait_succeeded_complex(self, build_proxy_get,
+                                                 create_from_url, auth_check,
+                                                 _can_build_in, config_from_file,
+                                                 mock_time, capsys):
         create_from_url.return_value = Munch(projectname="foo", id=1)
         self.stage = 0
 
@@ -731,11 +757,15 @@ class TestCreateBuild(object):
         assert "Watching build" in stdout
         assert len(mock_time.sleep.call_args_list) == 3
 
+    @mock.patch('copr.v3.proxies.project.ProjectProxy.can_build_in',
+                return_value=True)
     @mock.patch('copr.v3.proxies.BaseProxy.auth_check', return_value=Munch(name="test"))
     @mock.patch('copr.v3.proxies.build.BuildProxy.create_from_url')
     @mock.patch('copr.v3.proxies.build.BuildProxy.get')
-    def test_create_build_wait_failed_complex(self, build_proxy_get, create_from_url, auth_check,
-                                              config_from_file, mock_time, capsys):
+    def test_create_build_wait_failed_complex(self, build_proxy_get,
+                                              create_from_url, auth_check,
+                                              _can_build_in, config_from_file,
+                                              mock_time, capsys):
         create_from_url.return_value = Munch(projectname="foo", id=1)
         self.stage = 0
 

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_permissions.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_permissions.py
@@ -11,6 +11,14 @@ from coprs import db_session_scope, models
 from . import GET, PUT, editable_copr, get_copr
 
 
+@apiv3_ns.route("/project/permissions/can_build_in/<ownername>/<projectname>")
+@api_login_required
+def can_build_in(ownername, projectname):
+    copr = get_copr(ownername, projectname)
+    result = {"can_build_in": flask.g.user.can_build_in(copr)}
+    return flask.jsonify(result)
+
+
 @apiv3_ns.route("/project/permissions/get/<ownername>/<projectname>", methods=GET)
 @api_login_required
 @editable_copr

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_permissions.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_permissions.py
@@ -5,17 +5,26 @@ from coprs.views.misc import api_login_required
 from coprs.exceptions import ObjectNotFound, BadRequest
 from coprs.helpers import PermissionEnum
 from coprs.logic.coprs_logic import CoprPermissionsLogic
+from coprs.logic.users_logic import UsersLogic
 from coprs.mail import send_mail, PermissionRequestMessage, PermissionChangeMessage
 from coprs import db_session_scope, models
 
 from . import GET, PUT, editable_copr, get_copr
 
 
-@apiv3_ns.route("/project/permissions/can_build_in/<ownername>/<projectname>")
-@api_login_required
-def can_build_in(ownername, projectname):
+@apiv3_ns.route("/project/permissions/can_build_in/<who>/<ownername>/<projectname>")
+def can_build_in(who, ownername, projectname):
+    """
+    Can a user `who` submit builds in the `ownername/projectname` project?
+    """
+    user = UsersLogic.get(who).one()
     copr = get_copr(ownername, projectname)
-    result = {"can_build_in": flask.g.user.can_build_in(copr)}
+    result = {
+        "who": user.name,
+        "ownername": copr.owner.name,
+        "projectname": copr.name,
+        "can_build_in": user.can_build_in(copr),
+    }
     return flask.jsonify(result)
 
 

--- a/python/copr/v3/proxies/project.py
+++ b/python/copr/v3/proxies/project.py
@@ -288,6 +288,26 @@ class ProjectProxy(BaseProxy):
         )
         return munchify(response)
 
+    def can_build_in(self, ownername, projectname):
+        """
+        Return `True` a user can submit builds for a ownername/projectname
+
+        :param str ownername: owner of the project
+        :param str projectname: name of the project
+        :return Bool: `True` or raise
+        """
+        endpoint = "/project/permissions/can_build_in/{ownername}/{projectname}/"
+        params = {
+            "ownername": ownername,
+            "projectname": projectname,
+        }
+        response = self.request.send(
+            endpoint=endpoint,
+            params=params,
+            auth=self.auth
+        )
+        return munchify(response).can_build_in
+
     def get_permissions(self, ownername, projectname):
         """
         Get project permissions

--- a/python/copr/v3/proxies/project.py
+++ b/python/copr/v3/proxies/project.py
@@ -288,16 +288,19 @@ class ProjectProxy(BaseProxy):
         )
         return munchify(response)
 
-    def can_build_in(self, ownername, projectname):
+    def can_build_in(self, who, ownername, projectname):
         """
         Return `True` a user can submit builds for a ownername/projectname
 
+        :param str who: name of the user checking their permissions
         :param str ownername: owner of the project
         :param str projectname: name of the project
         :return Bool: `True` or raise
         """
-        endpoint = "/project/permissions/can_build_in/{ownername}/{projectname}/"
+        endpoint = ("/project/permissions/can_build_in/"
+                    "{who}/{ownername}/{projectname}/")
         params = {
+            "who": who,
             "ownername": ownername,
             "projectname": projectname,
         }


### PR DESCRIPTION
Fix #134

Tested for both non-existing project and someone else's project that I don't have permissions to.

We can easily drop the `self.client.base_proxy.auth_check()` from CLI because there is `@requires_api_auth` decorator on the function.