### PR TITLE
Fix tracebacks from OIDC

### DIFF
--- a/frontend/coprs_frontend/coprs/__init__.py
+++ b/frontend/coprs_frontend/coprs/__init__.py
@@ -119,9 +119,13 @@ app.config["RESTX_INCLUDE_ALL_MODELS"] = True
 app.config["ERROR_INCLUDE_MESSAGE"] = False
 
 
-from coprs.oidc import init_oidc_app
+with app.app_context():
+    setup_log()
 
+
+from coprs.oidc import init_oidc_app
 oidc = init_oidc_app(app)
+
 
 from coprs.views import admin_ns
 from coprs.views.admin_ns import admin_general
@@ -175,8 +179,6 @@ from coprs.views.explore_ns import explore_ns
 from coprs.error_handlers import get_error_handler, RestXErrorHandler
 import coprs.context_processors
 
-with app.app_context():
-    setup_log()
 
 app.register_blueprint(api_ns.api_ns)
 app.register_blueprint(apiv3_ns.apiv3_ns)

--- a/frontend/coprs_frontend/coprs/oidc.py
+++ b/frontend/coprs_frontend/coprs/oidc.py
@@ -17,6 +17,10 @@ def oidc_enabled(config):
     """
     Check whether the config is valid
     """
+    if config.get("OIDC_LOGIN") is False:
+        # OIDC is an optional feature, don't log anything if it is disabled
+        return False
+
     if not is_config_valid(config):
         app.logger.error("OIDC_LOGIN or OIDC_PROVIDER_NAME is empty")
         return False

--- a/frontend/coprs_frontend/coprs/oidc.py
+++ b/frontend/coprs_frontend/coprs/oidc.py
@@ -1,10 +1,8 @@
 """
 OpenId Connect helper functions.
 """
-import logging
 from authlib.integrations.flask_client import OAuth
-
-logger = logging.getLogger(__name__)
+from coprs import app
 
 
 def is_config_valid(config):
@@ -20,23 +18,23 @@ def oidc_enabled(config):
     Check whether the config is valid
     """
     if not is_config_valid(config):
-        logger.error("OIDC_LOGIN or OIDC_PROVIDER_NAME is empty")
+        app.logger.error("OIDC_LOGIN or OIDC_PROVIDER_NAME is empty")
         return False
 
     if not config.get("OIDC_CLIENT"):
-        logger.error("OIDC_CLIENT is empty")
+        app.logger.error("OIDC_CLIENT is empty")
         return False
 
     if not config.get("OIDC_SECRET"):
-        logger.error("OIDC_SECRET is empty")
+        app.logger.error("OIDC_SECRET is empty")
         return False
 
     if not config.get("OIDC_SCOPES"):
-        logger.error("OIDC_SCOPES is empty")
+        app.logger.error("OIDC_SCOPES is empty")
         return False
 
     if not config.get("OIDC_TOKEN_AUTH_METHOD"):
-        logger.warning("OIDC_SCOPES is empty, using default method: client_secret_basic")
+        app.logger.warning("OIDC_SCOPES is empty, using default method: client_secret_basic")
         config["OIDC_TOKEN_AUTH_METHOD"] = "client_secret_basic"
 
     return config.get("OIDC_METADATA") or (


### PR DESCRIPTION
The `oidc.py` has logging statements in case some configuration
options are missing. They traceback with this weird traceback because
they don't use our configured logger from `app`.

    Message: 'OIDC_LOGIN or OIDC_PROVIDER_NAME is empty'
    Arguments: ()
    ERROR:coprs.oidc:OIDC_LOGIN or OIDC_PROVIDER_NAME is empty
    --- Logging error ---
    Traceback (most recent call last):
      File "/usr/lib64/python3.11/logging/__init__.py", line 449, in format
        return self._format(record)
               ^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.11/logging/__init__.py", line 445, in _format
        return self._fmt % values
               ~~~~~~~~~~^~~~~~~~
    KeyError: 'user'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
    ...