### PR TITLE
frontend: accept the OpenID response as a POST request

### DIFF
--- a/frontend/coprs_frontend/coprs/views/misc.py
+++ b/frontend/coprs_frontend/coprs/views/misc.py
@@ -77,7 +77,7 @@ def workaround_ipsilon_email_login_bug_handler(f):
     return _the_handler
 
 
-@misc.route("/login/", methods=["GET"])
+@misc.route("/login/", methods=["GET", "POST"])
 @workaround_ipsilon_email_login_bug_handler
 @oid.loginhandler
 def oid_login():


### PR DESCRIPTION
Seems like something changed in the Fedora OpenID service, and that the second /login/ route request coming from the service to us is newly done as POST (not GET).

Closes: #2696