### PR TITLE
frontend: add relationship between actions and projects/builds

### DIFF
--- a/frontend/coprs_frontend/alembic/versions/08dd42f4c304_connect_copr_to_actions.py
+++ b/frontend/coprs_frontend/alembic/versions/08dd42f4c304_connect_copr_to_actions.py
@@ -1,0 +1,28 @@
+"""
+Connect Copr to Actions
+
+Revision ID: 08dd42f4c304
+Create Date: 2023-08-03 15:45:53.527538
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '08dd42f4c304'
+down_revision = 'daa62cd0743d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('action', sa.Column('copr_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_action_copr_id'), 'action', ['copr_id'], unique=False)
+    op.create_foreign_key(None, 'action', 'copr', ['copr_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint(None, 'action', type_='foreignkey')
+    op.drop_index(op.f('ix_action_copr_id'), table_name='action')
+    op.drop_column('action', 'copr_id')

--- a/frontend/coprs_frontend/commands/rawhide_to_release.py
+++ b/frontend/coprs_frontend/commands/rawhide_to_release.py
@@ -137,7 +137,7 @@ def rawhide_to_release_function(rawhide_chroot, dest_chroot, retry_forked):
             ))
 
         if len(data["builds"]):
-            actions_logic.ActionsLogic.send_rawhide_to_release(data)
+            actions_logic.ActionsLogic.send_rawhide_to_release(copr, data)
 
         db.session.commit()
 

--- a/frontend/coprs_frontend/coprs/logic/actions_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/actions_logic.py
@@ -132,6 +132,7 @@ class ActionsLogic(object):
                 object_id=0,
                 data=json.dumps(data_dict),
                 created_on=int(time.time()),
+                copr_id=copr.id,
             )
             if priority is not None:
                 action.priority = priority
@@ -148,7 +149,8 @@ class ActionsLogic(object):
                                object_type="copr",
                                object_id=copr.id,
                                data=json.dumps(data_dict),
-                               created_on=int(time.time()))
+                               created_on=int(time.time()),
+                               copr_id=copr.id)
         db.session.add(action)
         return action
 
@@ -200,7 +202,8 @@ class ActionsLogic(object):
             object_type="build",
             object_id=build.id,
             data=json.dumps(cls.get_build_delete_data(build)),
-            created_on=int(time.time())
+            created_on=int(time.time()),
+            copr_id=build.copr.id
         )
         db.session.add(action)
         return action
@@ -246,7 +249,8 @@ class ActionsLogic(object):
             action_type=ActionTypeEnum("delete"),
             object_type="builds",
             data=json.dumps(data),
-            created_on=int(time.time())
+            created_on=int(time.time()),
+            copr_id=builds[0].copr.id,
         )
         db.session.add(action)
         return action
@@ -286,7 +290,8 @@ class ActionsLogic(object):
             action_type=ActionTypeEnum("update_comps"),
             object_type="copr_chroot",
             data=json.dumps(data_dict),
-            created_on=int(time.time())
+            created_on=int(time.time()),
+            copr_id=chroot.copr.id,
         )
         db.session.add(action)
         return action
@@ -308,17 +313,19 @@ class ActionsLogic(object):
             object_type="copr",
             data=json.dumps(data_dict),
             created_on=int(time.time()),
+            copr_id=copr.id,
         )
         db.session.add(action)
         return action
 
     @classmethod
-    def send_rawhide_to_release(cls, data):
+    def send_rawhide_to_release(cls, copr, data):
         action = models.Action(
             action_type=ActionTypeEnum("rawhide_to_release"),
             object_type="None",
             data=json.dumps(data),
             created_on=int(time.time()),
+            copr_id=copr.id,
         )
         db.session.add(action)
         return action
@@ -338,6 +345,7 @@ class ActionsLogic(object):
             new_value="{0}".format(dst.full_name),
             data=json.dumps({"user": dst.owner_name, "copr": dst.name, "builds_map": builds_map}),
             created_on=int(time.time()),
+            copr_id=dst.id,
         )
         db.session.add(action)
         return action
@@ -364,6 +372,7 @@ class ActionsLogic(object):
             new_value="",
             data=json.dumps(data),
             created_on=int(time.time()),
+            copr_id=copr.id,
         )
         db.session.add(action)
         return action
@@ -386,7 +395,8 @@ class ActionsLogic(object):
             object_type="chroot",
             object_id=None,
             data=json.dumps(data_dict),
-            created_on=int(time.time())
+            created_on=int(time.time()),
+            copr_id=copr_chroot.copr.id,
         )
         db.session.add(action)
         return action

--- a/frontend/coprs_frontend/coprs/logic/coprs_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/coprs_logic.py
@@ -840,8 +840,8 @@ class CoprDirsLogic(object):
         """
         copr_ids = cls.get_copr_ids_with_pr_dirs().all()
 
-        remove_dirs = []
         for copr_id in copr_ids:
+            remove_dirs = []
             copr_id = copr_id[0]
             all_dirs = cls.get_all_with_latest_submitted_build(copr_id)
             for copr_dir in all_dirs:
@@ -857,13 +857,14 @@ class CoprDirsLogic(object):
                 cls.delete_with_builds(dir_object)
                 remove_dirs.append(dirname)
 
-        action = models.Action(
-            action_type=ActionTypeEnum("remove_dirs"),
-            object_type="copr",
-            data=json.dumps(remove_dirs),
-            created_on=int(time.time()))
-
-        db.session.add(action)
+            action = models.Action(
+                action_type=ActionTypeEnum("remove_dirs"),
+                object_type="copr",
+                data=json.dumps(remove_dirs),
+                created_on=int(time.time()),
+                copr_id=copr_id,
+            )
+            db.session.add(action)
 
     @classmethod
     def copr_name_from_dirname(cls, dirname):

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -2150,6 +2150,9 @@ class Action(db.Model, helpers.Serializer):
     # time ended as returned by int(time.time())
     ended_on = db.Column(db.Integer, index=True)
 
+    copr_id = db.Column(db.Integer, db.ForeignKey("copr.id"), nullable=True, index=True)
+    copr = db.relationship("Copr", backref=db.backref("actions"))
+
     def __str__(self):
         return self.__unicode__()
 


### PR DESCRIPTION
This will help to implement RFEs like #1108

TODO:
- [x] discuss what to do with `object_type` (e.g. what is None?)
- [x] do migration when we agree on relationships between tables
- [x] ~~tests~~ This PR just connects Copr and Action model, write tests for the RFEs like #1108

~~Merge after #2733 and change `down_revision` to `7d9f6f921fa0`~~ done

Closes #2823