### PR TITLE
keygen: fix config files installation pattern

### DIFF
--- a/keygen/copr-keygen.spec
+++ b/keygen/copr-keygen.spec
@@ -158,16 +158,15 @@ systemctl condrestart httpd &>/dev/null || :
 %{_bindir}/gpg_copr.sh
 %{_bindir}/gpg-copr
 %{_bindir}/gpg-copr-prolong
-%config(noreplace)  %{_sysconfdir}/sudoers.d/copr_signer
 
+%config %{_sysconfdir}/cron.daily/*
+%config %{_sysconfdir}/logrotate.d/copr-keygen
+%config %{_sysconfdir}/sudoers.d/copr_signer
+
+# Only copr-signer owned files go below!
 %defattr(600, copr-signer, copr-signer, 700)
 %{_sharedstatedir}/copr-keygen
 %config(noreplace) %{_sysconfdir}/copr-keygen
-
-%{_sysconfdir}/logrotate.d/copr-keygen
-
-%config %attr(0755, root, root) %{_sysconfdir}/cron.daily/*
-
 %dir %{_localstatedir}/log/copr-keygen
 %ghost %{_localstatedir}/log/copr-keygen/main.log
 


### PR DESCRIPTION
copr-keygen.spec uses %defattr for copr-signer, and we mistakenly included the logrotate drop-in file there, new logrotate started to dislike this, per logrotate error:

    error: Ignoring copr-keygen because the file owner is wrong (should
    be root or user with uid 0).

The cron.daily script, if moved up a bit in the %files section doesn't need the %attr override either.

While on it, the sudoers dropin config shouldn't be '(noreplace)'.  We want to maintain/replace the file via RPM updates.