### PR TITLE
Drop dependency on `future`

### DIFF
--- a/cli/copr-cli.spec
+++ b/cli/copr-cli.spec
@@ -35,7 +35,6 @@ Requires:      python3-jinja2
 Requires:      python3-simplejson
 Requires:      python3-humanize
 Requires:      python3-koji
-Requires:      python3-future
 
 Recommends:    python3-progress
 Suggests:      python3-beautifulsoup4
@@ -49,13 +48,11 @@ BuildRequires: python3-responses
 BuildRequires: python3-setuptools
 BuildRequires: python3-simplejson
 BuildRequires: python3-munch
-BuildRequires: python3-future
 %else
 Requires:      python-copr >= %min_python_copr_version
 Requires:      python-jinja2
 Requires:      python-simplejson
 Requires:      python-humanize
-Requires:      python-future
 
 BuildRequires: pytest
 BuildRequires: python-copr >= %min_python_copr_version
@@ -67,7 +64,6 @@ BuildRequires: python2-responses
 BuildRequires: python-setuptools
 BuildRequires: python-simplejson
 BuildRequires: python-munch
-BuildRequires: python-future
 %endif
 
 # We historically shipped empty doc package, uninstall it.

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -19,7 +19,6 @@ requires = [
     'simplejson',
     'jinja2',
     'setuptools',
-    'future',
 ]
 
 __name__ = 'copr-cli'

--- a/python/python-copr.spec
+++ b/python/python-copr.spec
@@ -37,7 +37,6 @@ BuildRequires: python-configparser
 BuildRequires: pytest
 BuildRequires: python2-devel
 BuildRequires: python2-requests-gssapi
-BuildRequires: python-future
 # for doc package
 BuildRequires: python-sphinx
 BuildRequires: python-docutils
@@ -52,7 +51,6 @@ BuildRequires: python-munch
 BuildRequires: python2-filelock
 BuildRequires: python2-configparser
 BuildRequires: python2-requests-gssapi
-BuildRequires: python-future
 # for doc package
 BuildRequires: python2-sphinx
 BuildRequires: python2-docutils
@@ -84,7 +82,6 @@ Requires: python-requests-toolbelt
 Requires: python-requests-gssapi
 Requires: python-setuptools
 Requires: python-six >= 1.9.0
-Requires: python-future
 %else
 Requires: python2-configparser
 Requires: python2-munch
@@ -94,7 +91,6 @@ Requires: python2-requests-toolbelt
 Requires: python2-setuptools
 Requires: python2-requests-gssapi
 Requires: python2-six >= 1.9.0
-Requires: python-future
 %endif
 
 %{?python_provide:%python_provide python2-copr}
@@ -121,7 +117,6 @@ BuildRequires: python3-requests-toolbelt
 BuildRequires: python3-six
 BuildRequires: python3-sphinx
 BuildRequires: python3-requests-gssapi
-BuildRequires: python3-future
 
 Requires: python3-munch
 Requires: python3-filelock
@@ -130,7 +125,6 @@ Requires: python3-requests-toolbelt
 Requires: python3-setuptools
 Requires: python3-six
 Requires: python3-requests-gssapi
-Requires: python3-future
 
 %{?python_provide:%python_provide python3-copr}
 
@@ -142,7 +136,6 @@ BuildRequires: python3-devel
 BuildRequires: python3-sphinx
 BuildRequires: python3-pytest
 BuildRequires: python3-requests-gssapi
-BuildRequires: python3-future
 BuildRequires: python3-filelock
 BuildRequires: pyproject-rpm-macros
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,7 +20,6 @@ requires = [
     'setuptools',
     'six',
     'munch',
-    'future',
 ]
 
 __description__ = "Python client for copr service."


### PR DESCRIPTION
PR https://github.com/fedora-copr/copr/pull/2812 removed the last usage of future from the project.