### PR TITLE
[WIP]Using args in openshift yaml to avoid tini to be overwritten

### DIFF
--- a/openshift/services/backend.yml.j2
+++ b/openshift/services/backend.yml.j2
@@ -119,7 +119,8 @@ spec:
         - name: log
           image: "{{ copr_backend_image }}"
           imagePullPolicy: IfNotPresent
-          command: ["/usr/bin/copr_run_logger.py"]
+          command: ["/usr/bin/tini", "--"]
+          args: ["/usr/bin/copr_run_logger.py"]
           volumeMounts:
             - name: config
               mountPath: /etc/copr
@@ -136,7 +137,8 @@ spec:
               mountPath: /var/lib/copr/public_html
             - name: locks
               mountPath: /var/lock/copr-backend
-          command: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher", "actions"]
+          command: ["/usr/bin/tini", "--"]
+          args: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher", "actions"]
 
         - name: builds
           image: "{{ copr_backend_image }}"
@@ -153,7 +155,8 @@ spec:
           env:
             - name: HOME
               value: /backend-home
-          command: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher", "builds"]
+          command: ["/usr/bin/tini", "--"]
+          args: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher", "builds"]
 
       # start these containers on the same node with copr-backend-httpd!
       affinity:

--- a/openshift/services/keygen.yml.j2
+++ b/openshift/services/keygen.yml.j2
@@ -68,7 +68,8 @@ spec:
         - name: signer
           image: "{{ copr_keygen_image }}"
           imagePullPolicy: IfNotPresent
-          command: ["/signd-entrypoint", "0.0.0.0/0"]
+          command: ["/usr/bin/tini", "--"]
+          args: ["/signd-entrypoint", "0.0.0.0/0"]
           volumeMounts:
             - name: storage
               mountPath: /var/lib/copr-keygen


### PR DESCRIPTION
For #2518 about openshift parts...
In the current docker subdir, i see distgit/keygen/backend using tini, so i change these deployments.
Mark it to WIP and if the changes work, I will remove WIP @praiskup.
The kubernetes subdir need to be some reworks, so i will sync code in another PR(already in progress).