### PR TITLE
Add --logs argument to download-build command

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -652,6 +652,9 @@ class Commands(object):
             if args.spec:
                 cmd.extend(["-A", "*.spec"])
 
+            if args.logs:
+                cmd.extend(["-A", "*.log.gz"])
+
             if args.review:
                 cmd.extend([
                     "-A", "files.dir",
@@ -1511,6 +1514,12 @@ def setup_parser():
         dest="review",
         action="store_true",
         help="Download only the fedora-review files",
+    )
+    parser_download_build.add_argument(
+        "--logs",
+        dest="logs",
+        action="store_true",
+        help="Download only the .log files",
     )
     parser_download_build.set_defaults(func="action_download_build")
 


### PR DESCRIPTION
Overview:

This pull request adds a new feature to Copr allowing a user to directly download the logs of a Copr build rather than download the entire build. 

Changes Made:

I added an argument called logs that supplements the already existing arguments "rpms" and "spec" to the command "copr cli download-build <build id>"

Testing:

I tested the command by running copr in a local fedora environment on copr builds that I had previously ran.

Conclusion:

Ultimately, adding this argument allows users to not have to download unnecessary files. My tech lead Josh Stone and I decided to create this command because I was creating a python script that looks for test cases that failed on certain architectures and passed on others. For this, only the logs were needed. If there are other applications that only require logs and not the entire build information, then this will be a useful push.