### PR TITLE
frontend: test compat with flask-sqlalchemy 3+

### DIFF
--- a/frontend/coprs_frontend/config/copr_unit_test.conf
+++ b/frontend/coprs_frontend/config/copr_unit_test.conf
@@ -10,6 +10,8 @@ SERVER_NAME = "localhost.localdomain"
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '..', '..', '..'))
 LOCAL_TMP_DIR = os.path.join(PROJECT_ROOT, '_tmp', str(int(time.time())) )
 
+SQLALCHEMY_RECORD_QUERIES = True
+
 # print(LOCAL_TMP_DIR)
 
 #DATABASE = './tmp/copr.db' # when executing >1 test instances use different db

--- a/frontend/coprs_frontend/tests/test_commands/test_rawhide_to_release.py
+++ b/frontend/coprs_frontend/tests/test_commands/test_rawhide_to_release.py
@@ -13,7 +13,7 @@ from commands.branch_fedora import branch_fedora_function
 from commands.rawhide_to_release import rawhide_to_release_function
 from commands.create_chroot import create_chroot_function
 
-from coprs_frontend.tests.coprs_test_case import CoprsTestCase, new_app_context
+from coprs_frontend.tests.coprs_test_case import CoprsTestCase
 
 
 class TestRawhideToRelease(CoprsTestCase):
@@ -60,7 +60,6 @@ class TestBranchFedora(CoprsTestCase):
         actions = self.models.Action.query.all()
         return [ActionTypeEnum(a.action_type) for a in actions]
 
-    @new_app_context
     def test_branch_fedora(self, capsys):
         """ Test rawhide-to-release through branch-fedora command """
 

--- a/frontend/coprs_frontend/tests/test_exceptions.py
+++ b/frontend/coprs_frontend/tests/test_exceptions.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 from werkzeug.exceptions import GatewayTimeout
-from tests.coprs_test_case import CoprsTestCase, new_app_context
+from tests.coprs_test_case import CoprsTestCase
 from coprs import app
 from coprs.exceptions import (CoprHttpException,
                               InsufficientStorage,
@@ -54,7 +54,6 @@ class TestExceptionHandling(CoprsTestCase):
         data = json.loads(r1.data)
         assert "Only owners and admins may update their projects" in data["error"]
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs",
                              "f_mock_chroots", "f_builds", "f_db")
     def test_api_409(self):
@@ -63,7 +62,6 @@ class TestExceptionHandling(CoprsTestCase):
         data = json.loads(r1.data)
         assert "Cannot cancel build 1" in data["error"]
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs",
                              "f_mock_chroots", "f_builds", "f_db")
     def test_api_400(self):
@@ -74,7 +72,6 @@ class TestExceptionHandling(CoprsTestCase):
         data = json.loads(r1.data)
         assert "is owner of the 'user1/foocopr' project" in data["error"]
 
-    @new_app_context
     def test_api_504(self):
         def raise_exception():
             raise GatewayTimeout()
@@ -84,7 +81,6 @@ class TestExceptionHandling(CoprsTestCase):
         data = json.loads(r1.data)
         assert "The API request timeouted" in data["error"]
 
-    @new_app_context
     def test_api_500(self):
         def raise_exception():
             raise CoprHttpException("Whatever unspecified error")
@@ -94,7 +90,6 @@ class TestExceptionHandling(CoprsTestCase):
         data = json.loads(r1.data)
         assert "Whatever unspecified error" in data["error"]
 
-    @new_app_context
     def test_api_500_default_message(self):
         def raise_exception():
             raise CoprHttpException
@@ -104,7 +99,6 @@ class TestExceptionHandling(CoprsTestCase):
         data = json.loads(r1.data)
         assert "Generic copr exception" in data["error"]
 
-    @new_app_context
     def test_api_500_runtime_error(self):
         def raise_exception():
             raise RuntimeError("Whatever unspecified error")
@@ -115,7 +109,6 @@ class TestExceptionHandling(CoprsTestCase):
         assert ("Request wasn't successful, there is probably "
                 "a bug in the Copr code.") in data["error"]
 
-    @new_app_context
     def test_api_500_storage(self):
         def raise_exception():
             raise InsufficientStorage
@@ -125,7 +118,6 @@ class TestExceptionHandling(CoprsTestCase):
         data = json.loads(r1.data)
         assert "Not enough space left" in data["error"]
 
-    @new_app_context
     def test_api_500_in_progress(self):
         def raise_exception():
             raise ActionInProgressException("Hey! Action in progress", None)

--- a/frontend/coprs_frontend/tests/test_logic/test_batch_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_batch_logic.py
@@ -138,9 +138,8 @@ class TestBatchesLogic(CoprsTestCase):
 
     def test_batched_build_queue_sql_performance(self):
         more_bchs = 5
-        with app.app_context():
-            self._prepare_project_with_batches(more=more_bchs)
-            self._succeed_first_batch()
+        self._prepare_project_with_batches(more=more_bchs)
+        self._succeed_first_batch()
 
         with app.app_context():
             r = self.tc.get("/backend/pending-jobs/")
