### PR TITLE
rpmbuild: dist-git-client: add basic "clone" method

### DIFF
--- a/rpmbuild/etc/copr-distgit-client/default.ini
+++ b/rpmbuild/etc/copr-distgit-client/default.ini
@@ -52,6 +52,7 @@ clone_hostnames =
     src.fedoraproject.org
 lookaside_location = https://src.fedoraproject.org
 lookaside_uri_pattern = repo/pkgs/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}
+cloning_pattern = https://src.fedoraproject.org/rpms/{package}.git
 
 [centos]
 clone_hostnames = git.centos.org
@@ -61,19 +62,25 @@ specs = SPECS
 sources = SOURCES
 default_sum = SHA1
 lookaside_uri_pattern = sources/{name}/{refspec}/{hash}
+cloning_pattern = https://git.centos.org/rpms/{package}.git
 
 [fedora-copr]
 clone_hostnames = copr-dist-git.fedorainfracloud.org
 lookaside_location = https://copr-dist-git.fedorainfracloud.org
 lookaside_uri_pattern = repo/pkgs/{namespace[1]}/{namespace[0]}/{name}/{filename}/{hashtype}/{hash}/{filename}
+cloning_pattern_package_parts = owner_name project_name package_name
+cloning_pattern=https://copr-dist-git.fedorainfracloud.org/git/{package}
 
 [fedora-copr-dev]
 clone_hostnames = copr-dist-git-dev.fedorainfracloud.org
 lookaside_location = https://copr-dist-git-dev.fedorainfracloud.org
 lookaside_uri_pattern = repo/pkgs/{namespace[1]}/{namespace[0]}/{name}/{filename}/{hashtype}/{hash}/{filename}
+cloning_pattern_package_parts = owner_name project_name package_name
+cloning_pattern=https://copr-dist-git-dev.fedorainfracloud.org/git/{package}
 
 [centos-stream]
 clone_hostnames = gitlab.com
 path_prefixes = /redhat/centos-stream/rpms
 lookaside_location = https://sources.stream.centos.org
 lookaside_uri_pattern = sources/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}
+cloning_pattern = https://gitlab.com/redhat/centos-stream/rpms/{package}.git


### PR DESCRIPTION
This is useful to easily clone package "Foo" from DistGit "Bar", without the need to recall the clone_url from head.  This isn't used by automation now, even though it could be in the future.