### PR TITLE
cli: simplify `mock-config` output

### DIFF
--- a/cli/copr_cli/build_config.py
+++ b/cli/copr_cli/build_config.py
@@ -41,7 +41,7 @@ config_opts['chroot_additional_packages'] = '
 {%- endif %}
 {%- if repos %}
 
-config_opts[config_opts['package_manager'] + '.conf'] += \"\"\"
+config_opts['dnf.conf'] += \"\"\"
 {%- for repo in repos %}
 
 [{{ repo.id }}]

--- a/cli/tests/test_mock_config.py
+++ b/cli/tests/test_mock_config.py
@@ -44,7 +44,7 @@ class TestMockConfig():
             additional=""
 
         return """
-config_opts[config_opts['package_manager'] + '.conf'] += \"\"\"
+config_opts['dnf.conf'] += \"\"\"
 
 [copr_base]
 name="Copr repository"


### PR DESCRIPTION
For Mock, config_opts['dnf.conf'] option is just an alias to the config_opts['yum.conf'] option.  Since 2020:
https://github.com/rpm-software-management/mock/commit/5d620ad326da0f656883f090c588bcfe36e92858