### PR TITLE
beaker-tests-sanity: don't test armhfp builds anymore

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
@@ -483,10 +483,6 @@ rlJournalStart
 
         # delete - wrong project name
         rlRun "copr-cli delete ${NAME_PREFIX}wrong-name" 1
-
-        # test building for armhfp
-        rlRun "copr-cli create --chroot fedora-36-armhfp ${NAME_PREFIX}ArmhfpBuild"
-        rlRun "copr-cli build ${NAME_PREFIX}ArmhfpBuild $HELLO"
     rlPhaseEnd
 
     rlPhaseStartCleanup
@@ -513,7 +509,6 @@ rlJournalStart
         cleanProject "${NAME_PREFIX}MockConfigParent"
         cleanProject "${NAME_PREFIX}TestBug1444804"
         cleanProject "${NAME_PREFIX}CoprDirTest"
-        cleanProject "${NAME_PREFIX}ArmhfpBuild"
 
         # and make sure we haven't left any mess
         rlRun "copr-cli list | grep $NAME_PREFIX" 1


### PR DESCRIPTION
The build fails with:

    Out of memory allocating 671088640 bytes!
    qemu: uncaught target signal 6 (Aborted) - core dumped

Already reported here:
https://bugzilla.redhat.com/show_bug.cgi?id=2152259

The bug likely won't be fixed since F36 is now EOL, and at the same time armhfp support ended with F36.