### PR TITLE
rpmbuild: more reliable SRPM vs RPM build check

### DIFF
--- a/rpmbuild/copr_rpmbuild/automation/rpm_results.py
+++ b/rpmbuild/copr_rpmbuild/automation/rpm_results.py
@@ -19,7 +19,7 @@ class RPMResults(AutomationTool):
         """
         Do this for every RPM build
         """
-        return self.chroot is not None
+        return self.task["source_type"] is None
 
     def run(self):
         """

--- a/rpmbuild/copr_rpmbuild/automation/srpm_results.py
+++ b/rpmbuild/copr_rpmbuild/automation/srpm_results.py
@@ -22,9 +22,9 @@ class SRPMResults(AutomationTool):
     @property
     def enabled(self):
         """
-        Do this for every RPM build
+        Do this for every SRPM build
         """
-        return not self.chroot
+        return self.task["source_type"] is not None
 
     def run(self):
         """


### PR DESCRIPTION
Fix #2841

The previous check worked for all SRPM methods except for custom method. It uses `self.chroot` to specify "what chroot to run the script in". Checking `source_type` should be more reliable.