### PR TITLE
Show users how to reproduce builds locally

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -447,10 +447,10 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         """ start the RPM build on builder on background """
         command = "copr-rpmbuild --verbose --drop-resultdir"
         if self.job.chroot == "srpm-builds":
-            command += " --srpm --build-id {build_id} --detached"
+            command += " --srpm --task-url {task_url} --detached"
         else:
-            command += " --build-id {build_id} --chroot {chroot} --detached"
-        command = command.format(build_id=self.job.build_id,
+            command += " --task-url {task_url} --chroot {chroot} --detached"
+        command = command.format(task_url=self.job.task_url,
                                  chroot=self.job.chroot)
 
         self.log.info("Starting remote build: %s", command)

--- a/backend/copr_backend/job.py
+++ b/backend/copr_backend/job.py
@@ -1,6 +1,7 @@
 import copy
 import os
 
+from urllib.parse import urljoin
 from copr_backend.exceptions import CoprBackendSrpmError
 from copr_backend.helpers import build_target_dir
 
@@ -28,6 +29,7 @@ class BuildJob(object):
         """
 
         self.timeout = worker_opts.timeout
+        self.frontend_base_url = worker_opts.frontend_base_url
         self.memory_reqs = None
         self.enable_net = True
 
@@ -214,3 +216,14 @@ class BuildJob(object):
         if self.ended_on is None or self.started_on is None:
             return None
         return self.ended_on - self.started_on
+
+    @property
+    def task_url(self):
+        """
+        URL where a builder can downloading the JSON definition for this task
+        """
+        base = "/backend/get-build-task/"
+        if self.chroot == "srpm-builds":
+            base = "/backend/get-srpm-build-task/"
+        path = urljoin(base, self.task_id)
+        return urljoin(self.frontend_base_url, path)

--- a/backend/tests/test_background_worker_build.py
+++ b/backend/tests/test_background_worker_build.py
@@ -171,7 +171,8 @@ def f_build_srpm(f_build_something):
     config = f_build_something
     config.fe_client.return_value.get.return_value = _get_srpm_job()
     config.ssh.set_command(
-        "copr-rpmbuild --verbose --drop-resultdir --srpm --build-id 855954 "
+        "copr-rpmbuild --verbose --drop-resultdir --srpm --task-url "
+        "http://copr-fe/backend/get-srpm-build-task/855954 "
         "--detached",
         0, "666", "",
     )
@@ -213,7 +214,8 @@ def f_build_rpm_case(f_build_rpm_case_no_repodata):
     _create_repodata(chroot)
 
     config.ssh.set_command(
-        "copr-rpmbuild --verbose --drop-resultdir --build-id 848963 "
+        "copr-rpmbuild --verbose --drop-resultdir --task-url "
+        "http://copr-fe/backend/get-build-task/848963-fedora-30-x86_64 "
         "--chroot fedora-30-x86_64 --detached",
         0, "666", "",
     )
@@ -815,7 +817,8 @@ def test_tail_f_nonzero_exit(_parse_results, f_build_rpm_case, caplog):
 def test_wrong_copr_rpmbuild_daemon_output(f_build_srpm, caplog):
     config = f_build_srpm
     config.ssh.set_command(
-        "copr-rpmbuild --verbose --drop-resultdir --srpm --build-id 855954 "
+        "copr-rpmbuild --verbose --drop-resultdir --srpm --task-url "
+        "http://copr-fe/backend/get-srpm-build-task/855954 "
         "--detached",
         0, "6a66", "",
     )
@@ -834,7 +837,8 @@ def test_wrong_copr_rpmbuild_daemon_output(f_build_srpm, caplog):
 def test_unable_to_start_builder(f_build_srpm, caplog):
     config = f_build_srpm
     config.ssh.set_command(
-        "copr-rpmbuild --verbose --drop-resultdir --srpm --build-id 855954 "
+        "copr-rpmbuild --verbose --drop-resultdir --srpm --task-url "
+        "http://copr-fe/backend/get-srpm-build-task/855954 "
         "--detached",
         10, "stdout\n", "stderr\n",
     )
@@ -889,3 +893,10 @@ def test_buildjob_tags(f_build_rpm_case):
     worker = config.bw
     worker.job = _get_rpm_job_object(worker.opts)
     assert worker.job.tags == ['arch_x86_64', 'test_tag']
+
+def test_task_url(f_build_rpm_case):
+    config = f_build_rpm_case
+    worker = config.bw
+    worker.job = _get_rpm_job_object(worker.opts)
+    assert worker.job.task_url == \
+        "http://copr-fe/backend/get-build-task/848963-fedora-30-x86_64"

--- a/rpmbuild/main.py
+++ b/rpmbuild/main.py
@@ -113,7 +113,10 @@ def main():
     with open(config.get("main", "logger_pidfile"), "w") as pidfile:
         pidfile.write(str(logging_pid))
 
-    log.info('Running: {0}'.format(" ".join(map(shlex.quote, sys.argv))))
+    cmd = " ".join(map(shlex.quote, sys.argv))
+    log.info('\nYou can reproduce this build on your computer by running:\n')
+    log.info('  sudo dnf install copr-rpmbuild')
+    log.info('  {0}\n\n'.format(cmd.replace(" --detached", "")))
     log.info('Version: {0}'.format(VERSION))
     log.info("PID: %s", main_pid)
     log.info("Logging PID: %s", logging_pid)


### PR DESCRIPTION
This will generate something like

```
You can reproduce this build on your computer by running:

  dnf install copr-rpmbuild
  /usr/bin/copr-rpmbuild --srpm --task-url https://copr.stg.fedoraproject.org/backend/get-srpm-build-task/2913535
```

at the beginning of the builder-live.log