### PR TITLE
fix: common build failed in openEuler

### DIFF
--- a/common/python-copr-common.spec
+++ b/common/python-copr-common.spec
@@ -5,12 +5,12 @@
 %global _pkgdocdir %{_docdir}/%{name}-%{version}
 %endif
 
-%if 0%{?fedora} || 0%{?rhel} > 7
+%if 0%{?fedora} || 0%{?rhel} > 7 || 0%{?openEuler}
 %global with_python3 1
 %global __python %_bindir/python3
 %endif
 
-%if 0%{?fedora} < 28 || 0%{?rhel} && 0%{?rhel} <= 7
+%if 0%{?fedora} && 0%{?fedora} < 28 || 0%{?rhel} && 0%{?rhel} <= 7
 %global with_python2 1
 %global __python %_bindir/python2
 %endif


### PR DESCRIPTION
ADD build supported in openEuler env, as openEuler use python3 as default