### PR TITLE
backend: run createrepo without --database

### DIFF
--- a/backend/copr_backend/constants.py
+++ b/backend/copr_backend/constants.py
@@ -1,5 +1,6 @@
 import os
 from logging import Formatter
+from typing import Dict, List
 
 mockchain = "/usr/bin/mockchain"
 # rsync path
@@ -43,3 +44,8 @@ build_log_format = Formatter(
     '[%(asctime)s][%(levelname)6s][PID:%(process)d] %(message)s')
 script_log_format = Formatter(
     "[%(asctime)s][%(thread)s][%(levelname)6s]: %(message)s")
+
+# dict of OS versions that are too old or the use sqlite repodata so they need --database
+# option with createrepo. This dict is in format "os_family": <list of versions>
+# e.g. "rhel": ["7", "6", "5"]
+CHROOTS_USING_SQLITE_REPODATA: Dict[str, List[str]] = {}

--- a/backend/run/copr-repo
+++ b/backend/run/copr-repo
@@ -21,13 +21,14 @@ import sys
 
 import filelock
 
+from copr_backend.constants import CHROOTS_USING_SQLITE_REPODATA
+from copr_backend.createrepo import BatchedCreaterepo
 from copr_backend.helpers import (
     BackendConfigReader,
     CommandException,
     run_cmd,
     get_redis_logger,
 )
-from copr_backend.createrepo import BatchedCreaterepo
 
 
 def printable_cmd(cmd):
@@ -127,8 +128,16 @@ def filter_existing(opts, subdirs):
     return new_subdirs
 
 
+def _database_option(chroot: str) -> str:
+    for os_family, old_versions in CHROOTS_USING_SQLITE_REPODATA.items():
+        if any(f"{os_family}-{old_version}" == chroot for old_version in old_versions):
+            return "--database"
+
+    return "--no-database"
+
+
 def run_createrepo(opts):
-    createrepo_cmd = ['/usr/bin/createrepo_c', opts.directory, '--database', '--ignore-lock',
+    createrepo_cmd = ['/usr/bin/createrepo_c', opts.directory, _database_option(opts.chroot), '--ignore-lock',
                       '--local-sqlite', '--cachedir', '/tmp/', '--workers', '8']
 
     if "epel-5" in opts.directory or "rhel-5" in opts.directory:


### PR DESCRIPTION
dnf and yum system don't need to create sqlite database since dnf and yum no longer utilize them.

Although there are some systems that still require --database option. Yum3 used sqlite data so system like RHEL <= 7 and EPEL <= 7 still require --database option.

for more detailed reasoning of the --database exception please refer to: https://github.com/fedora-copr/copr/issues/1171

Fixes #1171