### PR TITLE
rpmbuild: copr-distgit-client: don't be blocked by empty lines

### DIFF
--- a/rpmbuild/copr_distgit_client.py
+++ b/rpmbuild/copr_distgit_client.py
@@ -245,6 +245,10 @@ def sources(args, config):
             }
 
             source_spec = line.split()
+            if not source_spec:
+                # line full of white-spaces, skip
+                continue
+
             if len(source_spec) == 2:
                 # old md5/sha1 format: 0ced6f20b9fa1bea588005b5ad4b52c1  tar-1.26.tar.xz
                 kwargs["hashtype"] = distgit_config["default_sum"].lower()


### PR DESCRIPTION
Fixes: #2585