### PR TITLE
Fix outdated deps

### DIFF
--- a/backend/docs/requirements.txt
+++ b/backend/docs/requirements.txt
@@ -6,7 +6,7 @@ redis
 mock
 requests
 python-daemon
-bunch
+munch
 lockfile
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ PyYAML
 redis
 retask
 python-daemon
-bunch
+munch
 # documentation
 sphinx
 sphinx-argparse

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -9,7 +9,7 @@ blinker
 pytz
 markdown
 pyLibravatar
-pydns # pyLibravatar uses this
+py3dns # pyLibravatar uses this
 python-dateutil
 netaddr
 alembic


### PR DESCRIPTION
Some of `requirements.txt` files listed dependencies which haven’t been maintained in a while, replace by what Copr actually uses.