@@ -265,17 +264,16 @@ class TestBatchesLogic(CoprsTestCase):
         projects = ["aaa", "bbb", "ccc", "ddd", "eee", "fff"]
 
         t1 = time.time()
-        with app.app_context():
-            batches = 4
-            for projectname in projects:
-                self.web_ui.new_project(projectname,
-                                        ["fedora-rawhide-i386", "fedora-18-x86_64"])
-                self.web_ui.create_distgit_package(projectname, "testpkg")
+        batches = 4
+        for projectname in projects:
+            self.web_ui.new_project(projectname,
+                                    ["fedora-rawhide-i386", "fedora-18-x86_64"])
+            self.web_ui.create_distgit_package(projectname, "testpkg")
 
-                after_build = None
-                for _b in range(batches):
-                    after_build = self._add_one_large_batch(
-                        projectname, after_build=after_build)
+            after_build = None
+            for _b in range(batches):
+                after_build = self._add_one_large_batch(
+                    projectname, after_build=after_build)
 
         t2 = time.time()
         with app.app_context():

--- a/frontend/coprs_frontend/tests/test_logic/test_copr_dirs_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_copr_dirs_logic.py
@@ -9,14 +9,12 @@ from coprs import db, models
 from tests.coprs_test_case import (
     CoprsTestCase,
     TransactionDecorator,
-    new_app_context
 )
 from commands.delete_dirs import _delete_dirs_function
 
 
 class TestCoprDirsLogic(CoprsTestCase):
     @TransactionDecorator("u1")
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_mock_chroots", "f_users_api", "f_db")
     def test_coprdir_cleanup_no_removal(self):
         self.api3.new_project("test-pr-dirs", ["fedora-17-i386"])
@@ -31,7 +29,6 @@ class TestCoprDirsLogic(CoprsTestCase):
         assert models.CoprDir.query.count() == 4  # main + 3 PRs
 
     @TransactionDecorator("u1")
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_mock_chroots", "f_users_api", "f_db")
     def test_coprdir_cleanup_no_build(self):
         self.api3.new_project("test-pr-dirs", ["fedora-17-i386"])
@@ -51,7 +48,6 @@ class TestCoprDirsLogic(CoprsTestCase):
         assert json.loads(action.data) == ["user1/test-pr-dirs:pr:1"]
 
     @TransactionDecorator("u1")
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_mock_chroots", "f_users_api", "f_db")
     def test_coprdir_cleanup_old_pr(self):
         self.api3.new_project("test-pr-dirs", ["fedora-17-i386"])
@@ -71,7 +67,6 @@ class TestCoprDirsLogic(CoprsTestCase):
         assert json.loads(action.data) == ["user1/test-pr-dirs:pr:1"]
 
     @TransactionDecorator("u1")
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_mock_chroots", "f_users_api", "f_db")
     def test_coprdir_cleanup_one_prs(self):
         self.api3.new_project("test-pr-dirs", ["fedora-17-i386"])
@@ -98,7 +93,6 @@ class TestCoprDirsLogic(CoprsTestCase):
                                                     "user1/test-pr-dirs:pr:3"])
 
     @TransactionDecorator("u1")
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_mock_chroots", "f_users_api", "f_db")
     def test_coprdir_build_normal_then_pr(self):
         chroot = "fedora-17-i386"

--- a/frontend/coprs_frontend/tests/test_logic/test_modules_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_modules_logic.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 import modulemd_tools.yaml
 
-from tests.coprs_test_case import CoprsTestCase, new_app_context
+from tests.coprs_test_case import CoprsTestCase
 from coprs.logic.modules_logic import ModulesLogic, ModuleBuildFacade, ModulemdGenerator
 from coprs.logic.coprs_logic import CoprChrootsLogic
 from copr_common.enums import ActionTypeEnum, BackendResultEnum, ModuleStatusEnum, StatusEnum
@@ -166,7 +166,6 @@ class TestModuleBuildFacade(CoprsTestCase):
         assert builds[0].batch != builds[1].batch == builds[2].batch
         assert builds[1].batch.blocked_by == builds[0].batch
 
-    @new_app_context
     def test_platform_chroots(self, f_users, f_coprs, f_mock_chroots_many, f_builds, f_modules, f_db):
         flask.g.user = self.u1
         fedora_chroots = [chroot.name for chroot in self.c1.mock_chroots if chroot.name.startswith("fedora")]

--- a/frontend/coprs_frontend/tests/test_logic/test_outdated_chroots_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_outdated_chroots_logic.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import flask
 import pytest
 from copr_common.enums import ActionTypeEnum
-from tests.coprs_test_case import CoprsTestCase, new_app_context
+from tests.coprs_test_case import CoprsTestCase
 from coprs.logic.outdated_chroots_logic import OutdatedChrootsLogic
 from coprs.logic.coprs_logic import CoprChrootsLogic
 from coprs.logic.actions_logic import ActionsLogic
