### PR TITLE
frontend: allow automation (cron) to remove builds

### DIFF
--- a/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_builds.py
+++ b/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_builds.py
@@ -208,7 +208,7 @@ class TestCoprDeleteBuild(CoprsTestCase):
             .format(self.u1.name, self.c1.name, self.b1.id),
             data={},
             follow_redirects=True)
-        assert b"not allowed to delete build" in r.data
+        assert b"doesn't have permissions to delete" in r.data
         b = (self.models.Build.query.filter(
             self.models.Build.id == self.b1.id)
             .first())


### PR DESCRIPTION
Previously we somewhat "faked" the user who is requesting build removals in the 'manage.py clean-old-builds' cron task.  That was faked to the "build.copr.user" which - for the group projects - might not be part of the group anymore and the pedantic check from a4e7a5aa467cad6132eb9d00170 stops us.

Newly, for automation task, we can use "automation_user=str()" argument that will effectively disable the user.can_build_in() check.

While on it, tweak the logging and error reporting a bit so there's is more obvious what is going on.

Fixes: #2523