### PR TITLE
Revert "rpmbuild: use 'git switch', not 'git checkout'"

### DIFF
--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -308,7 +308,7 @@ def git_clone_and_checkout(url, committish, repo_path, scm_type="git"):
             fetch_cmd = ['git', 'fetch', 'origin', '{0}:{0}'.format(committish)]
             run_cmd(fetch_cmd, cwd=repo_path)
 
-        checkout_cmd = ['git', 'switch', '--detach', committish]
+        checkout_cmd = ['git', 'checkout', committish]
         run_cmd(checkout_cmd, cwd=repo_path)
 
 

--- a/rpmbuild/tests/test_distgit.py
+++ b/rpmbuild/tests/test_distgit.py
@@ -139,6 +139,6 @@ def test_with_without_committish(run_cmd, committish):
     expected += [mock.call(['git', 'clone', 'clone_url', '/dir', '--depth',
                             '500', '--no-single-branch', '--recursive'])]
     if committish:
-        expected += [mock.call(['git', 'switch', '--detach', committish], cwd='/dir')]
+        expected += [mock.call(['git', 'checkout', committish], cwd='/dir')]
 
     assert expected == run_cmd.call_args_list


### PR DESCRIPTION
This causes other problems, see #2655.

This reverts commit 26ea0dfaafb8d49607e53cefc92e442258b5c836.