### PR TITLE
Derive all message classes from _CoprMessage

### DIFF
--- a/messaging/copr_messaging/schema.py
+++ b/messaging/copr_messaging/schema.py
@@ -21,9 +21,8 @@ This file contains schemas for messages sent by Copr project.
 import copy
 
 from copr_common.enums import StatusEnum
-from fedora_messaging import message
 
-from .private.hierarchy import _BuildChrootMessage
+from .private.hierarchy import _BuildChrootMessage, _CoprMessage
 from .private.schema_old import _PreFMBuildMessage
 from .private import schema_stomp_old
 
@@ -95,7 +94,7 @@ class BuildChrootStartedV1Stomp(schema_stomp_old._OldStompChrootMessage,
     })
 
 
-class BuildChrootStartedV1StompDontUse(message.Message):
+class BuildChrootStartedV1StompDontUse(_CoprMessage):
     topic = 'chroot.start'
 
     body_schema = {

--- a/messaging/copr_messaging/tests/test_schema.py
+++ b/messaging/copr_messaging/tests/test_schema.py
@@ -21,6 +21,7 @@
 import copy
 import unittest
 
+import fedora_messaging.message
 from jsonschema import ValidationError
 from .. import schema
 
@@ -297,3 +298,19 @@ class CoprMessageBaseClassTest(unittest.TestCase):
 
     def test_app_name(self):
         assert self.message.app_name == "Copr"
+
+    def test_all_classes_derived_from_base(self):
+        underived_classes = []
+        for name, obj in vars(schema).items():
+            if isinstance(obj, type) and issubclass(
+                obj, fedora_messaging.message.Message
+            ):
+                if not issubclass(obj, schema._CoprMessage):
+                    underived_classes.append(name)
+
+        self.assertListEqual(
+            underived_classes, [], msg=(
+                "Message classes must be derived from _CoprMessage:"
+                ", ".join(underived_classes)
+            )
+        )


### PR DESCRIPTION
Previously, `BuildChrootStartedV1StompDontUse` didn’t and thus failed to set `app_name`, which made FMN fall back to the toplevel namespace of the message topic (lowercase `copr`), which in turn caused it to use both variations both in the user interface and when filtering messages (which warrants a fix of its own, see fedora-infra/fmn#854).