### PR TITLE
doc: fix typo, the backend data label is named copr-repo

### DIFF
--- a/doc/raid_on_backend.rst
+++ b/doc/raid_on_backend.rst
@@ -40,7 +40,7 @@ Attaching volume
 2. start raid and volume group ``mdadm --assemble --scan``.  In case the
    ``--assemble --scan`` doesn't reconstruct the array, it is OK to add the
    volumes manually ``mdadm /dev/md127 --add /dev/nvme2n1p1``.
-3. mount the ``/dev/disk/by-label/copr-data`` volume
+3. mount the ``/dev/disk/by-label/copr-repo`` volume
 
 There's a `ansible configuration`_ for this, and `list of volumes`_.
 


### PR DESCRIPTION
On both STG and production, the label is named `copr-repo` not `copr-data`:

    [root@copr-be-dev ~][STG]# ls /dev/disk/by-label/copr*
    /dev/disk/by-label/copr-repo

    [root@copr-be ~][PROD]# ls /dev/disk/by-label/copr*
    /dev/disk/by-label/copr-repo