### PR TITLE
rpmbuild: require new python-specfile version

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -39,7 +39,7 @@ BuildRequires: %{python}-pytest
 BuildRequires: %{python_pfx}-munch
 BuildRequires: %{python}-requests
 BuildRequires: %{python_pfx}-jinja2
-BuildRequires: %{python_pfx}-specfile >= 0.19.0
+BuildRequires: %{python_pfx}-specfile >= 0.21.0
 BuildRequires: python3-backoff >= 1.9.0
 
 BuildRequires: /usr/bin/argparse-manpage
@@ -56,7 +56,7 @@ Requires: %{python}-copr-common >= %copr_common_version
 Requires: %{python_pfx}-jinja2
 Requires: %{python_pfx}-munch
 Requires: %{python}-requests
-Requires: %{python_pfx}-specfile >= 0.19.0
+Requires: %{python_pfx}-specfile >= 0.21.0
 Requires: python3-backoff >= 1.9.0
 
 Requires: mock >= 5.0


### PR DESCRIPTION
Fix #2839