### PR TITLE
backend: don't eat the "build detail collecting" traceback

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -678,9 +678,9 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
                 }
             self.log.info("build details: %s", build_details)
         except Exception as e:
-            raise BackendError(
-                "Error while collecting built packages for {}: {}"
-                .format(job.task_id, str(e)))
+            self.log.exception("Can't collect build results for %s",
+                               job.task_id)
+            raise BackendError("Can not deduct build details") from e
 
         return build_details
 

--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -1034,11 +1034,12 @@ class BuildsLogic(object):
                 for chroot in build.build_chroots:
                     arch = chroot.mock_chroot.arch
 
-                    exclusivearch = upd_dict["results"]["exclusivearch"]
+                    exclusivearch = upd_dict["results"].get("exclusivearch")
                     if exclusivearch and arch not in exclusivearch:
                         finish(chroot, StatusEnum("skipped"))
 
-                    if arch in upd_dict["results"]["excludearch"]:
+                    excludearch = upd_dict["results"].get("excludearch")
+                    if arch in excludearch:
                         finish(chroot, StatusEnum("skipped"))
 
             cls.process_update_callback(build)


### PR DESCRIPTION
Use "log.exception()" which passes the traceback down to backend.log. This helps me to debug some release-blocker issue right now, normally we (when infra is OK) we shouldn't ever catch an exception there.