### PR TITLE
backend: react on staled SSH connections

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -419,7 +419,8 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         self.ssh = SSHConnection(
             user=self.opts.build_user,
             host=self.host.hostname,
-            config_file=self.opts.ssh.builder_config
+            config_file=self.opts.ssh.builder_config,
+            log=self.log,
         )
 
     def _cancel_running_worker(self):

--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -469,7 +469,8 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         with open(self.job.builder_log, 'w') as logfile:
             # We can not use 'max_retries' here because that would concatenate
             # the attempts to the same log file.
-            if self.ssh.run(live_cmd, stdout=logfile, stderr=logfile):
+            if self.ssh.run(live_cmd, stdout=logfile, stderr=logfile,
+                            subprocess_timeout=None):
                 return "{} shouldn't exit != 0".format(live_cmd)
         return None
 

--- a/backend/tests/testlib/__init__.py
+++ b/backend/tests/testlib/__init__.py
@@ -8,7 +8,7 @@ import shutil
 from unittest.mock import MagicMock
 
 from copr_backend.background_worker_build import COMMANDS
-from copr_backend.sshcmd import SSHConnection, SSHConnectionError
+from copr_backend.sshcmd import SSHConnection, SSHConnectionError, DEFAULT_SUBPROCESS_TIMEOUT
 
 
 def minimal_be_config(where, overrides=None):
@@ -154,7 +154,8 @@ class FakeSSHConnection(SSHConnection):
             raise SSHConnectionError("undefined cmd '{}' in FakeSSHConnection"
                                      .format(cmd))
 
-    def run(self, user_command, stdout=None, stderr=None, max_retries=0):
+    def run(self, user_command, stdout=None, stderr=None, max_retries=0,
+            subprocess_timeout=DEFAULT_SUBPROCESS_TIMEOUT):
         """ fake SSHConnection.run() """
         with open(os.devnull, "w") as devnull:
             out = stdout or devnull
@@ -164,7 +165,8 @@ class FakeSSHConnection(SSHConnection):
             err.write(res[2])
             return res[0]
 
-    def run_expensive(self, user_command, max_retries=0):
+    def run_expensive(self, user_command, max_retries=0,
+                      subprocess_timeout=DEFAULT_SUBPROCESS_TIMEOUT):
         """ fake SSHConnection.run_expensive() """
         res = self.get_command(user_command)
         return (res[0], res[1], res[2])
@@ -175,7 +177,8 @@ class FakeSSHConnection(SSHConnection):
     def _full_source_path(self, src):
         return src
 
-    def rsync_download(self, src, dest, logfile=None, max_retries=0):
+    def rsync_download(self, src, dest, logfile=None, max_retries=0,
+                       subprocess_timeout=DEFAULT_SUBPROCESS_TIMEOUT):
         data = os.environ["TEST_DATA_DIRECTORY"]
         trail_slash = src.endswith("/")
         src = os.path.join(data, "build_results", self.resultdir)


### PR DESCRIPTION
All the SSHConnection "public" methods now have subprocess_timeout option.  If the option is set, and the local utility (ssh or rsync) doesn't finish within the specified timeout, SSHConnectionError is raised as in any other connection-issues situation.

The SSHConnection.run() and SSHConnection.run_expensive() methods have the default timeout set to 180s by default.  The reason is that both of those commands are always expected to finish reasonably quick (much less than 10s).  If not, after 180s period we can either expect the builder is dead, or optionally retry.

The timeout detection should help us to cover weird situations like in the issue #2888.  If the remote process is in 'D' state (uninterruptible sleep), we simply kill the ssh client (subprocess) locally.  Subsequent SSHConnectionError handlers are able to close the corresponding Resalloc ticket, and take a new builder.

Relates: #2888