### PR TITLE
build_aux: Add hack for unittesting in container

### DIFF
--- a/build_aux/Containerfile.unittest
+++ b/build_aux/Containerfile.unittest
@@ -1,0 +1,12 @@
+FROM fedora:37
+
+RUN dnf update -y && dnf install dnf-plugins-core -y && dnf install python-pytest-cov rpmdevtools python3-copr copr-cli -y
+
+RUN useradd copr_user
+USER copr_user
+WORKDIR /home/copr_user/copr
+COPY --chown=copr_user . /home/copr_user/copr
+
+USER root
+RUN dnf builddep *.spec -y
+USER copr_user

--- a/build_aux/per-subdir-makefile
+++ b/build_aux/per-subdir-makefile
@@ -12,3 +12,8 @@ unittests:
 
 lint:
 	vcs-diff-lint
+
+unittest-in-container:
+	podman build -f ../build_aux/Containerfile.unittest . -t copr_test_image
+	podman run --rm -it copr_test_image /bin/sh -c "./run_tests.sh -vv -s"
+	podman image rm copr_test_image


### PR DESCRIPTION
this is just my personal hack that I am using to unittest in containers. (bcs I don't want to install many packages in my system that I won't use)