### PR TITLE
frontend: show recent copr builds on homepage as opt-in

### DIFF
--- a/frontend/coprs_frontend/config/copr.conf
+++ b/frontend/coprs_frontend/config/copr.conf
@@ -183,6 +183,10 @@ HIDE_IMPORT_LOG_AFTER_DAYS = 14
 #    "tags": ["extra_powerful"],
 #EXTRA_BUILDCHROOT_TAGS = []
 
+# Set this to True if you want to see the last 4 builds listed on the Copr
+# homepage (this is useful for rather smaller Copr instances with not so many
+# builds in database, otherwise implying rather expensive SQL queries).
+#RECENT_BUILDS_ON_FRONTPAGE = False
 
 #############################
 ##### DEBUGGING Section #####

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -179,6 +179,8 @@ class Config(object):
 
     EXTRA_BUILDCHROOT_TAGS = []
 
+    RECENT_BUILDS_ON_FRONTPAGE = False
+
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
@@ -91,9 +91,12 @@ def coprs_show(page=1):
     # flask.g.user is none when no user is logged - showing builds from everyone
     # TODO: builds_logic.BuildsLogic.get_recent_tasks(flask.g.user, 5) takes too much time, optimize sql
     # users_builds = builds_logic.BuildsLogic.get_recent_tasks(flask.g.user, 5)
-    # users_builds = builds_logic.BuildsLogic.get_recent_tasks(None, 4)
-    # err - this is all taking so much time, do not display this box on main page
+
     users_builds = None
+    if app.config["RECENT_BUILDS_ON_FRONTPAGE"]:
+        # this is typically taking too much time, display this box on main page
+        # only if explicitly opted-in
+        users_builds = builds_logic.BuildsLogic.get_recent_tasks(None, 4)
 
     data = builds_logic.BuildsLogic.get_small_graph_data('30min')
 


### PR DESCRIPTION
This is still useful for the Red Hat Internal Copr instance.