### PR TITLE
beaker-tests-sanity: don't test project searching pt.2

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
@@ -358,13 +358,13 @@ rlJournalStart
         # See https://github.com/fedora-copr/copr/pull/2578
 
         # # test search index update by copr insertion
-        # rlRun "copr-cli create --chroot $CHROOT --chroot fedora-rawhide-x86_64 ${NAME_PREFIX}Project8"
+        rlRun "copr-cli create --chroot $CHROOT --chroot fedora-rawhide-x86_64 ${NAME_PREFIX}Project8"
         # rlRun "curl $FRONTEND_URL/coprs/fulltext/?fulltext=${NAME_VAR}Project8 --silent | grep -E \"href=.*${NAME_VAR}Project8.*\"" 1 # search results _not_ returned
         # rlRun "curl -X POST $FRONTEND_URL/coprs/update_search_index/"
         # rlRun "curl $FRONTEND_URL/coprs/fulltext/?fulltext=${NAME_VAR}Project8 --silent | grep -E \"href=.*${NAME_VAR}Project8.*\"" 0 # search results returned
 
         # # test search index update by package addition
-        # rlRun "copr-cli create --chroot $CHROOT --chroot fedora-rawhide-x86_64 ${NAME_PREFIX}Project9" && sleep 65
+        rlRun "copr-cli create --chroot $CHROOT --chroot fedora-rawhide-x86_64 ${NAME_PREFIX}Project9" && sleep 65
         # rlRun "curl -X POST $FRONTEND_URL/coprs/update_search_index/"
         # rlRun "curl $FRONTEND_URL/coprs/fulltext/?fulltext=${NAME_VAR}Project9 --silent | grep -E \"href=.*${NAME_VAR}Project9.*\"" 1 # search results _not_ returned
         # rlRun "copr-cli add-package-scm ${NAME_PREFIX}Project9 --name test_package_scm --clone-url $COPR_HELLO_GIT --commit rpkg-util" # insert package to the copr


### PR DESCRIPTION
See PR #2731

I made a mistake and forgot to comment the following code as well:

    cleanProject "${NAME_PREFIX}Project8"
    cleanProject "${NAME_PREFIX}Project9"

Now the project deletion fails because the projects are not being created in the first place. This PR fixes it. Alternatively I could comment the project deletion but then we will surely forget to uncoment them in the future because they are too far from the project search tests.