### PR TITLE
cli, frontend: rely on DNF with documenting repo priority

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -1179,8 +1179,10 @@ def setup_parser():
               "created for you (as soon as they are available) as rawhide "
               "chroot forks."))
 
-    parser_create.add_argument("--repo-priority", default=None,
-                               help="Set the priority value of this repository")
+    parser_create.add_argument(
+        "--repo-priority", default=None,
+        help=("Use the priority=<INT> config option for repositories in this "
+              "project, see man dnf.conf(5) for more info."))
 
     create_and_modify_common_opts(parser_create)
 

--- a/frontend/coprs_frontend/coprs/forms.py
+++ b/frontend/coprs_frontend/coprs/forms.py
@@ -656,10 +656,8 @@ class CoprForm(BaseForm):
         validators=[wtforms.validators.Optional()],)
 
     repo_priority = wtforms.IntegerField(
-        "The priority value of this repository",
-        description="""The priority value of this repository, default is 99. If there is more than one candidate
-        package for a particular operation, the one from a repo with the lowest priority value is
-        picked, possibly despite being less convenient otherwise (e.g. by being a lower version).""",
+        "Use the priority=<INT> config option for repositories in this "
+        "project, see man dnf.conf(5) for more info.",
         render_kw={"placeholder": "Optional - integer, e.g. 22"},
         validators=[
             wtforms.validators.Optional(),


### PR DESCRIPTION
The 'description' metadata for 'short-input-field' is not visible anyway, so it was useful.  The priority field is nicely documented in 'dnf.conf' manual page, so it is fair to delegate our users there.