### PR TITLE
ci: avoid the ubiquitous github-code-scanning message

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -2,6 +2,7 @@
 name: Lint Python issues
 
 on:
+  push:
   pull_request:
     branches: [main]
 
@@ -31,15 +32,15 @@ jobs:
             rpmbuild
             selinux
 
-      - if: ${{ always() }}
-        name: Upload artifact with detected defects in SARIF format
+      - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v3
         with:
           name: VCS Diff Lint SARIF
           path: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
+        if: ${{ always() }}
 
-      - if: ${{ always() }}
-        name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
+      - name: Upload SARIF to GitHub using github/codeql-action/upload-sarif
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.VCS_Diff_Lint.outputs.sarif }}
+        if: ${{ always() }}


### PR DESCRIPTION
It looked like:

    You have successfully added a new vcs-diff-lint configuration
    .github/workflows/python-diff-lint.yml:python-lint-job. As part of
    the setup process, we have scanned this repository and found no
    existing alerts. In the future, you will see all code scanning
    alerts on the repository Security tab.

The reason was that GitHub assumed that every single pull-request actually *newly* enabled the vcs-diff-lint action.  When we define also the 'push' action, the assumption no longer applies (sorta GitHub bug, not sure).

Relates: https://github.com/fedora-copr/vcs-diff-lint-action/pull/16
Relates: redhat-plumbers-in-action/differential-shellcheck#215