### PR TITLE
backend, frontend: add lock mechanism around copr projects for delete action

### DIFF
--- a/backend/run/copr-backend-process-action
+++ b/backend/run/copr-backend-process-action
@@ -29,7 +29,10 @@ class ActionBackgroundWorker(BackendBackgroundWorker):
                            resp.status_code)
             return result
         action_task = resp.json()
-        action = Action.create_from(self.opts, action_task, log=self.log)
+        action = Action.create_from(self.opts, action_task, self.frontend_client, log=self.log)
+
+        action.lock.wait_for_resource_to_be_unlocked()
+
         try:
             self.log.info("Executing: %s", str(action))
             result = action.run()

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -409,6 +409,10 @@ class _CoprPrivate(db.Model, helpers.Serializer):
     # remote Git sites auth info
     scm_api_auth_json = db.Column(db.Text)
 
+    # if set to True then an action prone to race condition is working with this
+    # resource
+    copr_resource_locked = db.Column(db.Boolean, default=False)
+
 
 class Copr(db.Model, helpers.Serializer, CoprSearchRelatedData):
     """


### PR DESCRIPTION
This implements a lock mechanism around the whole project so the delete action can lock its resources and block other actions to work on particular projects until deletion is done. I don't like that the information about locking is implemented via DB thus this means a lot of new requests for DB but I can't think of a better mechanism to pass this info between actions. Suggestions are welcomed 

Fixes #2698