### PR TITLE
packit: use tito to generate "python-copr-common" versions

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,10 @@
 # https://packit.dev/docs/configuration/
 upstream_project_url: https://github.com/fedora-copr/copr.git
 
+srpm_build_deps:
+  - tito
+  - git
+
 packages:
 
   python-copr:
@@ -27,6 +31,13 @@ packages:
     specfile_path: python-copr-common.spec
     files_to_sync:
       - python-copr-common.spec
+    actions:
+      create-archive:
+        - bash -c "tito build --tgz --test -o ."
+        - bash -c "ls -1t ./*.tar.gz | head -n 1"
+      get-current-version:
+        - bash -c "git describe --match python-copr-common-[0-9]* --abbrev=0 HEAD | egrep -o
+          [0-9]+\.[0-9]+"
     upstream_tag_template: python-copr-common-{version}
     upstream_tag_include: "^python-copr-common-.*"
 


### PR DESCRIPTION
Similar thing was done in mock:
https://github.com/rpm-software-management/mock/blob/7222e29f57f83fc7257f8c0015e112e951d9299f/.packit.yaml#L11-L16

Relates: #2884