### PR TITLE
use openEuler as the canonical name

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -195,6 +195,8 @@
     EPEL {{ os_version }}
   {% elif os_release == 'opensuse-leap' %}
     openSUSE Leap {{ os_version }}
+  {% elif os_release == 'openeuler' %}
+    openEuler {{ os_version }}
   {% elif os_release == 'opensuse' and os_version == 'tumbleweed' %}
     openSUSE Tumbleweed
   {% else %}


### PR DESCRIPTION
`openEuler` is our canonical name ：）