### PR TITLE
frontend: change footer links from Bugzilla to GitHub

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/project_info.html
+++ b/frontend/coprs_frontend/coprs/templates/project_info.html
@@ -3,8 +3,8 @@
   <ul>
     <li><a href="https://github.com/fedora-copr/copr">Project Homepage</a></li>
     <li><a href="https://docs.pagure.org/copr.copr/user_documentation.html">User Documentation</a></li>
-    <li><a href="https://bugzilla.redhat.com/enter_bug.cgi?product=Copr">Report a Bug</a></li>
-    <li><a href="https://bugzilla.redhat.com/buglist.cgi?bug_status=NEW&bug_status=ASSIGNED&bug_status=MODIFIED&bug_status=ON_QA&classification=Community&list_id=6150623&product=Copr&query_format=advanced">Known Issues</a></li>
+    <li><a href="https://github.com/fedora-copr/copr/issues/new">Report a Bug</a></li>
+    <li><a href="https://github.com/fedora-copr/copr/issues">Known Issues</a></li>
     <li><a href="https://docs.pagure.org/copr.copr/user_documentation.html#faq">FAQ</a></li>
   </ul>
 </dd>


### PR DESCRIPTION
We prefer GitHub issues and going to migrate all Bugzilla tickets soon.