### PR TITLE
rpmbuild: save review.json from fedora-review

### DIFF
--- a/rpmbuild/copr_rpmbuild/automation/fedora_review.py
+++ b/rpmbuild/copr_rpmbuild/automation/fedora_review.py
@@ -73,7 +73,8 @@ class FedoraReview(AutomationTool):
             self.log.error("Can't find fedora-review results: %s", srcdir)
             return
 
-        results = ["review.txt", "licensecheck.txt", "rpmlint.txt", "files.dir"]
+        results = ["review.txt", "review.json", "licensecheck.txt",
+                   "rpmlint.txt", "files.dir"]
         for result in results:
             try:
                 os.rename(os.path.join(srcdir, result),


### PR DESCRIPTION
See https://pagure.io/FedoraReview/pull-request/463 
See https://pagure.io/FedoraReview/issue/310

I am planning to use this file from the fedora-review-service and provide users with better feedback based on that.

Also, we don't need to depend on a specific fedora-review version. If the file is not present, we skip it without failing.