### PR TITLE
rpmbuild: use Copr custom macros when parsing the specfile

### DIFF
--- a/rpmbuild/copr_rpmbuild/automation/__init__.py
+++ b/rpmbuild/copr_rpmbuild/automation/__init__.py
@@ -8,14 +8,14 @@ from copr_rpmbuild.automation.srpm_results import SRPMResults
 from copr_rpmbuild.automation.rpm_results import RPMResults
 
 
-def run_automation_tools(task, resultdir, mock_config_file, log):
+def run_automation_tools(task, resultdir, mock_config_file, log, config):
     """
     Iterate over all supported post-build tools (e.g. `fedora-review`,
     `rpmlint`, etc) and run the desired ones for a given task.
     """
     tools = [FedoraReview, SRPMResults, RPMResults]
     for _class in tools:
-        tool = _class(task, resultdir, mock_config_file, log)
+        tool = _class(task, resultdir, mock_config_file, log, config)
         if not tool.enabled:
             continue
         log.info("Running %s tool", tool.__class__.__name__)

--- a/rpmbuild/copr_rpmbuild/automation/base.py
+++ b/rpmbuild/copr_rpmbuild/automation/base.py
@@ -10,13 +10,14 @@ class AutomationTool:
     interface.
     """
 
-    def __init__(self, task, resultdir, mock_config_file, log):
+    def __init__(self, task, resultdir, mock_config_file, log, config):
         self.task = task
         self.resultdir = resultdir
         self.mock_config_file = mock_config_file
         self.log = log
         self.package_name = task["package_name"]
         self.chroot = task["chroot"]
+        self.config = config
 
     @property
     def enabled(self):

--- a/rpmbuild/copr_rpmbuild/automation/srpm_results.py
+++ b/rpmbuild/copr_rpmbuild/automation/srpm_results.py
@@ -8,6 +8,7 @@ import os
 from copr_rpmbuild.automation.base import AutomationTool
 from copr_rpmbuild.helpers import (
     get_rpm_header,
+    macros_for_task,
     locate_srpm,
     locate_spec,
     Spec,
@@ -44,8 +45,9 @@ class SRPMResults(AutomationTool):
         keys = ["name", "epoch", "version", "release",
                 "exclusivearch", "excludearch"]
         try:
+            macros = macros_for_task(self.task, self.config)
             path = locate_spec(self.resultdir)
-            spec = Spec(path)
+            spec = Spec(path, macros)
             return {key: getattr(spec, key) for key in keys}
 
         except Exception:  # pylint: disable=broad-exception-caught

--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -390,12 +390,17 @@ class Spec:
     Wrapper around `specfile.Specfile` to easily access attributes that we need
     """
 
-    def __init__(self, path):
+    def __init__(self, path, macros):
+        # The specfile library expects macros in a certain format otherwise
+        # it tracebacks:
+        # 1. It needs to be a list of tuples, e.g.
+        #    [("fedora", "39"), ("foo", "bar")]
+        # 2. The macros cannot start with %, it needs to be just the names
+        macros = [(k.lstrip("%"), v) for k, v in macros.items()]
+
         try:
             # TODO We want to loop over all name-version chroots and parse the
             # spec values for each of them. For that, we will set dist macros.
-            # It expect tuples like this: [("fedora", "39"), ("foo", "bar")]
-            macros = [("dist", None)]
             self.spec = Specfile(path, macros=macros)
         except TypeError as ex:
             raise RuntimeError("No .spec file") from ex

--- a/rpmbuild/main.py
+++ b/rpmbuild/main.py
@@ -227,7 +227,7 @@ def build_srpm(args, config):
 
     with open(os.path.join(resultdir, 'success'), "w") as success:
         success.write("done")
-    run_automation_tools(task, resultdir, None, log)
+    run_automation_tools(task, resultdir, None, log, config)
 
 
 def build_rpm(args, config):
@@ -268,7 +268,8 @@ def build_rpm(args, config):
         builder = MockBuilder(task, distgit.clone_to, resultdir, config)
         builder.run()
         builder.touch_success_file()
-        run_automation_tools(task, resultdir, builder.mock_config_file, log)
+        run_automation_tools(
+            task, resultdir, builder.mock_config_file, log, config)
     finally:
         builder.archive_configs()
         distgit.cleanup()


### PR DESCRIPTION
Fix #2881

The Copr macros are documented here
https://docs.pagure.org/copr.copr/user_documentation.html#rpm-macros