### PR TITLE
frontend: unify naming convention for safe methods

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -40,5 +40,14 @@ normal form. Having numeric primary keys is a convention agreed among team
 members.
 
 
+## Safe, or_none methods
+
+In sake of consistency we have two conventions when naming a method/function
+
+- `*_safe`: Some methods are considered as "safe" in the sense of "safe from exceptions". They
+deal with the exceptions in proper way and/or logs the errors.
+- `*_or_none`: returns the desired output or if object was not found in the database they
+return None.
+
 
 [pep8]: https://www.python.org/dev/peps/pep-0008/

--- a/frontend/coprs_frontend/coprs/logic/coprs_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/coprs_logic.py
@@ -622,7 +622,7 @@ class CoprPermissionsLogic(object):
 
 class CoprDirsLogic(object):
     @classmethod
-    def get_by_copr_safe(cls, copr, dirname):
+    def get_by_copr_or_none(cls, copr, dirname):
         """
         Return _query_ for getting CoprDir by Copr and dirname
         """
@@ -637,7 +637,7 @@ class CoprDirsLogic(object):
         Return CoprDir instance per given Copr instance and dirname.  Raise
         ObjectNotFound if it doesn't exist.
         """
-        coprdir = cls.get_by_copr_safe(copr, dirname)
+        coprdir = cls.get_by_copr_or_none(copr, dirname)
         if not coprdir:
             raise exceptions.ObjectNotFound(
                 "Dirname '{}' doesn't exist in '{}' copr".format(
@@ -669,7 +669,7 @@ class CoprDirsLogic(object):
         submitted.  We don't create the "main" CoprDirs here (those are created
         when a new project is created.
         """
-        copr_dir = cls.get_by_copr_safe(copr, dirname)
+        copr_dir = cls.get_by_copr_or_none(copr, dirname)
         if copr_dir:
             return copr_dir
 
@@ -948,9 +948,17 @@ class CoprChrootsLogic(object):
         return cls.get_by_mock_chroot_id(copr, mc.id)
 
     @classmethod
-    def get_by_name_safe(cls, copr, chroot_name):
+    def get_by_name_or_none(cls, copr, chroot_name):
         """
-        :rtype: models.CoprChroot
+        Get CoprChroot in Copr model by chroot name.
+
+        Args:
+            copr: Copr model
+            chroot_name: str
+
+        Returns:
+            CoprChroot model or None if no such chroot name in given Copr
+             model exists.
         """
         try:
             return cls.get_by_name(copr, chroot_name).one()

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/__init__.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/__init__.py
@@ -123,7 +123,7 @@ def get_copr(ownername=None, projectname=None):
     request = flask.request
     ownername = ownername or request.form.get("ownername") or request.json["ownername"]
     projectname = projectname or request.form.get("projectname") or request.json["projectname"]
-    return ComplexLogic.get_copr_by_owner_safe(ownername, projectname)
+    return ComplexLogic.get_copr_by_owner(ownername, projectname)
 
 
 class Paginator(object):

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_build_chroots.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_build_chroots.py
@@ -19,7 +19,7 @@ def to_dict(build_chroot):
 
 def build_config(build_chroot):
     config = BuildConfigLogic.generate_build_config(build_chroot.build.copr, build_chroot.name)
