### PR TITLE
frontend: allow "epoch is null" field in BuildChrootResult

### DIFF
--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -2137,7 +2137,7 @@ class BuildChrootResult(db.Model, helpers.Serializer):
     )
 
     name = db.Column(db.Text, nullable=False)
-    epoch = db.Column(db.Integer, default=0)
+    epoch = db.Column(db.Integer, default=None)
     version = db.Column(db.Text, nullable=False)
     release = db.Column(db.Text, nullable=False)
     arch = db.Column(db.Text, nullable=False)

--- a/frontend/coprs_frontend/tests/test_apiv3/test_build_chroots.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_build_chroots.py
@@ -15,17 +15,19 @@ class TestAPIv3BuildChrootsResults(CoprsTestCase):
     @TransactionDecorator("u1")
     @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs",
                              "f_mock_chroots", "f_builds", "f_db")
-    def test_build_chroot_built_packages(self):
+    @pytest.mark.parametrize("value", [None, 1, 11])
+    def test_build_chroot_built_packages(self, value):
         """
         Test the endpoint for getting built packages (NEVRA dicts) for a given
         build chroot.
         """
         self.db.session.add(self.b1, self.b1_bc)
+
         built_packages = {
             "packages": [
                 {
                     "name": "hello",
-                    "epoch": 0,
+                    "epoch": value,
                     "version": "2.8",
                     "release": "1.fc33",
                     "arch": "x86_64"


### PR DESCRIPTION
This is what we prefer doing in FE<->BE protocol, what we return in result.json in BE<->Builder protocol, and what we _should_ return to users.