### PR TITLE
packit: wait for python-copr-common to build first

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,6 +13,9 @@ packages:
     files_to_sync:
       - python-copr.spec
     upstream_tag_template: python-copr-{version}
+    actions:
+      post-upstream-clone:
+        - sh -c "wait-for-copr --owner $COPR_OWNER --project $COPR_PROJECT python-copr-common `git rev-parse --short HEAD`"
 
   python-copr-common:
     downstream_package_name: python-copr-common


### PR DESCRIPTION
e.g. in #2804 python-copr-common has to be built before FE so FE build can pass