### PR TITLE
group alias need 1:1 mapping to group

### DIFF
--- a/frontend/coprs_frontend/alembic/versions/daa62cd0743d_add_unique_constraint_to_fas_group.py
+++ b/frontend/coprs_frontend/alembic/versions/daa62cd0743d_add_unique_constraint_to_fas_group.py
@@ -1,0 +1,24 @@
+"""
+add unique constraint to fas_group
+
+Revision ID: daa62cd0743d
+Revises: ba6ac0936bfb
+Create Date: 2023-08-01 09:52:01.522171
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'daa62cd0743d'
+down_revision = 'ba6ac0936bfb'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint(None, 'group', ['fas_name'])
+
+
+def downgrade():
+    op.drop_constraint(None, 'group', type_='unique')

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -2206,8 +2206,7 @@ class Group(db.Model, helpers.Serializer):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(127))
 
-    # TODO: add unique=True
-    fas_name = db.Column(db.String(127))
+    fas_name = db.Column(db.String(127), unique=True)
 
     @property
     def at_name(self):

--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -304,7 +304,7 @@
         <span class="badge">{{ g.user.coprs_count }}</span>
         My projects
       </a>
-    {% if config.FAS_LOGIN or config.LDAP_URL %}
+    {% if config.FAS_LOGIN or config.LDAP_URL or config.OIDC_LOGIN %}
       <a href="{{url_for('groups_ns.list_user_groups') }}" class="list-group-item">
         <span class="badge"> {{ user.user_groups|length }} </span>
         My groups
@@ -457,11 +457,6 @@
 {% macro package_href(package) %}
   {{- copr_url('coprs_ns.copr_package', package.copr, package_name=package.name) -}}
 {% endmacro %}
-
-{%- macro fas_group_href(name) -%}
-https://accounts.fedoraproject.org/group/{{name}}
-{%- endmacro -%}
-
 
 {% macro repo_file_href(copr, repo, arch=None) %}
 {%- if not arch %}

--- a/frontend/coprs_frontend/coprs/templates/coprs/show/group.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/show/group.html
@@ -1,7 +1,7 @@
 {% extends "coprs/group_show.html" %}
 {% block title %}Project List{% endblock %}
 {% block header %}Project List{% endblock %}
-{% from "_helpers.html" import render_pagination, fas_group_href %}
+{% from "_helpers.html" import render_pagination %}
 {% block breadcrumbs %}
 <ol class="breadcrumb">
   <li>

--- a/frontend/coprs_frontend/coprs/templates/groups/user_fas_groups.html
+++ b/frontend/coprs_frontend/coprs/templates/groups/user_fas_groups.html
@@ -1,5 +1,5 @@
 {% extends "layout.html" %}
-{% from "_helpers.html" import fas_group_href, initialize_datatables %}
+{% from "_helpers.html" import initialize_datatables %}
 {% block title %}Add a Group{% endblock %}
 {% block header %}Add a Group{% endblock %}
 
@@ -37,7 +37,7 @@
     <tbody>
     {% for team in teams %}
       <tr>
-        <td><a href="{{ fas_group_href(team) }}">
+        <td><a href="{{ config.GROUP_INFO.link.format(name=team) }}">
           {{ team }}
         </a></td>
         <td>


### PR DESCRIPTION
This PR try to fix: #2825 also fortunately fix: #2563
1. add unique contraint to `fas_name` and add migration script generated by ` alembic revision --autogenerate `
2. I think  macro `fas_group_href` canbe replaced by `onfig.GROUP_INFO.link.forma` which is more configurable
3. When creating a new alias for a group, if the group already has one alias, popup a flash and redirect to the already existed group