### PR TITLE
frontend, cli: make pyp2spec the default PyPI spec generator

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -1294,7 +1294,7 @@ def setup_parser():
         dest="spec_generator",
         help="Tool for generating specfile from a PyPI package",
         choices=["pyp2rpm", "pyp2spec"],
-        default="pyp2rpm",
+        default="pyp2spec",
     )
 
     parser_pypi_args_optional.add_argument("--template", "-t", dest="spec_template",

--- a/frontend/coprs_frontend/coprs/forms.py
+++ b/frontend/coprs_frontend/coprs/forms.py
@@ -933,7 +933,7 @@ class PackageFormPyPI(BasePackageForm):
         choices=[
             ("pyp2rpm", "pyp2rpm"),
             ("pyp2spec", "pyp2spec"),
-        ], default="pyp2rpm")
+        ], default="pyp2spec")
 
     spec_template = wtforms.SelectField(
         "Spec template",


### PR DESCRIPTION
Fix #2791