### PR TITLE
rpmbuild: speedup the custom build with mock bootstrap image

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -59,7 +59,7 @@ Requires: %{python}-requests
 Requires: %{python_pfx}-specfile >= 0.19.0
 Requires: python3-backoff >= 1.9.0
 
-Requires: mock >= 2.0
+Requires: mock >= 5.0
 Requires: git
 Requires: git-svn
 # for the /bin/unbuffer binary

--- a/rpmbuild/mock-custom-build.cfg.j2
+++ b/rpmbuild/mock-custom-build.cfg.j2
@@ -2,6 +2,13 @@ include('/etc/mock/{{ chroot }}.cfg')
 config_opts['rpmbuild_networking'] = True
 config_opts['use_host_resolv'] = True
 
+# We don't do 'dnf builddep' for the custom method, so we don't need to install
+# python3-dnf-plugins core or dnf5-plugins at all.
+config_opts["bootstrap_image_ready"] = True
+
+# Don't mixup caches with the normal mock build.
+config_opts["root"] = "copr-custom-" + config_opts["root"]
+
 # Important e.g. to keep '/script' file available across several
 # /bin/mock calls (when tmpfs_enable is on).
 config_opts['plugin_conf']['tmpfs_opts']['keep_mounted'] = True


### PR DESCRIPTION
We don't have to install 'dnf builddep' into bootstrap at all, we can go straight to the 'buildroot' installation.