### PR TITLE
rpmbuild, frontend: add loggs to python-backoff decorator

### DIFF
--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -116,7 +116,7 @@ BuildRequires: python3-whoosh
 BuildRequires: python3-wtforms >= 2.2.1
 BuildRequires: python3-ldap
 BuildRequires: python3-yaml
-BuildRequires: python3-backoff
+BuildRequires: python3-backoff >= 1.9.0
 BuildRequires: redis
 BuildRequires: modulemd-tools >= 0.6
 %endif
@@ -173,7 +173,7 @@ Requires: python3-templated-dictionary
 Requires: python3-wtforms >= 2.2.1
 Requires: python3-zmq
 Requires: python3-ldap
-Requires: python3-backoff
+Requires: python3-backoff >= 1.9.0
 Requires: xstatic-bootstrap-scss-common
 Requires: xstatic-datatables-common
 Requires: js-jquery-ui

--- a/frontend/coprs_frontend/coprs/logic/batches_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/batches_logic.py
@@ -18,7 +18,7 @@ import coprs.logic.builds_logic as bl
 log = app.logger
 
 
-@backoff.on_exception(backoff.expo, SQLAlchemyError, max_time=20)
+@backoff.on_exception(backoff.expo, SQLAlchemyError, max_time=20, logger=log)
 def _lock_table(table):
     # It seems that every database has different locking commands and we
     # don't care about anything else than PostgreSQL.

--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -47,7 +47,7 @@ BuildRequires: %{python_pfx}-munch
 BuildRequires: %{python}-requests
 BuildRequires: %{python_pfx}-jinja2
 BuildRequires: %{python_pfx}-simplejson
-BuildRequires: %{python}-backoff
+BuildRequires: python-backoff >= 1.9.0
 
 %if 0%{?fedora} || 0%{?rhel} > 7
 BuildRequires: argparse-manpage
@@ -66,7 +66,7 @@ Requires: %{python_pfx}-jinja2
 Requires: %{python_pfx}-munch
 Requires: %{python}-requests
 Requires: %{python_pfx}-simplejson
-Requires: %{python}-backoff
+Requires: python-backoff >= 1.9.0
 
 Requires: mock >= 2.0
 Requires: git

--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -272,7 +272,7 @@ def git_clone_url_basepath(clone_url):
 
 
 @backoff.on_exception(
-    wait_gen=backoff.expo, exception=RuntimeError, max_time=300, jitter=None
+    wait_gen=backoff.expo, exception=RuntimeError, max_time=300, jitter=None, logger=log
 )
 def git_clone(url, repo_path, scm_type="git"):
     """


### PR DESCRIPTION
Do not merge until https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-995ddb45a1 is pushed into stable

Fix #2470