### PR TITLE
frontend: support grab group info from OIDC provider

### DIFF
--- a/frontend/coprs_frontend/coprs/context_processors.py
+++ b/frontend/coprs_frontend/coprs/context_processors.py
@@ -4,6 +4,7 @@ import flask
 from coprs import app
 from coprs.constants import BANNER_LOCATION
 from coprs.helpers import current_url
+from coprs.oidc import oidc_enabled
 
 
 @app.context_processor
@@ -67,7 +68,7 @@ def login_menu():
                 'desc': 'sign up',
             })
 
-        if config['OIDC_LOGIN'] and config['OIDC_PROVIDER_NAME']:
+        if oidc_enabled(config):
             menu.append({
                 'link': flask.url_for("misc.oidc_login"),
                 'desc': '{} login'.format(app.config['OIDC_PROVIDER_NAME']),

--- a/frontend/coprs_frontend/coprs/oidc.py
+++ b/frontend/coprs_frontend/coprs/oidc.py
@@ -11,13 +11,18 @@ def is_config_valid(config):
     """
     If OpenID Connect is enabled
     """
-    return "OIDC_LOGIN" in config and config["OIDC_LOGIN"] is True
+    return "OIDC_LOGIN" in config and config["OIDC_LOGIN"] is True and \
+            "OIDC_PROVIDER_NAME" in config and config["OIDC_PROVIDER_NAME"]
 
 
 def oidc_enabled(config):
     """
     Check whether the config is valid
     """
+    if not is_config_valid(config):
+        logger.error("OIDC_LOGIN or OIDC_PROVIDER_NAME is empty")
+        return False
+
     if not config.get("OIDC_CLIENT"):
         logger.error("OIDC_CLIENT is empty")
         return False
@@ -47,7 +52,7 @@ def init_oidc_app(app):
     When configs check failed, a invalid client object is returned
     """
     oidc = OAuth(app)
-    if oidc_enabled(app.config) and is_config_valid(app.config):
+    if oidc_enabled(app.config):
         client_id = app.config.get("OIDC_CLIENT")
         secret = app.config.get("OIDC_SECRET")
         client_kwargs = {

--- a/frontend/coprs_frontend/tests/test_auth.py
+++ b/frontend/coprs_frontend/tests/test_auth.py
@@ -3,7 +3,7 @@
 from unittest import mock
 from tests.coprs_test_case import CoprsTestCase
 from coprs import app
-from coprs.auth import GroupAuth
+from coprs.auth import GroupAuth, LDAPGroups
 
 
 class TestGroupAuth(CoprsTestCase):
@@ -29,7 +29,7 @@ class TestGroupAuth(CoprsTestCase):
             b'cn=another-group-2,ou=foo,ou=bar,dc=company,dc=com'
         ]
         user = mock.MagicMock()
-        GroupAuth.update_user_groups(user)
+        GroupAuth.update_user_groups(user, LDAPGroups.group_names(user.username))
         assert user.openid_groups == {
             "fas_groups": ["group1", "group2", "another-group",
                            "another-group-2"]}


### PR DESCRIPTION
As our former OIDC PR #2422 didn't have ability to grab any group info from Idp,
This PR add the missing functionalities:
1. unitfied the update group API, so it can be use by LDAP, openID and OIDC
2. suppose our OIDC Idp can return sort of group info like
    ```
    {
      "sub": "user123",
      "name": "John Doe",
      "email": "john.doe@example.com",
      "groups": [
        "dev-utils",
        "eBPF",
        "kernel"
      ]
    }
    ```
    PS: to achieve this, our Idp implement a non-standard but defacto standard: `group` scope and we add it in the `OIDC_SCOPES` config item
3. some refactor for oidc module: make `oidc_enabled` more useful, which will guarantee the OIDC related configs is configured and valid

try to fix: #2788 