### PR TITLE
Parse specfile or RPM headers only once

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -3,7 +3,7 @@
 %endif
 
 %global prunerepo_version 1.20
-%global tests_version 3
+%global tests_version 4
 %global tests_tar test-data-copr-backend
 
 %global copr_common_version 0.16.4.dev

--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -630,13 +630,15 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         build_details = {'srpm_url': ''}
         self.log.info("Retrieving SRPM info from %s", job.results_dir)
 
-        results_path = os.path.join(job.results_dir, "results.json")
-        with open(results_path, "r", encoding="utf-8") as fp:
-            results = json.load(fp)
+        # pylint: disable=unsubscriptable-object
+        assert isinstance(self.job.results, dict)
 
-        build_details["pkg_name"] = results["name"]
+        build_details["pkg_name"] = self.job.results["name"]
         build_details["pkg_version"] = format_evr(
-            results["epoch"], results["version"], results["release"])
+            self.job.results["epoch"],
+            self.job.results["version"],
+            self.job.results["release"],
+        )
 
         pattern = os.path.join(job.results_dir, '*.src.rpm')
         srpm_file = glob.glob(pattern)[0]

--- a/backend/tests/test_background_worker_build.py
+++ b/backend/tests/test_background_worker_build.py
@@ -271,8 +271,7 @@ def test_waiting_for_repo_success(mc_time, f_build_rpm_case_no_repodata, caplog)
     assert (logging.INFO, MESSAGES["repo_waiting"]) \
         in [(r[1], r[2]) for r in caplog.record_tuples]
 
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_full_rpm_build_no_sign(_parse_results, f_build_rpm_case, caplog):
+def test_full_rpm_build_no_sign(f_build_rpm_case, caplog):
     """
     Go through the whole (successful) build of a binary RPM
     """
@@ -311,8 +310,7 @@ def test_prev_build_backup(f_build_rpm_case):
     assert len(glob.glob(os.path.join(prev_results, rsync_patt))) == 1
 
 
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_full_srpm_build(_parse_results, f_build_srpm):
+def test_full_srpm_build(f_build_srpm):
     worker = f_build_srpm.bw
     worker.process()
     assert worker.job.pkg_name == "hello"
@@ -328,8 +326,7 @@ def test_full_srpm_build(_parse_results, f_build_srpm):
 
 @mock.patch("copr_backend.sign.SIGN_BINARY", "tests/fake-bin-sign")
 @mock.patch("copr_backend.sign._sign_one")
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_build_and_sign(_parse_results, mc_sign_one, f_build_rpm_sign_on, caplog):
+def test_build_and_sign(mc_sign_one, f_build_rpm_sign_on, caplog):
     config = f_build_rpm_sign_on
     worker = config.bw
     worker.process()
@@ -581,9 +578,8 @@ def test_cancel_before_start(f_build_rpm_sign_on, caplog):
     ], caplog)
 
 @_patch_bwbuild_object("CANCEL_CHECK_PERIOD", 0.5)
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
 @mock.patch("copr_backend.sign.SIGN_BINARY", "tests/fake-bin-sign")
-def test_build_retry(_parse_results, f_build_rpm_sign_on):
+def test_build_retry(f_build_rpm_sign_on):
     config = f_build_rpm_sign_on
     worker = config.bw
     class _SideEffect():
@@ -693,8 +689,7 @@ def test_cancel_build_during_log_download(f_build_rpm_sign_on, caplog):
         COMMON_MSGS["not finished"],
     ], caplog)
 
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_ssh_connection_error(_parse_results, f_build_rpm_case, caplog):
+def test_ssh_connection_error(f_build_rpm_case, caplog):
     class _SideEffect:
         counter = 0
         def __call__(self):
@@ -721,8 +716,7 @@ def test_average_step():
 
 @_patch_bwbuild_object("time.sleep", mock.MagicMock())
 @_patch_bwbuild_object("time.time")
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_retry_for_ssh_tail_failure(_parse_results, mc_time, f_build_rpm_case,
+def test_retry_for_ssh_tail_failure(mc_time, f_build_rpm_case,
                                     caplog):
     mc_time.side_effect = list(range(500))
     class _SideEffect:
@@ -769,8 +763,7 @@ def test_createrepo_failure(mc_call_copr_repo, f_build_rpm_case, caplog):
         "Finished build: id=848963 failed=True ",
     ], caplog)
 
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_existing_compressed_file(_parse_results, f_build_rpm_case, caplog):
+def test_existing_compressed_file(f_build_rpm_case, caplog):
     config = f_build_rpm_case
     config.ssh.precreate_compressed_log_file = True
     worker = config.bw
@@ -781,8 +774,7 @@ def test_existing_compressed_file(_parse_results, f_build_rpm_case, caplog):
         "Finished build: id=848963 failed=False ",  # still success!
     ], caplog)
 
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_tail_f_nonzero_exit(_parse_results, f_build_rpm_case, caplog):
+def test_tail_f_nonzero_exit(f_build_rpm_case, caplog):
     config = f_build_rpm_case
     worker = config.bw
     class _SideEffect:
@@ -841,8 +833,7 @@ def test_unable_to_start_builder(f_build_srpm, caplog):
     assert_logs_dont_exist(["Retry"], caplog)
 
 @_patch_bwbuild_object("time.sleep", mock.MagicMock())
-@_patch_bwbuild_object("BuildBackgroundWorker._parse_results")
-def test_retry_vm_factory_take(_parse_results, f_build_srpm, caplog):
+def test_retry_vm_factory_take(f_build_srpm, caplog):
     config = f_build_srpm
     rhf = config.resalloc_host_factory
     host = config.host


### PR DESCRIPTION
Fix #2850

CI for this will probably fail. We need merge tests data PR
https://github.com/fedora-copr/test-data-copr-backend/pull/2
and tag a new version first.