@@ -17,7 +17,6 @@ from commands.notify_outdated_chroots import notify_outdated_chroots_function
 
 class TestOutdatedChrootsLogic(CoprsTestCase):
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_delete_status_outdated(self):
         """
@@ -65,7 +64,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         assert chroot.delete_status == ChrootDeletionStatus("preserved")
         assert chroot.delete_status_str == "preserved"
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_delete_status_unclicked(self):
         """
@@ -91,7 +89,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         chroot.delete_after = None
         assert chroot.delete_status == ChrootDeletionStatus("deleted")
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_simple(self):
         # Make sure, that there are no unreviewed outdated chroots yet
@@ -107,7 +104,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         OutdatedChrootsLogic.make_review(self.u2)
         assert not OutdatedChrootsLogic.has_not_reviewed(self.u2)
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_groups", "f_group_copr", "f_db")
     def test_outdated_chroots_group(self):
         # Make sure that a user is a part of a group
@@ -137,7 +133,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         self.u2.openid_groups = {"fas_groups": [self.g1.fas_name]}
         assert OutdatedChrootsLogic.has_not_reviewed(self.u2)
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_flash_not_immediately(self):
         # Make sure, that there are no unreviewed outdated chroots yet
@@ -153,7 +148,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         self.c2.copr_chroots[0].delete_after = datetime.now() + timedelta(days=80)
         assert OutdatedChrootsLogic.has_not_reviewed(self.u2)
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_flash_not_expired(self):
         # A preservation period is gone and the chroot is scheduled to be
@@ -162,7 +156,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         self.c2.copr_chroots[0].delete_after = datetime.now() - timedelta(days=1)
         assert not OutdatedChrootsLogic.has_not_reviewed(self.u2)
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_review_only_after_some_time(self):
         # Make sure that `self.u2` hasn't reviewed anything yet
@@ -190,7 +183,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
             self.c3.copr_chroots[1],
         }
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_extend_or_expire(self):
         # Make sure that `self.u2` hasn't reviewed anything yet
@@ -218,7 +210,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         assert (self.c2.copr_chroots[0].delete_after.date()
                 == expected.date())
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_humanized(self):
         chroot = self.c2.copr_chroots[0]
@@ -235,7 +226,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         chroot.delete_after = datetime.now() + timedelta(minutes=30)
         assert chroot.delete_after_humanized == "less then an hour"
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_expired(self):
         chroot = self.c2.copr_chroots[0]
@@ -248,7 +238,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         chroot.delete_after = datetime.now() + timedelta(days=-35)
         assert chroot.delete_after_expired
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_builds",
                              "f_db")
     def test_expired_chroot_detection(self):
@@ -365,7 +354,6 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         assert len(ActionsLogic.get_many(ActionTypeEnum("delete")).all()) == 1
 
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_unclicked_repeat(self):
         """

--- a/frontend/coprs_frontend/tests/test_models.py
+++ b/frontend/coprs_frontend/tests/test_models.py
@@ -4,7 +4,7 @@ import pytest
 import coprs
 from copr_common.enums import StatusEnum
 from coprs.helpers import ChrootDeletionStatus
-from tests.coprs_test_case import CoprsTestCase, new_app_context
+from tests.coprs_test_case import CoprsTestCase
 
 
 class TestBuildModel(CoprsTestCase):
@@ -192,7 +192,6 @@ class TestBuildModel(CoprsTestCase):
 
 class TestCoprModel(CoprsTestCase):
 
-    @new_app_context
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_permissible_chroots(self):
         """

--- a/frontend/coprs_frontend/tests/test_views/test_backend_ns/test_backend_general.py
+++ b/frontend/coprs_frontend/tests/test_views/test_backend_ns/test_backend_general.py
@@ -6,7 +6,7 @@ import pytest
 from flask_sqlalchemy import get_debug_queries
 
 from copr_common.enums import BackendResultEnum, StatusEnum, DefaultActionPriorityEnum
-from tests.coprs_test_case import CoprsTestCase, new_app_context
+from tests.coprs_test_case import CoprsTestCase
 from coprs.logic.builds_logic import BuildsLogic
 from coprs import app
 
@@ -400,7 +400,6 @@ class TestWaitingActions(CoprsTestCase):
         r = self.tc.get("/backend/pending-action/", headers=self.auth_header)
         assert json.loads(r.data.decode("utf-8")) != None
 
-    @new_app_context
     def test_pending_actions_list(self, f_users, f_coprs, f_actions, f_db):
         r = self.tc.get("/backend/pending-actions/", headers=self.auth_header)
         actions = json.loads(r.data.decode("utf-8"))
@@ -417,7 +416,6 @@ class TestWaitingActions(CoprsTestCase):
         actions = json.loads(r.data.decode("utf-8"))
         assert len(actions) == 1
 
-    @new_app_context
     def test_get_action_succeeded(self, f_users, f_coprs, f_actions, f_db):
         r = self.tc.get("/backend/action/1/",
                         headers=self.auth_header)


### PR DESCRIPTION
Drop the @new_app_context, we are creating a new app context for each test-case, and "pushing" it to the stack.

Also, recording SQL queries is now not ON by default, therefore setting SQLALCHEMY_RECORD_QUERIES to True.

Fixes: #2606