### PR TITLE
frontend: don't traceback on generating tasks for disabled chroots

### DIFF
--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -172,6 +172,11 @@ def get_build_record(task, for_backend=False):
         })
 
         copr_chroot = CoprChrootsLogic.get_by_name_safe(task.build.copr, task.mock_chroot.name)
+        if not copr_chroot:
+            app.logger.error("The %s chroot is disabled (build %s)",
+                             task.mock_chroot.name, task.build.id)
+            return None
+
         modules = copr_chroot.module_setup_commands
         if modules:
             build_record["modules"] = {'toggle': modules}


### PR DESCRIPTION
This happens in cases like #2904 and infinitely produces the following tracebacks:

    ERROR:coprs:'NoneType' object has no attribute 'module_setup_commands'
    Traceback (most recent call last):
      File "/usr/share/copr/coprs_frontend/coprs/views/backend_ns/backend_general.py", line 175, in get_build_record
        modules = copr_chroot.module_setup_commands
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'NoneType' object has no attribute 'module_setup_commands'