### PR TITLE
frontend: do not display recent builds box on main page

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -356,6 +356,7 @@
     <div class="panel-heading">
       <h3 class="panel-title"> Recent Builds - <a href="{{ url_for('recent_ns.all') }}">View All</a></h3>
     </div>
+    {%- if builds %}
     <div class="list-group">
       {% for build in builds %}
         <a href="{{copr_url('coprs_ns.copr_build', build.copr, build_id=build.id)}}" class="list-group-item">
@@ -380,6 +381,7 @@
         </a>
       {% endfor %}
     </div>
+    {% endif %}
   </div>
 {% endmacro %}
 

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
@@ -91,7 +91,9 @@ def coprs_show(page=1):
     # flask.g.user is none when no user is logged - showing builds from everyone
     # TODO: builds_logic.BuildsLogic.get_recent_tasks(flask.g.user, 5) takes too much time, optimize sql
     # users_builds = builds_logic.BuildsLogic.get_recent_tasks(flask.g.user, 5)
-    users_builds = builds_logic.BuildsLogic.get_recent_tasks(None, 4)
+    # users_builds = builds_logic.BuildsLogic.get_recent_tasks(None, 4)
+    # err - this is all taking so much time, do not display this box on main page
+    users_builds = None
 
     data = builds_logic.BuildsLogic.get_small_graph_data('30min')
 


### PR DESCRIPTION
This is taking so much time. And even when it is cached it is taking down whole server.