### PR TITLE
dist-git:add supported openeuler

### DIFF
--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -30,7 +30,7 @@ Recommends: logrotate
 Requires: systemd
 Requires: httpd
 Requires: coreutils
-Requires: crudini
+Requires: /usr/bin/crudini
 Requires: dist-git
 Requires: python3-copr-common >= %copr_common_version
 Requires: python3-requests


### PR DESCRIPTION
In openEuler, the crudini also provides `/usr/bin/crudini` but the package name is `python3-crudini`, this PR make the spec portable in fedora&rhel&openEuler :)