### PR TITLE
dist-git: skip tests that python3-rpkg breaks

### DIFF
--- a/dist-git/tests/test_crazy_merging.py
+++ b/dist-git/tests/test_crazy_merging.py
@@ -189,6 +189,7 @@ class TestMerging(object):
     def setup_method(self, method):
         srpm_cache = {}
 
+    @skip("Remove the skip once python-rpkg is repared (correct version is 1.65)")
     def test_merged_everything(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches
@@ -208,6 +209,7 @@ class TestMerging(object):
         assert v3_hash != v1_hash
         assert v3_hash != v2_hash
 
+    @skip("Remove the skip once python-rpkg is repared (correct version is 1.65)")
     def test_diverge_middle_branches(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches


### PR DESCRIPTION
new release of python-rpkg 1.66-5 introduces new bugs that breaks our tests.