### PR TITLE
backend: fix tests for zst compression on F39+

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -56,6 +56,7 @@ BuildRequires: python3-retask
 BuildRequires: python3-setproctitle
 BuildRequires: python3-sphinx
 BuildRequires: python3-tabulate
+BuildRequires: python3-zstandard
 BuildRequires: modulemd-tools >= 0.6
 BuildRequires: prunerepo >= %prunerepo_version
 BuildRequires: dnf

--- a/backend/tests/test_modifyrepo.py
+++ b/backend/tests/test_modifyrepo.py
@@ -547,9 +547,10 @@ class TestModifyRepo(object):
             pass
 
         assert call_copr_repo(chrootdir)
-        name = glob.glob(os.path.join(chrootdir, "repodata", "*-comps.xml.gz"))
-        assert os.path.exists(name[0])
 
+        name = glob.glob(os.path.join(chrootdir, "repodata", "*-comps.xml.*"))
+        assert os.path.exists(name[0])
+        assert name[0].endswith((".zst", ".gz"))
 
     @skip("Works locally and in Copr but fails in Koji")
     @mock.patch("copr_prune_results.LOG", logging.getLogger())


### PR DESCRIPTION
Fix #2832

Since F39 we are using zst compression for repodata instead of gz. https://fedoraproject.org/wiki/Changes/createrepo_c_1.0.0