### PR TITLE
dist-git: use `skip` for skipping tests from pytest

### DIFF
--- a/dist-git/tests/test_crazy_merging.py
+++ b/dist-git/tests/test_crazy_merging.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 import tempfile
-from unittest import mock, skip
+from unittest import mock
 import pytest
 import shutil
 import time
@@ -189,7 +189,7 @@ class TestMerging(object):
     def setup_method(self, method):
         srpm_cache = {}
 
-    @skip("Remove the skip once python-rpkg is repared (correct version is 1.65)")
+    @pytest.mark.skip(reason="Remove the skip once python-rpkg is repared (correct version is 1.65)")
     def test_merged_everything(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches
@@ -209,7 +209,7 @@ class TestMerging(object):
         assert v3_hash != v1_hash
         assert v3_hash != v2_hash
 
-    @skip("Remove the skip once python-rpkg is repared (correct version is 1.65)")
+    @pytest.mark.skip(reason="Remove the skip once python-rpkg is repared (correct version is 1.65)")
     def test_diverge_middle_branches(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches
@@ -232,7 +232,7 @@ class TestMerging(object):
         assert v3_hash_a != v1_hash
         assert v3_hash_b != v1_hash
 
-    @skip("Remove the skip once python-rpkg resolves issue #677")
+    @pytest.mark.skip(reason="Remove the skip once python-rpkg resolves issue #677")
     def test_no_op_1(self, initial_commit_everywhere, mc_setup_git_repo):
         branches, opts, v1_hash = initial_commit_everywhere
         origin, all_branches, middle_branches, border_branches = branches


### PR DESCRIPTION
with newer version of pytest, the `skip` method from unittest stops working well with pytest