### PR TITLE
beaker: align tests with the August 2023 release

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/helpers
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/helpers
@@ -25,6 +25,14 @@ quote_args()
     done
 }
 
+copr_build_and_parse_id()
+{
+    quote_args "copr-cli" "$@" --nowait
+    rlRun -s "$quote_args_result"
+    rlRun parse_build_id
+    rlRun "copr watch-build $BUILD_ID"
+}
+
 cleanAction()
 {
     quote_args "$@"

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-bootstrap.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-bootstrap.sh
@@ -43,7 +43,8 @@ rlJournalStart
         rlRun "bootstrap=\$($detail_cmd | jq -r '.bootstrap')"
         rlAssertEquals "Check that bootstrap is enabled" "$bootstrap" on
 
-        rlRun "copr-cli edit-chroot $PROJECT/epel-8-x86_64 --bootstrap-image=fedora:$FEDORA_VERSION"
+        custom_image=registry.access.redhat.com/ubi8/ubi
+        rlRun "copr-cli edit-chroot $PROJECT/epel-8-x86_64 --bootstrap-image=$custom_image"
         rlRun "copr-cli edit-chroot $PROJECT/fedora-rawhide-x86_64 --bootstrap=default"
         rlRun -s "copr-cli build $PROJECT $HELLO --nowait"
         rlRun "parse_build_id"
@@ -58,7 +59,7 @@ rlJournalStart
         rlRun "curl $BACKEND_URL/results/$PROJECT/$chroot/$(printf %08d "$BUILD_ID")-hello/configs.tar.gz | tar xz -O '*configs/child.cfg' > child.cfg"
         rlRun 'grep -F "config_opts['\''use_bootstrap'\''] = True" child.cfg'
         rlRun 'grep -F "config_opts['\''use_bootstrap_image'\''] = True" child.cfg'
-        rlRun 'grep -F "config_opts['\''bootstrap_image'\'']" child.cfg | grep fedora:$FEDORA_VERSION'
+        rlRun 'grep -F "config_opts['\''bootstrap_image'\'']" child.cfg | grep $custom_image'
 
         chroot=fedora-rawhide-x86_64
         rlRun "curl $BACKEND_URL/results/$PROJECT/$chroot/$(printf %08d "$BUILD_ID")-hello/configs.tar.gz | tar xz -O '*configs/child.cfg' > child.cfg"

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-build-results-json.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-build-results-json.sh
@@ -41,25 +41,25 @@ rlJournalStart
             rlAssertEquals "There should be 4 results" "$(jq '.packages|length' < "$path")" 4
 
             rlRun "cat $path |jq -e '.packages[0].name == \"hello\"'"
-            rlRun "cat $path |jq -e '.packages[0].epoch == 0'"
+            rlRun "cat $path |jq -e '.packages[0].epoch == null'"
             rlRun "cat $path |jq -e '.packages[0].version == \"2.8\"'"
             rlRun "cat $path |jq -e '.packages[0].release == \"1.fc$FEDORA_VERSION\"'"
             rlRun "cat $path |jq -e '.packages[0].arch == \"src\"'"
 
             rlRun "cat $path |jq -e '.packages[1].name == \"hello\"'"
-            rlRun "cat $path |jq -e '.packages[1].epoch == 0'"
+            rlRun "cat $path |jq -e '.packages[1].epoch == null'"
             rlRun "cat $path |jq -e '.packages[1].version == \"2.8\"'"
             rlRun "cat $path |jq -e '.packages[1].release == \"1.fc$FEDORA_VERSION\"'"
             rlRun "cat $path |jq -e '.packages[1].arch == \"x86_64\"'"
 
             rlRun "cat $path |jq -e '.packages[2].name == \"hello-debuginfo\"'"
