### PR TITLE
Fix our dist-git CI

### DIFF
--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -19,7 +19,7 @@ BuildRequires: systemd
 BuildRequires: python3-devel
 BuildRequires: python3-munch
 BuildRequires: python3-requests
-BuildRequires: python3-rpkg
+BuildRequires: python3-rpkg >= 1.66-6
 BuildRequires: python3-pytest
 BuildRequires: python3-copr-common >= %copr_common_version
 BuildRequires: python3-oslo-concurrency
@@ -34,7 +34,7 @@ Requires: /usr/bin/crudini
 Requires: dist-git
 Requires: python3-copr-common >= %copr_common_version
 Requires: python3-requests
-Requires: python3-rpkg >= 1.63-5
+Requires: python3-rpkg >= 1.66-6
 Requires: python3-munch
 Requires: python3-oslo-concurrency
 Requires: python3-setproctitle

--- a/dist-git/copr_dist_git/package_import.py
+++ b/dist-git/copr_dist_git/package_import.py
@@ -158,7 +158,8 @@ def _load_commands(opts, repo_name, repo_dir):
                         anongiturl="",
                         branchre="",
                         kojiprofile="",
-                        build_client="")
+                        build_client="",
+                        allow_pre_generated_srpm=True)
 
     # rpkg gets module_name as a basename of git url
     # we use module_name as "username/projectname/package_name"

--- a/dist-git/tests/test_crazy_merging.py
+++ b/dist-git/tests/test_crazy_merging.py
@@ -6,7 +6,6 @@ import pytest
 import shutil
 import time
 import os
-import logging
 
 from munch import Munch
 from subprocess import check_output
@@ -230,7 +229,6 @@ class TestMerging(object):
         assert v3_hash_a != v1_hash
         assert v3_hash_b != v1_hash
 
-    @pytest.mark.skip(reason="Remove the skip once python-rpkg resolves issue #677")
     def test_no_op_1(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches

--- a/dist-git/tests/test_crazy_merging.py
+++ b/dist-git/tests/test_crazy_merging.py
@@ -189,7 +189,6 @@ class TestMerging(object):
     def setup_method(self, method):
         srpm_cache = {}
 
-    @pytest.mark.skip(reason="Remove the skip once python-rpkg is repared (correct version is 1.65)")
     def test_merged_everything(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches
@@ -209,7 +208,6 @@ class TestMerging(object):
         assert v3_hash != v1_hash
         assert v3_hash != v2_hash
 
-    @pytest.mark.skip(reason="Remove the skip once python-rpkg is repared (correct version is 1.65)")
     def test_diverge_middle_branches(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches


### PR DESCRIPTION
this PR is an attempt to shut down our CI problems with pyrpkg

`dist-git: refresh pyrpkg.Commands after import_srpm` commit - WDYT? this shouldn't be a problem for us from the efficiency side

- [x] wait until [rpkg updates](https://bodhi.fedoraproject.org/updates/?packages=rpkg) will be in stable

after merging this, don't forget to merge https://pagure.io/fedora-infra/ansible/pull-request/1386

Fixes #2608 
Fixes #2317 