### PR TITLE
Collect Fedora Review Logs After Runs

### DIFF
--- a/backend/copr_backend/job.py
+++ b/backend/copr_backend/job.py
@@ -145,6 +145,13 @@ class BuildJob(object):
         return os.path.join(self.results_dir, "builder-live.log")
 
     @property
+    def review_log(self):
+        """
+        The log file from running fedora-review
+        """
+        return os.path.join(self.results_dir, "fedora-review/fedora-review.log")
+
+    @property
     def rsync_log_name(self):
         return "build-{:08d}.rsync.log".format(self.build_id)
 

--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -38,13 +38,14 @@ def cmd_readable(cmd):
     return ' '.join([shlex.quote(part) for part in cmd])
 
 
-def run_cmd(cmd, cwd=".", preexec_fn=None):
+def run_cmd(cmd, cwd=".", preexec_fn=None, env=None):
     """
     Runs given command in a subprocess.
 
     :param list(str) cmd: command to be executed and its arguments
     :param str cwd: In which directory to execute the command
     :param func preexec_fn: a callback invoked before exec in subprocess
+    :param dict env: environment variables to set for process
 
     :raises RuntimeError
     :returns munch.Munch(cmd, stdout, stderr, returncode)
@@ -53,7 +54,7 @@ def run_cmd(cmd, cwd=".", preexec_fn=None):
 
     try:
         process = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, preexec_fn=preexec_fn)
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, preexec_fn=preexec_fn, env=env)
         (stdout, stderr) = process.communicate()
     except OSError as e:
         if e.errno == errno.ENOENT:


### PR DESCRIPTION
This is really hacky and unpleasant. `fedora-review` does not have a way to set a custom log path, and adding one will not be easy. You have to wait for it to have parsed the command line arguments, and by that point it's already expecting to have started logging. See <https://pagure.io/FedoraReview/blob/master/f/src/FedoraReview/settings.py#_44> and its uses for more context.

This PR redirects everything that's looking at `$XDG_CACHE_HOME` into a unique directory per run, then discards everything except the `fedora-review` logs in that directory. I am very open to suggestions of better ways to do this. 

For all its many many faults though, this did work when I tested it locally.

Resolves #2919 