-            rlRun "cat $path |jq -e '.packages[2].epoch == 0'"
+            rlRun "cat $path |jq -e '.packages[2].epoch == null'"
             rlRun "cat $path |jq -e '.packages[2].version == \"2.8\"'"
             rlRun "cat $path |jq -e '.packages[2].release == \"1.fc$FEDORA_VERSION\"'"
             rlRun "cat $path |jq -e '.packages[2].arch == \"x86_64\"'"
 
             rlRun "cat $path |jq -e '.packages[3].name == \"hello-debugsource\"'"
-            rlRun "cat $path |jq -e '.packages[3].epoch == 0'"
+            rlRun "cat $path |jq -e '.packages[3].epoch == null'"
             rlRun "cat $path |jq -e '.packages[3].version == \"2.8\"'"
             rlRun "cat $path |jq -e '.packages[3].release == \"1.fc$FEDORA_VERSION\"'"
             rlRun "cat $path |jq -e '.packages[3].arch == \"x86_64\"'"
@@ -101,7 +101,7 @@ END
 
     rlPhaseStartCleanup
         cleanProject "${NAME_PREFIX}TestResultsJson"
-        rlRun "rm -rf $RESULTDIR/*"
+        cleanAction rlRun "rm -rf $RESULTDIR/*"
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-exclusivearch.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-exclusivearch.sh
@@ -33,7 +33,8 @@ rlJournalStart
 
         # This is a more complicated package with `BuildArch: noarch` and
         # ExclusiveArch for subpackages. Test that we don't fail while parsing it
-        rlRun "copr-cli build-distgit ${NAME_PREFIX}ExclusiveArch --name procyon"
+        # TODO: we fail the build actually, https://github.com/fedora-copr/copr/issues/2870
+        #rlRun "copr-cli build-distgit ${NAME_PREFIX}ExclusiveArch --name procyon"
 
         # Test ExcludeArch
         rlRun "copr-cli create ${NAME_PREFIX}ExcludeArch $chroots"
@@ -44,8 +45,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "copr-cli delete ${NAME_PREFIX}ExclusiveArch"
-        rlRun "copr-cli delete ${NAME_PREFIX}ExcludeArch"
+        cleanupAction rlRun "copr-cli delete ${NAME_PREFIX}ExclusiveArch"
+        cleanupAction rlRun "copr-cli delete ${NAME_PREFIX}ExcludeArch"
     rlPhaseEnd
 rlJournalPrintText
 rlJournalEnd

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
@@ -341,8 +341,8 @@ rlJournalStart
         # build the package
         rlRun "copr-cli build-package --name test_package_scm ${NAME_PREFIX}Project6 --timeout 10000 -r $CHROOT" # TODO: timeout not honored
 
-        # create pyp2rpm package
-        rlRun "copr-cli add-package-pypi ${NAME_PREFIX}Project6 --name test_package_pypi --template fedora --packagename motionpaint --pythonversions 3"
+        # create pyp2spec (default) package
+        rlRun "copr-cli add-package-pypi ${NAME_PREFIX}Project6 --name test_package_pypi --template fedora --packagename copr-cli --pythonversions 3"
 
         # build the package
         rlRun "copr-cli build-package --name test_package_pypi ${NAME_PREFIX}Project6 -r $CHROOT"


### PR DESCRIPTION
Mock 5.0 is enforced by the new Copr release, and there's the bootstrap_image feature that can not use "fedora image" for EPEL target chroot

The unspecified `Epoch` tag in spec file is newly evaluated as "null" value in the BuildChrootResults table, and returned as None to end-user (null JSON value).

The default PyPI method is pyp2spec, not pyp2rpm now.  Let's use a package that is easily buildable with pyp2spec (motionpaint doesn't comply with the new licensing format, we could submit PR but that would require a release into PyPI, and ...).

Skip one test related to a ExclusiveArch parsing for now; our ppc64le builders are somewhat broken or non-standard, see #2870.

Several cleanup actions are now wrapped with cleanupAction, so we can keep the intermediate files/projects hanging around with COPR_CLEANUP=false when debugging testsuite failures.