### PR TITLE
Explicitly depend on python3-six

### DIFF
--- a/common/python-copr-common.spec
+++ b/common/python-copr-common.spec
@@ -36,6 +36,7 @@ BuildRequires: python-setuptools
 BuildRequires: python-pytest
 BuildRequires: python-mock
 BuildRequires: python-requests
+BuildRequires: python-six
 %endif
 
 %if %{with python3}
@@ -43,6 +44,7 @@ BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: python3-pytest
 BuildRequires: python3-requests
+BuildRequires: python3-six
 %endif
 
 %global _description\


### PR DESCRIPTION
~~This means that python-copr-common is no longer compatible with Python 2 and EPEL 7, but we stay compatible with Python 3.6 on EL8+.~~

~~If we ever want make it compatible with EL7, we should even there use the Python 3 (python36) stack.~~

Just adding python-six into BuildRequires.