### PR TITLE
frontend: for-DNF5 API rpmrepo route

### DIFF
--- a/frontend/coprs_frontend/coprs/__init__.py
+++ b/frontend/coprs_frontend/coprs/__init__.py
@@ -108,6 +108,7 @@ from coprs.views.apiv3_ns import (
     apiv3_general, apiv3_builds, apiv3_packages, apiv3_projects,
     apiv3_project_chroots, apiv3_modules, apiv3_build_chroots,
     apiv3_mock_chroots, apiv3_permissions, apiv3_webhooks, apiv3_monitor,
+    apiv3_rpmrepo,
 )
 
 from coprs.views import batches_ns

--- a/frontend/coprs_frontend/coprs/logic/coprs_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/coprs_logic.py
@@ -199,6 +199,9 @@ class CoprsLogic(object):
         Return a Copr object given by OWNERNAME (either '@groupname' or
         'username') and copr DIRNAME (e.g. 'copr-dev:pr:11').
         """
+
+        # Some of the calling methods (routes) strictly require us not to check
+        # if the dirname exists.
         coprname = CoprDirsLogic.copr_name_from_dirname(dirname)
         return cls.get_by_ownername_coprname(ownername, coprname)
 

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_rpmrepo.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_rpmrepo.py
@@ -1,0 +1,140 @@
+"""
+/api_3/rpmrepo routes
+"""
+
+import flask
+from coprs import app
+from coprs.logic.coprs_logic import (
+    CoprsLogic,
+    CoprDirsLogic,
+)
+
+from coprs.logic.complex_logic import (
+    ComplexLogic
+)
+
+from coprs.views.apiv3_ns import (
+    apiv3_ns,
+    GET,
+)
+
+from coprs import cache
+from coprs.logic.complex_logic import ReposLogic
+from coprs.logic.stat_logic import CounterStatLogic
+from coprs.helpers import (
+    generate_repo_id_and_name,
+    generate_repo_id_and_name_ext,
+    get_stat_name,
+    CounterStatType,
+)
+
+@cache.memoize(timeout=2*60)
+def get_project_rpmrepo_metadata(copr):
+    """
+    Get the copr-related JSON data with available
+    chroots/directories/external/etc.  This is parsed by DNF5 copr plugin.
+    We cache (memoize) this for several minutes because generating the data can
+    be relatively DB demanding (for rather larger dependency trees).
+    """
+
+    # pylint: disable=too-many-locals
+
+    repo_dl_stat = CounterStatLogic.get_copr_repo_dl_stat(copr)
+    repos_info = ReposLogic.repos_for_copr(copr, repo_dl_stat)
+
+    data = {
+        "results_url": "/".join([app.config["BACKEND_BASE_URL"], "results"]),
+    }
+
+    repos = data['repos'] = {}
+    chroots = {}  # TODO: data["chroots"] = {}
+    directories = data["directories"] = {}
+
+    for name_release, info in repos_info.items():
+        repo = repos[name_release] = {
+            "arch": {},
+        }
+        for arch in info["arch_list"]:
+            archspec = repo["arch"][arch] = {"opts": {}}
+            if arch in info["expirations"]:
+                archspec["delete_after_days"] = info["expirations"][arch]
+
+        for arch, multilib in info.get("arch_repos", {}).items():
+            repo["arch"][arch]["multilib"] = {
+                multilib: {
+                    "opts": {
+                        "cost": "1100",
+                    },
+                },
+            }
+
+    for copr_chroot in copr.enable_permissible_copr_chroots:
+        cc_data = chroots[copr_chroot.name] = {}
+        delete = copr_chroot.delete_after_days
+        if delete is not None:
+            cc_data["delete_after_days"] = delete
+
+    copr_dirs = CoprDirsLogic.get_all_with_latest_submitted_build(copr.id)
+    for dir_info in copr_dirs:
+        dir_data = directories[dir_info["copr_dir"].name] = {}
+        if dir_info["removal_candidate"]:
+            dir_data["delete_after_days"] = dir_info["remaining_days"]
+
+    delete = copr.delete_after_days
+    if delete is not None:
+        data["delete_after_days"] = delete
+
+    internal_deps, external_deps, _ = \
+            ComplexLogic.get_transitive_runtime_dependencies(copr)
+
+    dependencies = data["dependencies"] = []
+
+    dep_idx = 1
+    for dep in internal_deps:
+        repo_id, repo_name = generate_repo_id_and_name(
+            dep, dep.name, dep_idx=dep_idx,
+            dependent=copr)
+        dependencies.append({
+            "opts": {
+                "id": repo_id,
+                "name": repo_name,
+            },
+            "type": "copr",
+            "data": {
+                "owner": dep.owner_name,
+                "projectname": dep.name,
+            },
+        })
+        dep_idx += 1
+
+    for dep in external_deps:
+        repo_id, repo_name = generate_repo_id_and_name_ext(
+            copr, dep, dep_idx)
+        dependencies.append({
+            "opts": {
+                "id": repo_id,
+                "name": repo_name,
+            },
+            "type": "external_baseurl",
+            "data": {
+                "pattern": dep,
+            }
+        })
+
+
+    return flask.jsonify(data)
+
+@apiv3_ns.route("/rpmrepo/<ownername>/<dirname>/<name_release>/", methods=GET)
+def rpmrepo_route(ownername, dirname, name_release):
+    """
+    Wrap get_project_rpmrepo_metadata() JSON provider, and gather some
+    statistics.
+    """
+    copr = CoprsLogic.get_by_ownername_and_dirname(ownername, dirname)
+    name = get_stat_name(
+        CounterStatType.REPO_DL,
+        copr_dir=copr.main_dir,
+        name_release=name_release,
+    )
+    CounterStatLogic.incr(name=name, counter_type=CounterStatType.REPO_DL)
+    return get_project_rpmrepo_metadata(copr)

--- a/frontend/coprs_frontend/tests/coprs_test_case.py
+++ b/frontend/coprs_frontend/tests/coprs_test_case.py
@@ -810,6 +810,34 @@ def foo():
         with self.setup_user_session(self.u1):
             yield
 
+    @pytest.fixture
+    def f_custom_builds(self):
+        """ Custom builds are used in order not to break the default ones """
+        self.b5 = self.models.Build(
+            copr=self.c1, copr_dir=self.c1_dir,
+            user=self.u1, submitted_on=9,
+            result_dir="bar")
+        self.b6 = self.models.Build(
+            copr=self.c1, copr_dir=self.c1_dir,
+            user=self.u1, submitted_on=11)
+        self.b7 = self.models.Build(
+            copr=self.c1, copr_dir=self.c1_dir,
+            user=self.u1, submitted_on=10,
+            result_dir="bar")
+
+        # assign with chroots
+        for build in [self.b5, self.b6, self.b7]:
+            self.db.session.add(
+                self.models.BuildChroot(
+                    build=build,
+                    mock_chroot=self.mc1
+                )
+            )
+
+        self.db.session.add_all(
+            [self.b5, self.b6, self.b7])
+
+
     def _get_auth_string(self, login, token):
         userstring = "{}:{}".format(login, token).encode("utf-8")
         base64string_user = base64.b64encode(userstring)

--- a/frontend/coprs_frontend/tests/test_apiv3/test_rpmrepo.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_rpmrepo.py
@@ -1,0 +1,98 @@
+from datetime import datetime, timedelta
+import pytest
+from tests.coprs_test_case import (
+    CoprsTestCase,
+    TransactionDecorator,
+)
+
+
+U1_DATA = {'dependencies': [],
+ 'directories': {'foocopr': {}},
+ 'repos': {'epel-5': {'arch': {'i386': {'opts': {}},
+                               'x86_64': {'multilib': {'i386': {'opts': {'cost': '1100'}}},
+                                          'opts': {}}}},
+           'epel-6': {'arch': {'i386': {'opts': {}},
+                               'x86_64': {'multilib': {'i386': {'opts': {'cost': '1100'}}},
+                                          'opts': {}}}},
+           'epel-7': {'arch': {'x86_64': {'opts': {}}}},
+           'fedora-18': {'arch': {'x86_64': {'opts': {}}}},
+           'fedora-19': {'arch': {'i386': {'opts': {}},
+                                  'x86_64': {'multilib': {'i386': {'opts': {'cost': '1100'}}},
+                                             'opts': {}}}},
+           'fedora-20': {'arch': {'i386': {'opts': {}},
+                                  'x86_64': {'multilib': {'i386': {'opts': {'cost': '1100'}}},
+                                             'opts': {}}}},
+           'fedora-21': {'arch': {'i386': {'opts': {}},
+                                  'x86_64': {'multilib': {'i386': {'opts': {'cost': '1100'}}},
+                                             'opts': {}}}},
+           'fedora-22': {'arch': {'i386': {'opts': {}},
+                                  'x86_64': {'multilib': {'i386': {'opts': {'cost': '1100'}}},
+                                             'opts': {}}}},
+           'fedora-23': {'arch': {'i386': {'opts': {}},
+                                  'x86_64': {'multilib': {'i386': {'opts': {'cost': '1100'}}},
+                                             'opts': {}}}}},
+ 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results'}
+
+
+U2_DATA = {'delete_after_days': 179,
+ 'dependencies': [{'data': {'owner': 'user1', 'projectname': 'foocopr'},
+                   'opts': {'id': 'coprdep:localhost:user1:foocopr',
+                            'name': 'Copr localhost/user2/barcopr runtime '
+                                    'dependency #1 - user1/foocopr'},
+                   'type': 'copr'},
+                  {'data': {'pattern': 'https://url.to/external/repo'},
+                   'opts': {'id': 'coprdep:https_url_to_external_repo',
+                            'name': 'Copr localhost/user2/barcopr external '
+                                    'runtime dependency #2 - '
+                                    'https_url_to_external_repo'},
+                   'type': 'external_baseurl'}],
+ 'directories': {'barcopr': {}},
+ 'repos': {'fedora-18': {'arch': {'x86_64': {'delete_after_days': 9,
+                                             'opts': {}}}},
+           'fedora-rawhide': {'arch': {'i386': {'opts': {}}}}},
+ 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results'}
+
+
+DIRS = {'dependencies': [],
+ 'directories': {'test': {}, 'test:pr:1123': {'delete_after_days': 39}},
+ 'repos': {'fedora-17': {'arch': {'i386': {'opts': {}},
+                                  'x86_64': {'opts': {}}}}},
+ 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results'}
+
+
+class TestApiRPMRepo(CoprsTestCase):
+    @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
+    def test_apiv3_rpmrepo_external_deps(self):
+        # both 'foo' and 'foo:pr:11' give the same output.
+
+        self.c3.delete_after = datetime.now() + timedelta(days=180)
+        self.c3.copr_chroots[0].deleted = True
+        self.c3.copr_chroots[0].delete_after = \
+                datetime.now() + timedelta(days=10)
+        self.db.session.commit()
+
+        for dirname in [self.c3.name, self.c3.name + ':pr:11']:
+            repodata = self.tc.get(
+                "/api_3/rpmrepo/{0}/{1}/fedora-18/".format(
+                    self.u2.name, dirname))
+            assert repodata.json == U2_DATA
+
+    @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots",
+                             "f_mock_chroots_many", "f_custom_builds", "f_db")
+    def test_apiv3_rpmrepo_multilib(self):
+        self.c1.multilib = True
+        self.db.session.commit()
+        repodata = self.tc.get(
+            "/api_3/rpmrepo/{0}/{1}/fedora-24/".format(
+                self.u1.name, self.c1.name))
+        assert repodata.json == U1_DATA
+
+    @TransactionDecorator("u1")
+    @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
+    def test_apiv3_rpmrepo_dirs(self):
+        self.web_ui.new_project("test", ["fedora-17-i386", "fedora-17-x86_64"])
+        self.web_ui.create_distgit_package("test", "copr-cli")
+        self.api3.rebuild_package("test:pr:1123", "copr-cli")
+        for dirname in ['test', 'test:pr:11']:
+            repodata = self.tc.get(f"/api_3/rpmrepo/user1/{dirname}/fedora-18/")
+            assert repodata.json == DIRS

--- a/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
+++ b/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
@@ -733,36 +733,6 @@ class TestCoprDelete(CoprsTestCase):
 
 class TestCoprRepoGeneration(CoprsTestCase):
 
-    """
-    Requires f_mock_chroots
-    """
-    @pytest.fixture
-    def f_custom_builds(self):
-        """ Custom builds are used in order not to break the default ones """
-        self.b5 = self.models.Build(
-            copr=self.c1, copr_dir=self.c1_dir,
-            user=self.u1, submitted_on=9,
-            result_dir="bar")
-        self.b6 = self.models.Build(
-            copr=self.c1, copr_dir=self.c1_dir,
-            user=self.u1, submitted_on=11)
-        self.b7 = self.models.Build(
-            copr=self.c1, copr_dir=self.c1_dir,
-            user=self.u1, submitted_on=10,
-            result_dir="bar")
-
-        # assign with chroots
-        for build in [self.b5, self.b6, self.b7]:
-            self.db.session.add(
-                self.models.BuildChroot(
-                    build=build,
-                    mock_chroot=self.mc1
-                )
-            )
-
-        self.db.session.add_all(
-            [self.b5, self.b6, self.b7])
-
     @pytest.fixture
     def f_not_finished_builds(self):
         """ Custom builds are used in order not to break the default ones """


### PR DESCRIPTION
The new route provides all the necessary info needed to let the rest of the "repofile" creation task on DNF5 Copr plugin.  The route lists all the available CoprDirs, CoprChroots (even soon to be deleted) and dependencies.

The route contains seemingly useless parts like <dirname> and <name_release>.  These are only needed to keep the repo downloading statistics working with DNF5.