### PR TITLE
get info about build from SRPM's spec file

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -56,6 +56,7 @@ BuildRequires: python3-retask
 BuildRequires: python3-setproctitle
 BuildRequires: python3-sphinx
 BuildRequires: python3-tabulate
+BuildRequires: python3-specfile
 BuildRequires: modulemd-tools >= 0.6
 BuildRequires: prunerepo >= %prunerepo_version
 BuildRequires: dnf
@@ -94,6 +95,7 @@ Requires:   python3-retask
 Requires:   python3-setproctitle
 Requires:   python3-tabulate
 Requires:   python3-boto3
+Requires:   python3-specfile
 Requires:   redis
 Requires:   rpm-sign
 Requires:   rsync

--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -24,7 +24,7 @@ from copr_backend.exceptions import (
     FrontendClientException,
 )
 from copr_backend.helpers import (
-    call_copr_repo, pkg_name_evr, run_cmd, register_build_result,
+    call_copr_repo, pkg_name_evr, run_cmd, register_build_result, find_spec_file,
 )
 from copr_backend.job import BuildJob
 from copr_backend.msgbus import MessageSender
@@ -637,8 +637,10 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         srpm_file = glob.glob(pattern)[0]
         srpm_name = os.path.basename(srpm_file)
         srpm_url = os.path.join(job.results_dir_url, srpm_name)
+        spec_file_path = find_spec_file(job.results_dir, self.log)
+
         build_details['pkg_name'], build_details['pkg_version'] = \
-                pkg_name_evr(srpm_file, self.log)
+                pkg_name_evr(spec_file_path, srpm_file, self.log)
         build_details['srpm_url'] = srpm_url
         self.log.info("SRPM URL: %s", srpm_url)
         return build_details

--- a/backend/tests/test_background_worker_build.py
+++ b/backend/tests/test_background_worker_build.py
@@ -310,6 +310,7 @@ def test_prev_build_backup(f_build_rpm_case):
     rsync_patt = "*{}.rsync.log".format(worker.job.build_id)
     assert len(glob.glob(os.path.join(prev_results, rsync_patt))) == 1
 
+
 def test_full_srpm_build(f_build_srpm):
     worker = f_build_srpm.bw
     worker.process()
@@ -317,11 +318,27 @@ def test_full_srpm_build(f_build_srpm):
 
     # TODO: fix this is ugly pkg_version testament
     assert worker.job.pkg_version is None
-    assert worker.job.__dict__["pkg_version"] == "1.0.14-1.fc30"
+    assert worker.job.__dict__["pkg_version"] == "1.0.14-1"
 
     assert worker.job.srpm_url == (
         "https://example.com/results/@copr/PROJECT_2/srpm-builds/"
         "00855954/example-1.0.14-1.fc30.src.rpm")
+
+
+@mock.patch("copr_backend.background_worker_build.find_spec_file")
+def test_full_srpm_build_without_specfile(mock_find_spec_file, f_build_srpm):
+    mock_find_spec_file.return_value = None
+
+    worker = f_build_srpm.bw
+    worker.process()
+
+    assert worker.job.pkg_name == "example"
+    assert worker.job.pkg_version is None
+    assert worker.job.__dict__["pkg_version"] == "1.0.14-1.fc30"
+    assert worker.job.srpm_url == (
+            "https://example.com/results/@copr/PROJECT_2/srpm-builds/"
+            "00855954/example-1.0.14-1.fc30.src.rpm")
+
 
 @mock.patch("copr_backend.sign.SIGN_BINARY", "tests/fake-bin-sign")
 @mock.patch("copr_backend.sign._sign_one")

--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -18,7 +18,6 @@ import munch
 from six.moves.urllib.parse import urlparse
 from copr_common.enums import BuildSourceEnum
 
-
 log = logging.getLogger("__main__")
 
 CONF_DIRS = [os.getcwd(), "/etc/copr-rpmbuild"]

--- a/rpmbuild/main.py
+++ b/rpmbuild/main.py
@@ -3,6 +3,7 @@
 import re
 import os
 import fcntl
+import subprocess
 import sys
 import argparse
 import json
@@ -22,7 +23,7 @@ from copr_rpmbuild import providers
 from copr_rpmbuild.builders.mock import MockBuilder
 from copr_rpmbuild.automation import run_automation_tools
 from copr_rpmbuild.helpers import read_config, \
-     parse_copr_name, dump_live_log, copr_chroot_to_task_id, macros_for_task
+    parse_copr_name, dump_live_log, copr_chroot_to_task_id, macros_for_task, locate_srpm
 from six.moves.urllib.parse import urlparse, urljoin, urlencode
 
 log = logging.getLogger(__name__)
@@ -224,6 +225,9 @@ def build_srpm(args, config):
     resultdir = config.get("main", "resultdir")
     log.info("Output: {0}".format(
         os.listdir(resultdir)))
+
+    # extract spec file from SRPM
+    subprocess.run(f"rpm2archive -n < {locate_srpm(resultdir)} | tar xf - '*.spec'", shell=True, check=False)
 
     with open(os.path.join(resultdir, 'success'), "w") as success:
         success.write("done")


### PR DESCRIPTION
I am wondering whether we want to use information from spec file to name the SRPM? This means that SRPM name would be `example-1.0.14-1.src.rpm` instead of `example-1.0.14-1.fc37.src.rpm`

Fixes #1701 