### PR TITLE
rpmbuild: supported in openeuler

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -1,16 +1,9 @@
-%if 0%{?fedora} || 0%{?rhel} > 7
 %global __python        %__python3
 %global python          python3
 %global python_pfx      python3
 %global rpm_python      python3-rpm
 %global sitelib         %python3_sitelib
-%else
-%global __python        %__python2
-%global python          python2
-%global python_pfx      python
-%global rpm_python      rpm-python
-%global sitelib         %python_sitelib
-%endif
+
 %global copr_common_version 0.12.1.dev
 
 # do not build debuginfo sub-packages
@@ -49,9 +42,7 @@ BuildRequires: %{python_pfx}-jinja2
 BuildRequires: %{python_pfx}-simplejson
 BuildRequires: python3-backoff >= 1.9.0
 
-%if 0%{?fedora} || 0%{?rhel} > 7
-BuildRequires: argparse-manpage
-%endif
+BuildRequires: /usr/bin/argparse-manpage
 BuildRequires: python-rpm-macros
 
 %if "%{?python}" == "python2"
@@ -73,7 +64,9 @@ Requires: git
 Requires: git-svn
 # for the /bin/unbuffer binary
 Requires: expect
+%if !0%{?openEuler}
 Requires: qemu-user-static
+%endif
 Requires: sed
 
 %if 0%{?fedora} || 0%{?rhel} > 7
@@ -103,32 +96,27 @@ Requires: dnf-yum
 Requires: dnf-utils
 %endif
 # selinux toolset to allow running ansible against the builder
-%if 0%{?fedora}
 Requires: python3-libselinux
 Requires: python3-libsemanage
-%else
-Requires: libselinux-python
-Requires: libsemanage-python
-%endif
+%if 0%{?openEuler}
 # for mock to allow: config_opts['nosync'] = True
 Requires: nosync
-%ifarch x86_64
-# multilib counterpart to avoid: config_opts['nosync_force'] = True
-Requires: nosync(x86-32)
 %endif
 Requires: openssh-clients
 Requires: podman
+%if !0%{?openEuler}
 Requires: pyp2rpm
 Requires: pyp2spec
+Requires: rubygem-gem2rpm
+Requires: scl-utils-build
+Requires: fedora-review >= 0.8
+Requires: fedora-review-plugin-java
+%endif
 # We need %%pypi_source defined, which is in 3-29+
 Requires: python-srpm-macros >= 3-29
 Requires: rpkg
 Requires: rsync
-Requires: rubygem-gem2rpm
-Requires: scl-utils-build
 Requires: tito
-Requires: fedora-review >= 0.8
-Requires: fedora-review-plugin-java
 # yum* to allow mock to build against el* chroots without bootstrap_container
 %if 0%{?rhel}
 Requires: yum
@@ -138,8 +126,6 @@ Requires: yum-utils
 # We want those to be always up-2-date
 %latest_requires ca-certificates
 %latest_requires distribution-gpg-keys
-%if 0%{?fedora}
-
 %if 0%{?fedora} >= 38
 %latest_requires dnf5
 %latest_requires dnf5-plugins
@@ -150,14 +136,10 @@ Requires: yum-utils
 %latest_requires libdnf
 %latest_requires librepo
 %latest_requires libsolv
-%endif
 %latest_requires mock
 %latest_requires mock-core-configs
-%latest_requires redhat-rpm-config
+%latest_requires system-rpm-config
 %latest_requires rpm
-
-# Outdated gem2rpm version may have problems with fetching from rubygems.org
-%latest_requires rubygem-gem2rpm
 
 
 %description -n copr-builder
@@ -282,14 +264,12 @@ install -p -m 755 copr-update-builder %buildroot%_bindir
 )
 
 install -p -m 755 bin/copr-distgit-client %buildroot%_bindir
-%if 0%{?fedora} || 0%{?rhel} > 7
 argparse-manpage --pyfile copr_distgit_client.py \
     --function _get_argparser \
     --author "Copr Team" \
     --author-email "copr-team@redhat.com" \
     --url %url --project-name Copr \
 > %{buildroot}%{_mandir}/man1/copr-distgit-client.1
-%endif
 mkdir -p %{buildroot}%{_sysconfdir}/copr-distgit-client
 install -p -m 644 etc/copr-distgit-client/default.ini \
     %{buildroot}%{_sysconfdir}/copr-distgit-client
@@ -330,9 +310,7 @@ install -p -m 644 copr_distgit_client.py %{buildroot}%{expand:%%%{python}_siteli
 %files -n copr-distgit-client
 %license LICENSE
 %_bindir/copr-distgit-client
-%if 0%{?fedora} || 0%{?rhel} > 7
 %_mandir/man1/copr-distgit-client.1*
-%endif
 %dir %_sysconfdir/copr-distgit-client
 %config %_sysconfdir/copr-distgit-client/default.ini
 %sitelib/copr_distgit_client.*


### PR DESCRIPTION
This PR make tito build works in openEuler chroot:
1. some packages not exsted in openEuler so we exclude
2. some packages have a different name in openEuler
3. we donot have a dnf5 for now