### PR TITLE
all: add "prepare_script" to SCM build method

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -382,6 +382,7 @@ class Commands(object):
             "subdirectory": args.subdirectory,
             "spec": args.spec,
             "scm_type": args.scm_type,
+            "prepare_script": ''.join(args.prepare_script.readlines()) if args.prepare_script else '',
             "source_build_method": args.srpm_build_method,
         }
         return self.process_build(args, self.client.build_proxy.create_from_scm, data)
@@ -794,6 +795,7 @@ class Commands(object):
             "subdirectory": args.subdirectory,
             "spec": args.spec,
             "scm_type": args.scm_type,
+            "prepare_script": ''.join(args.prepare_script.readlines()) if args.prepare_script else '',
             "source_build_method": args.srpm_build_method,
             "max_builds": args.max_builds,
             "webhook_rebuild": ON_OFF_MAP[args.webhook_rebuild],
@@ -1328,6 +1330,8 @@ def setup_parser():
                                         help="relative path from the subdirectory to the .spec file")
     parser_scm_args_parent.add_argument("--type", dest="scm_type", choices=["git", "svn"], default="git",
                                         help="Specify versioning tool. Default is 'git'.")
+    parser_scm_args_parent.add_argument('--prepare-script', type=argparse.FileType('r'),
+                                        help='text file (script) to be used as prepare script for make_srpm method')
     parser_scm_args_parent.add_argument("--method", dest="srpm_build_method", default="rpkg",
                                         choices=["rpkg", "tito", "tito_test", "make_srpm"],
                                         help="Srpm build method. Default is 'rpkg'.")

--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -491,11 +491,13 @@ class BuildsLogic(object):
 
     @classmethod
     def create_new_from_scm(cls, user, copr, scm_type, clone_url,
-                            committish='', subdirectory='', spec='', srpm_build_method='rpkg',
+                            committish='', subdirectory='', spec='', prepare_script='',
+                            srpm_build_method='rpkg',
                             chroot_names=None, copr_dirname=None, **build_options):
         """
         :type user: models.User
         :type copr: models.Copr
+        :type prepare_script: str
 
         :type chroot_names: List[str]
 
@@ -507,6 +509,7 @@ class BuildsLogic(object):
                                   "committish": committish,
                                   "subdirectory": subdirectory,
                                   "spec": spec,
+                                  "prepare_script": prepare_script,
                                   "srpm_build_method": srpm_build_method})
         return cls.create_new(user, copr, source_type, source_json, chroot_names, copr_dirname=copr_dirname, **build_options)
 

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
@@ -267,6 +267,7 @@ def create_from_scm():
             committish=form.committish.data,
             subdirectory=form.subdirectory.data,
             spec=form.spec.data,
+            prepare_script=form.prepare_script.data,
             srpm_build_method=form.srpm_build_method.data,
             **options,
         )

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/schema.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/schema.py
@@ -120,6 +120,11 @@ scm_type_field = String(
     example="git",
 )
 
+scm_prepare_script = String(
+    description="Script code sourced(!) by shell before running make (only with `make srpm` type)",
+    example="MY_ENV_FOO=hello",
+)
+
 source_build_method_field = String(
     description="https://docs.pagure.org/copr.copr/user_documentation.html#scm",
     example="tito",
@@ -507,6 +512,7 @@ def add_package_parser():
         field2arg("subdirectory", subdirectory_field),
         field2arg("spec", spec_field),
         field2arg("scm_type", scm_type_field),
+        field2arg('prepare_script', scm_prepare_script)
 
         # Rubygems
         field2arg("gem_name", gem_name_field),

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_builds.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_builds.py
@@ -203,6 +203,7 @@ def process_new_build_scm(copr, add_view, url_on_success):
             form.committish.data,
             form.subdirectory.data,
             form.spec.data,
+            form.prepare_script.data,
             form.srpm_build_method.data,
             form.selected_chroots,
             **build_options

--- a/python/copr/v3/proxies/build.py
+++ b/python/copr/v3/proxies/build.py
@@ -181,7 +181,7 @@ class BuildProxy(BaseProxy):
         return munchify(response)
 
     def create_from_scm(self, ownername, projectname, clone_url, committish="", subdirectory="", spec="",
-                        scm_type="git", source_build_method="rpkg", buildopts=None, project_dirname=None):
+                        scm_type="git", prepare_script="", source_build_method="rpkg", buildopts=None, project_dirname=None):
         """
         Create a build from SCM repository
 
@@ -192,6 +192,7 @@ class BuildProxy(BaseProxy):
         :param str subdirectory: path to a subdirectory with package content
         :param str spec: path to spec file, relative to 'subdirectory'
         :param str scm_type:
+        :param str prepare_script:
         :param str source_build_method:
         :param buildopts: http://python-copr.readthedocs.io/en/latest/client_v3/build_options.html
         :param str project_dirname:
@@ -206,6 +207,7 @@ class BuildProxy(BaseProxy):
             "subdirectory": subdirectory,
             "spec": spec,
             "scm_type": scm_type,
+            "prepare_script": prepare_script,
             "source_build_method": source_build_method,
             "project_dirname": project_dirname,
         }


### PR DESCRIPTION
Add a new "prepare_script" option to the SCM method.

It (currently) only works with "make srpm" build type. If specified, we will source(!) the script by the calling shell (bash?) right before `make -f ... srpm`.

This allows to run arbitrary shell commands before `make srpm`. The main usage would be to set environment variables that are honored by the `make srpm` script.

---


This would be my idea for solving https://github.com/fedora-copr/copr/issues/2621

Main problem: it's quite the expert method. The user can provide a shell script that is sourced. Sourcing is already confusing, and may not be understood by the user. Also, copr itself doesn't understand what the script does (but neither does it understand what happens during `make srpm`). Also, the main usage is to set arbitrary environment variables, for which a more specific solution might have better ergonomics. On the other hand, it's very flexible and relatively easy to add.

This is not ready yet. I don't know how to test it, it's certainly broken. This is an RFC.

Also, the web UI will always show the "Prepare Script" field, even if it only works with "make srpm" type.