### PR TITLE
frontend, backend: remove libmodulemd1 dependency

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -47,7 +47,6 @@ BuildRequires: python3-filelock
 BuildRequires: python3-gobject
 BuildRequires: python3-httpretty
 BuildRequires: python3-humanize
-BuildRequires: python3-libmodulemd1 >= 1.7.0
 BuildRequires: python3-munch
 BuildRequires: python3-netaddr
 BuildRequires: python3-packaging
@@ -86,7 +85,6 @@ Requires:   python3-filelock
 Requires:   python3-gobject
 Requires:   python3-humanize
 Requires:   python3-jinja2
-Requires:   python3-libmodulemd1 >= 1.7.0
 Requires:   python3-munch
 Requires:   python3-netaddr
 Requires:   python3-novaclient

--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -99,7 +99,6 @@ BuildRequires: python3-gobject
 BuildRequires: python3-html2text
 BuildRequires: python3-html5-parser
 BuildRequires: python3-humanize
-BuildRequires: python3-libmodulemd1 >= 1.7.0
 BuildRequires: python3-lxml
 BuildRequires: python3-markdown
 BuildRequires: python3-munch
@@ -158,7 +157,6 @@ Requires: python3-gobject
 Requires: python3-html2text
 Requires: python3-html5-parser
 Requires: python3-humanize
-Requires: python3-libmodulemd1 >= 1.7.0
 Requires: python3-lxml
 Requires: python3-markdown
 Requires: python3-mod_wsgi


### PR DESCRIPTION
It is a leftover, we are using modulemd-tools for modularity things, so let it figure out the dependencies.