-    copr_chroot = CoprChrootsLogic.get_by_name_safe(build_chroot.build.copr, build_chroot.name)
+    copr_chroot = CoprChrootsLogic.get_by_name_or_none(build_chroot.build.copr, build_chroot.name)
     dict_data = {
         "repos": config.get("repos"),
         "additional_repos": BuildConfigLogic.generate_additional_repos(copr_chroot),

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
@@ -102,7 +102,7 @@ class GetBuild(Resource):
         Get a build
         Get details for a single Copr build.
         """
-        build = ComplexLogic.get_build_safe(build_id)
+        build = ComplexLogic.get_build(build_id)
         result = to_dict(build)
 
         # Workaround - `marshal_with` needs the input `build_id` to be present
@@ -154,13 +154,13 @@ def get_build_list(ownername, projectname, packagename=None, status=None, **kwar
 
 @apiv3_ns.route("/build/source-chroot/<int:build_id>/", methods=GET)
 def get_source_chroot(build_id):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     return flask.jsonify(to_source_chroot(build))
 
 
 @apiv3_ns.route("/build/source-build-config/<int:build_id>/", methods=GET)
 def get_source_build_config(build_id):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     return flask.jsonify(to_source_build_config(build))
 
 
@@ -169,14 +169,14 @@ def get_build_built_packages(build_id):
     """
     Return built packages (NEVRA dicts) for a given build
     """
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     return flask.jsonify(build.results_dict)
 
 
 @apiv3_ns.route("/build/cancel/<int:build_id>", methods=PUT)
 @api_login_required
 def cancel_build(build_id):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     BuildsLogic.cancel_build(flask.g.user, build)
     db.session.commit()
     return render_build(build)
@@ -396,7 +396,7 @@ def process_creating_new_build(copr, form, create_new_build):
 @apiv3_ns.route("/build/delete/<int:build_id>", methods=DELETE)
 @api_login_required
 def delete_build(build_id):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     build_dict = to_dict(build)
     BuildsLogic.delete_build(flask.g.user, build)
     db.session.commit()

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_project_chroots.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_project_chroots.py
@@ -86,7 +86,7 @@ class ProjectChroot(Resource):
         """
         args = self.parser.parse_args()
         copr = get_copr(args.ownername, args.projectname)
-        chroot = ComplexLogic.get_copr_chroot_safe(copr, args.chrootname)
+        chroot = ComplexLogic.get_copr_chroot(copr, args.chrootname)
         return to_dict(chroot)
 
 
@@ -103,7 +103,7 @@ class BuildConfig(Resource):
         """
         args = self.parser.parse_args()
         copr = get_copr(args.ownername, args.projectname)
-        chroot = ComplexLogic.get_copr_chroot_safe(copr, args.chrootname)
+        chroot = ComplexLogic.get_copr_chroot(copr, args.chrootname)
         if not chroot:
             raise ObjectNotFound('Chroot not found.')
         return to_build_config_dict(chroot)
@@ -116,7 +116,7 @@ def edit_project_chroot(ownername, projectname, chrootname):
     copr = get_copr(ownername, projectname)
     data = rename_fields(get_form_compatible_data(preserve=["additional_modules"]))
     form = forms.ModifyChrootForm(data, meta={'csrf': False})
-    chroot = ComplexLogic.get_copr_chroot_safe(copr, chrootname)
+    chroot = ComplexLogic.get_copr_chroot(copr, chrootname)
 
     if not form.validate_on_submit():
         raise InvalidForm(form)

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_projects.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_projects.py
@@ -70,7 +70,7 @@ def owner2tuple(ownername):
     user = flask.g.user
     group = None
     if ownername[0] == "@":
-        group = ComplexLogic.get_group_by_name_safe(ownername[1:])
+        group = ComplexLogic.get_group_by_name(ownername[1:])
     elif ownername != flask.g.user.name:
         user = UsersLogic.get(ownername).first()
     if not user:

--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -5,7 +5,7 @@ from coprs import models
 from coprs.logic import actions_logic
 from coprs.logic.builds_logic import BuildsLogic
 from coprs.logic.complex_logic import ComplexLogic, BuildConfigLogic
-from coprs.logic.coprs_logic import MockChrootsLogic
+from coprs.logic.coprs_logic import CoprChrootsLogic, MockChrootsLogic
 from coprs.exceptions import CoprHttpException, ObjectNotFound
 from coprs.helpers import streamed_json
 
@@ -81,7 +81,7 @@ def dist_git_upload_completed():
     build_id = flask.request.json.get("build_id")
 
     try:
-        build = ComplexLogic.get_build_safe(build_id)
+        build = ComplexLogic.get_build(build_id)
     except ObjectNotFound:
         return flask.jsonify({"updated": False})
 
@@ -168,7 +168,7 @@ def get_build_record(task, for_backend=False):
         "repo_priority": task.build.copr.repo_priority
     })
 
-    copr_chroot = ComplexLogic.get_copr_chroot_safe(task.build.copr, task.mock_chroot.name)
+    copr_chroot = CoprChrootsLogic.get_by_name_or_none(task.build.copr, task.mock_chroot.name)
     modules = copr_chroot.module_setup_commands
     if modules:
         build_record["modules"] = {'toggle': modules}
@@ -419,7 +419,7 @@ def starting_build():
     data = flask.request.json
 
     try:
-        build = ComplexLogic.get_build_safe(data.get('build_id'))
+        build = ComplexLogic.get_build(data.get('build_id'))
     except ObjectNotFound:
         return flask.jsonify({"can_start": False})
 
@@ -440,7 +440,7 @@ def reschedule_build_chroot():
     chroot = flask.request.json.get("chroot")
 
     try:
-        build = ComplexLogic.get_build_safe(build_id)
+        build = ComplexLogic.get_build(build_id)
     except ObjectNotFound:
         response["result"] = "noop"
         response["msg"] = "Build {} wasn't found".format(build_id)

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_builds.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_builds.py
@@ -33,7 +33,7 @@ from coprs.exceptions import (
 
 @coprs_ns.route("/build/<int:build_id>/")
 def copr_build_redirect(build_id):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     copr = build.copr
     return flask.redirect(helpers.copr_url("coprs_ns.copr_build", copr, build_id=build_id))
 
@@ -53,7 +53,7 @@ def copr_build(copr, build_id):
 
 
 def render_copr_build(build_id, copr):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     return render_template("coprs/detail/build.html", build=build, copr=copr)
 
 
@@ -440,7 +440,7 @@ def copr_new_build_rebuild(copr, build_id):
     view='coprs_ns.copr_new_build'
     url_on_success = helpers.copr_url("coprs_ns.copr_builds", copr)
     def factory(**build_options):
-        source_build = ComplexLogic.get_build_safe(build_id)
+        source_build = ComplexLogic.get_build(build_id)
         BuildsLogic.create_new_from_other_build(
             flask.g.user, copr, source_build,
             chroot_names=form.selected_chroots,
@@ -458,7 +458,7 @@ def copr_new_build_rebuild(copr, build_id):
 @login_required
 @req_with_copr
 def copr_repeat_build(copr, build_id):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     if not flask.g.user.can_build_in(build.copr):
         flask.flash("You are not allowed to repeat this build.")
 
@@ -520,7 +520,7 @@ def process_cancel_build(build):
 @req_with_copr
 def copr_cancel_build(copr, build_id):
     # only the user who ran the build can cancel it
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
     return process_cancel_build(build)
 
 
@@ -530,7 +530,7 @@ def copr_cancel_build(copr, build_id):
                 methods=["POST"])
 @login_required
 def copr_delete_build(username, coprname, build_id):
-    build = ComplexLogic.get_build_safe(build_id)
+    build = ComplexLogic.get_build(build_id)
 
     try:
         builds_logic.BuildsLogic.delete_build(flask.g.user, build)

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_chroots.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_chroots.py
@@ -20,7 +20,7 @@ from coprs.views.coprs_ns import coprs_ns
 @req_with_copr
 def chroot_edit(copr, chrootname):
     """ Route for editing CoprChroot's """
-    chroot = ComplexLogic.get_copr_chroot_safe(copr, chrootname)
+    chroot = ComplexLogic.get_copr_chroot(copr, chrootname)
     form = forms.ChrootForm(buildroot_pkgs=chroot.buildroot_pkgs, repos=chroot.repos,
                             module_toggle=chroot.module_toggle, with_opts=chroot.with_opts,
                             without_opts=chroot.without_opts,
@@ -51,7 +51,7 @@ def render_chroot_edit(form, copr, chroot):
 def chroot_update(copr, chrootname):
     chroot_name = chrootname
     form = forms.ChrootForm()
-    chroot = ComplexLogic.get_copr_chroot_safe(copr, chroot_name)
+    chroot = ComplexLogic.get_copr_chroot(copr, chroot_name)
 
     if not flask.g.user.can_edit(copr):
         raise AccessRestricted(
@@ -102,5 +102,5 @@ def chroot_view_comps(copr, chrootname):
 
 
 def render_chroot_view_comps(copr, chroot_name):
-    chroot = ComplexLogic.get_copr_chroot_safe(copr, chroot_name)
+    chroot = ComplexLogic.get_copr_chroot(copr, chroot_name)
     return Response(chroot.comps or "", mimetype="text/plain; charset=utf-8")

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
@@ -241,7 +241,7 @@ def copr_add(username=None, group_name=None):
     for chroot in MockChrootsLogic.get_multiple(active_only=True):
         comments[chroot.name] = chroot.comment
     if group_name:
-        group = ComplexLogic.get_group_by_name_safe(group_name)
+        group = ComplexLogic.get_group_by_name(group_name)
         return flask.render_template("coprs/group_add.html", form=form, group=group, comments=comments)
     return flask.render_template("coprs/add.html", form=form, comments=comments)
 
@@ -257,7 +257,7 @@ def copr_new(username=None, group_name=None):
     group = None
     redirect = "coprs/add.html"
     if group_name:
-        group = ComplexLogic.get_group_by_name_safe(group_name)
+        group = ComplexLogic.get_group_by_name(group_name)
         redirect = "coprs/group_add.html"
 
     form = forms.CoprFormFactory.create_form_cls(group=group)()
@@ -737,8 +737,8 @@ def process_copr_repositories(copr, on_success):
         raise ValidationError("Ambiguous to what project the chroot belongs")
 
     if not copr:
-        copr = ComplexLogic.get_copr_by_owner_safe(form.ownername.data,
-                                                   form.projectname.data)
+        copr = ComplexLogic.get_copr_by_owner(form.ownername.data,
+                                              form.projectname.data)
     if not flask.g.user.can_edit(copr):
         flask.flash("You don't have access to this page.", "error")
         return flask.redirect(url_for_copr_details(copr))
@@ -766,7 +766,7 @@ def process_copr_repositories(copr, on_success):
 @coprs_ns.route("/id/<copr_id>/createrepo/", methods=["POST"])
 @login_required
 def copr_createrepo(copr_id):
-    copr = ComplexLogic.get_copr_by_id_safe(copr_id)
+    copr = ComplexLogic.get_copr_by_id(copr_id)
     if not flask.g.user.can_edit(copr):
         flask.flash(
             "You are not allowed to recreate repository metadata of copr with id {}.".format(copr_id), "error")
@@ -939,7 +939,7 @@ def render_generate_repo_file(copr_dir, name_release, arch=None):
         owner_name = runtime_dep.owner.name
         if isinstance(runtime_dep.owner, models.Group):
             owner_name = "@{0}".format(owner_name)
-        copr_dep_dir = ComplexLogic.get_copr_dir_safe(owner_name, runtime_dep.name)
+        copr_dep_dir = ComplexLogic.get_copr_dir(owner_name, runtime_dep.name)
         response_content += "\n" + render_repo_template(copr_dep_dir, mock_chroot,
                                                         runtime_dep=dep_idx,
                                                         dependent=copr_dir.copr)

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_packages.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_packages.py
@@ -63,7 +63,7 @@ def copr_packages(copr, page=1):
 @coprs_ns.route("/g/<group_name>/<coprname>/package/<package_name>/")
 @req_with_copr
 def copr_package(copr, package_name):
-    package = ComplexLogic.get_package_safe(copr, package_name)
+    package = ComplexLogic.get_package(copr, package_name)
     return flask.render_template("coprs/detail/package.html", package=package, copr=copr)
 
 @coprs_ns.route("/<username>/<coprname>/package/<package_name>/status_image/last_build.png")
@@ -71,7 +71,7 @@ def copr_package(copr, package_name):
 @req_with_copr
 def copr_package_icon(copr, package_name):
     try:
-        package = ComplexLogic.get_package_safe(copr, package_name)
+        package = ComplexLogic.get_package(copr, package_name)
     except ObjectNotFound:
         return send_file("static/status_images/bad_url.png", mimetype='image/png')
 
@@ -96,7 +96,7 @@ def copr_rebuild_all_packages(copr):
         try:
             packages = []
             for package_name in form.packages.data:
-                packages.append(ComplexLogic.get_package_safe(copr, package_name))
+                packages.append(ComplexLogic.get_package(copr, package_name))
 
             PackagesLogic.batch_build(
                 flask.g.user,
@@ -126,7 +126,7 @@ def copr_rebuild_all_packages(copr):
 @coprs_ns.route("/g/<group_name>/<coprname>/package/<package_name>/rebuild")
 @req_with_copr
 def copr_rebuild_package(copr, package_name):
-    package = ComplexLogic.get_package_safe(copr, package_name)
+    package = ComplexLogic.get_package(copr, package_name)
     data = package.source_json_dict
 
     if package.source_type_text == "scm":
@@ -204,7 +204,7 @@ def copr_new_package(copr, source_type_text):
 @coprs_ns.route("/g/<group_name>/<coprname>/package/<package_name>/edit/<source_type_text>")
 @req_with_copr
 def copr_edit_package(copr, package_name, source_type_text=None, **kwargs):
-    package = ComplexLogic.get_package_safe(copr, package_name)
+    package = ComplexLogic.get_package(copr, package_name)
     data = package.source_json_dict
     data["webhook_rebuild"] = package.webhook_rebuild
     data["chroot_denylist"] = package.chroot_denylist_raw
@@ -311,7 +311,7 @@ def process_save_package(copr, source_type_text, package_name, view, view_method
 @login_required
 @req_with_copr
 def copr_delete_package(copr, package_id):
-    package = ComplexLogic.get_package_by_id_safe(package_id)
+    package = ComplexLogic.get_package_by_id(package_id)
 
     try:
         PackagesLogic.delete_package(flask.g.user, package)

--- a/frontend/coprs_frontend/coprs/views/groups_ns/groups_general.py
+++ b/frontend/coprs_frontend/coprs/views/groups_ns/groups_general.py
@@ -65,7 +65,7 @@ def activate_group(fas_group):
 @groups_ns.route("/g/<group_name>/coprs/", defaults={"page": 1})
 @groups_ns.route("/g/<group_name>/coprs/<int:page>")
 def list_projects_by_group(group_name, page=1):
-    group = ComplexLogic.get_group_by_name_safe(group_name)
+    group = ComplexLogic.get_group_by_name(group_name)
 
     pinned = [pin.copr for pin in PinnedCoprsLogic.get_by_group_id(group.id)] if page == 1 else []
     query = CoprsLogic.get_multiple_by_group_id(group.id)

--- a/frontend/coprs_frontend/coprs/views/misc.py
+++ b/frontend/coprs_frontend/coprs/views/misc.py
@@ -238,10 +238,10 @@ def req_with_copr(f):
         coprname = kwargs.pop("coprname")
         if "group_name" in kwargs:
             group_name = kwargs.pop("group_name")
-            copr = ComplexLogic.get_group_copr_safe(group_name, coprname, with_mock_chroots=True)
+            copr = ComplexLogic.get_group_copr(group_name, coprname, with_mock_chroots=True)
         else:
             username = kwargs.pop("username")
-            copr = ComplexLogic.get_copr_safe(username, coprname, with_mock_chroots=True)
+            copr = ComplexLogic.get_copr(username, coprname, with_mock_chroots=True)
         return f(copr, **kwargs)
     return wrapper
 
@@ -254,7 +254,7 @@ def req_with_copr_dir(f):
         else:
             ownername = kwargs.pop("username")
         copr_dirname = kwargs.pop("copr_dirname")
-        copr_dir = ComplexLogic.get_copr_dir_safe(ownername, copr_dirname)
+        copr_dir = ComplexLogic.get_copr_dir(ownername, copr_dirname)
         return f(copr_dir, **kwargs)
     return wrapper
 

--- a/frontend/coprs_frontend/coprs/views/user_ns/user_general.py
+++ b/frontend/coprs_frontend/coprs/views/user_ns/user_general.py
@@ -49,7 +49,7 @@ def delete_data():
 @user_ns.route("/customize-pinned/<group_name>")
 @login_required
 def pinned_projects(group_name=None):
-    owner = flask.g.user if not group_name else ComplexLogic.get_group_by_name_safe(group_name)
+    owner = flask.g.user if not group_name else ComplexLogic.get_group_by_name(group_name)
     return render_pinned_projects(owner)
 
 
@@ -76,7 +76,7 @@ def render_pinned_projects(owner, form=None):
 @user_ns.route("/customize-pinned/<group_name>", methods=["POST"])
 @login_required
 def pinned_projects_post(group_name=None):
-    owner = flask.g.user if not group_name else ComplexLogic.get_group_by_name_safe(group_name)
+    owner = flask.g.user if not group_name else ComplexLogic.get_group_by_name(group_name)
     url_on_success = helpers.owner_url(owner)
     return process_pinned_projects_post(owner, url_on_success)
 

--- a/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
+++ b/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
@@ -51,7 +51,7 @@ def copr_id_and_uuid_required(route):
 
         copr_id = kwargs.pop('copr_id')
         try:
-            copr = ComplexLogic.get_copr_by_id_safe(copr_id)
+            copr = ComplexLogic.get_copr_by_id(copr_id)
         except ObjectNotFound:
             return "PROJECT_NOT_FOUND\n", 404
 
@@ -71,7 +71,7 @@ def package_name_required(route):
 
         package_name = kwargs.pop('package_name')
         try:
-            package = ComplexLogic.get_package_safe(copr, package_name)
+            package = ComplexLogic.get_package(copr, package_name)
         except ObjectNotFound:
             return "PACKAGE_NOT_FOUND\n", 404
 
@@ -85,7 +85,7 @@ def package_name_required(route):
 def webhooks_bitbucket_push(copr_id, uuid, pkg_name: Optional[str] = None):
     # For the documentation of the data we receive see:
     # https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html
-    copr = ComplexLogic.get_copr_by_id_safe(copr_id)
+    copr = ComplexLogic.get_copr_by_id(copr_id)
     if copr.webhook_secret != uuid:
         raise AccessRestricted("This webhook is not valid")
 
@@ -128,7 +128,7 @@ def webhooks_git_push(copr_id: int, uuid, pkg_name: Optional[str] = None):
         return "OK", 200
     # For the documentation of the data we receive see:
     # https://developer.github.com/v3/activity/events/types/#pushevent
-    copr = ComplexLogic.get_copr_by_id_safe(copr_id)
+    copr = ComplexLogic.get_copr_by_id(copr_id)
     if copr.webhook_secret != uuid:
         raise AccessRestricted("This webhook is not valid")
 
@@ -175,7 +175,7 @@ def webhooks_git_push(copr_id: int, uuid, pkg_name: Optional[str] = None):
 def webhooks_gitlab_push(copr_id: int, uuid, pkg_name: Optional[str] = None):
     # For the documentation of the data we receive see:
     # https://gitlab.com/help/user/project/integrations/webhooks#events
-    copr = ComplexLogic.get_copr_by_id_safe(copr_id)
+    copr = ComplexLogic.get_copr_by_id(copr_id)
     if copr.webhook_secret != uuid:
         raise AccessRestricted("This webhook is not valid")
 
@@ -267,7 +267,7 @@ def webhooks_coprdir_custom(ownername, dirname, uuid, package_name):
         return "PROJECT_NOT_FOUND\n", 404
 
     try:
-        package = ComplexLogic.get_package_safe(copr, package_name)
+        package = ComplexLogic.get_package(copr, package_name)
     except ObjectNotFound:
         return "PACKAGE_NOT_FOUND\n", 404
 

--- a/frontend/coprs_frontend/pagure_events.py
+++ b/frontend/coprs_frontend/pagure_events.py
@@ -51,7 +51,7 @@ class ScmPackage(object):
         self.committish = self.source_json_dict.get('committish') or ''
         self.subdirectory = self.source_json_dict.get('subdirectory') or ''
 
-        self.package = ComplexLogic.get_package_by_id_safe(db_row.id)
+        self.package = ComplexLogic.get_package_by_id(db_row.id)
         self.copr = self.package.copr
 
     def build(self, source_dict_update, copr_dir, update_callback,

--- a/frontend/coprs_frontend/tests/test_logic/test_complex_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_complex_logic.py
@@ -233,15 +233,15 @@ class TestProjectForking(CoprsTestCase):
     def test_copr_by_repo_safe(self, f_users, f_coprs, f_mock_chroots, f_builds,
                                f_db):
 
-        assert ComplexLogic.get_copr_by_repo_safe("xxx") == None
-        assert ComplexLogic.get_copr_by_repo_safe("copr://") == None
-        assert ComplexLogic.get_copr_by_repo_safe("copr://a/b/c") == None
+        assert ComplexLogic.get_copr_by_repo("xxx") is None
+        assert ComplexLogic.get_copr_by_repo("copr://") is None
+        assert ComplexLogic.get_copr_by_repo("copr://a/b/c") is None
 
-        assert ComplexLogic.get_copr_by_repo_safe("copr://user1/foocopr") != None
+        assert ComplexLogic.get_copr_by_repo("copr://user1/foocopr") is not None
 
         # we could fix these in future
-        assert ComplexLogic.get_copr_by_repo_safe("copr:///user1/foocopr") == None
-        assert ComplexLogic.get_copr_by_repo_safe("copr://user1//foocopr") == None
+        assert ComplexLogic.get_copr_by_repo("copr:///user1/foocopr") is None
+        assert ComplexLogic.get_copr_by_repo("copr://user1//foocopr") is None
 
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_builds",
                              "f_db")


### PR DESCRIPTION
Originally, safe methods were considered as methods raising ObjectNotFound for API (mainly with session.one() method). Now methods which returns None or ignores the error completely are also considered as "safe".

For the sake of consistency:
- *_or_none -> returns None if object was not found in the database
- *_safe -> methods that ignores error completely (they basically logs and/or are safe from exceptions)

and renaming some of the current safe methods to normal ones that aren't safe by the new rules