### PR TITLE
dist-git: don't kill background workers for service restarts

### DIFF
--- a/dist-git/copr-dist-git.service
+++ b/dist-git/copr-dist-git.service
@@ -9,6 +9,8 @@ User=copr-dist-git
 Group=packager
 AmbientCapabilities=CAP_SETGID
 ExecStart=/usr/bin/copr-run-dispatcher imports
+KillMode=process
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I tried to 'systemctl restart copr-dist-git' on Fried, and this killed several background git processes and that broke the repositories.

Relates: https://pagure.io/fedora-infrastructure/issue/11174
Relates: https://pagure.io/fedora-infrastructure/issue/11176
Relates: #2571