### PR TITLE
dist-git: fix test_do_import test

### DIFF
--- a/dist-git/tests/test_importer.py
+++ b/dist-git/tests/test_importer.py
@@ -119,12 +119,14 @@ class TestImporter(Base):
         assert mc_import_package.call_args[0][2] == self.url_task.branches
         assert mc_import_package.call_args[0][3] == 'somepath.src.rpm'
 
-        print(self.importer.post_back_safe.has_calls([
-            mock.call({'build_id': 125, 'pkg_name': 'foo', 'branch': self.BRANCH,
-                       'pkg_version': '1.2', 'git_hash': '123', 'repo_name': 'foo'}),
-            mock.call({'build_id': 125, 'pkg_name': 'foo', 'branch': self.BRANCH2,
-                       'pkg_version': '1.2', 'git_hash': '124', 'repo_name': 'foo'})
-        ]))
+        self.importer.post_back_safe.assert_has_calls([
+            mock.call({
+                'build_id': 123,
+                'pkg_name': 'foo',
+                'pkg_evr': '1.2',
+                'reponame': 'foo',
+                'branch_commits': {'f22': '123', 'f23': '124'}}),
+        ])
 
 
     @mock.patch("copr_dist_git.import_dispatcher.Importer", return_value=MagicMock())


### PR DESCRIPTION
The 'has_calls" actually never worked - it was a typo which had a no-op effect - and with the Python 3.12 in Fedora 39+ it finally started failing.

Let's switch to a valid 'assert_has_calls' and update the expected output (which is a bit artificial after the years, but it doesn't matter).

Relates: #2811