### PR TITLE
build_aux: don't recreate testing image every time new test is launched

### DIFF
--- a/build_aux/Containerfile.unittest
+++ b/build_aux/Containerfile.unittest
@@ -1,6 +1,6 @@
 FROM fedora:37
 
-RUN dnf update -y && dnf install dnf-plugins-core -y && dnf install python-pytest-cov rpmdevtools python3-copr copr-cli -y
+RUN dnf update -y && dnf install python-pytest-cov copr-dist-git rpmdevtools python3-copr copr-cli dnf-plugins-core -y
 
 RUN useradd copr_user
 USER copr_user
@@ -10,3 +10,6 @@ COPY --chown=copr_user . /home/copr_user/copr
 USER root
 RUN dnf builddep *.spec -y
 USER copr_user
+
+# bind the code from local machine here
+WORKDIR /home/copr_user/copr_bind

--- a/build_aux/per-subdir-makefile
+++ b/build_aux/per-subdir-makefile
@@ -1,3 +1,6 @@
+COPR_TEST_IMAGE ?= copr_test_image
+CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
+
 .PHONY: check test lint unittests
 
 # we keep this serialized to avoid messed standard output
@@ -13,7 +16,12 @@ unittests:
 lint:
 	vcs-diff-lint
 
+build-test-image:
+	$(CONTAINER_ENGINE) build -f ../build_aux/Containerfile.unittest . -t $(COPR_TEST_IMAGE)
+
+enter-test-image:
+	$(CONTAINER_ENGINE) run -v .:/home/copr_user/copr_bind:Z -ti $(COPR_TEST_IMAGE) /bin/bash
+
 unittest-in-container:
-	podman build -f ../build_aux/Containerfile.unittest . -t copr_test_image
-	podman run --rm -it copr_test_image /bin/sh -c "./run_tests.sh -vv -s"
-	podman image rm copr_test_image
+	$(CONTAINER_ENGINE) run --rm -v .:/home/copr_user/copr_bind:Z \
+		-it $(COPR_TEST_IMAGE) /bin/sh -c "./run_tests.sh -vvv -s --no-coverage"


### PR DESCRIPTION
update of make targets I use for unit testing in containers