### PR TITLE
rpmbuild: use git checkout instead of switch but ignore files

### DIFF
--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -308,7 +308,9 @@ def git_clone_and_checkout(url, committish, repo_path, scm_type="git"):
             fetch_cmd = ['git', 'fetch', 'origin', '{0}:{0}'.format(committish)]
             run_cmd(fetch_cmd, cwd=repo_path)
 
-        checkout_cmd = ['git', 'switch', '--detach', committish]
+        # In case there are both a git branch and a file with the same name,
+        # git checkout fails. In order to ignore files, we can use --
+        checkout_cmd = ['git', 'checkout', committish, '--']
         run_cmd(checkout_cmd, cwd=repo_path)
 
 

--- a/rpmbuild/tests/test_distgit.py
+++ b/rpmbuild/tests/test_distgit.py
@@ -139,6 +139,6 @@ def test_with_without_committish(run_cmd, committish):
     expected += [mock.call(['git', 'clone', 'clone_url', '/dir', '--depth',
                             '500', '--no-single-branch', '--recursive'])]
     if committish:
-        expected += [mock.call(['git', 'switch', '--detach', committish], cwd='/dir')]
+        expected += [mock.call(['git', 'checkout', committish, '--'], cwd='/dir')]
 
     assert expected == run_cmd.call_args_list


### PR DESCRIPTION
Fix #2655
See #2566
See #2594
Close #2656