### PR TITLE
Improve the fallback for generating GPG keys

### DIFF
--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -167,7 +167,7 @@ def sign_rpms_in_dir(username, projectname, path, chroot, opts, log):
     try:
         get_pubkey(username, projectname, log, opts.sign_domain)
     except CoprSignNoKeyError:
-        create_user_keys(username, projectname, opts)
+        create_user_keys(username, projectname, opts, try_indefinitely=True)
 
     errors = []  # tuples (rpm_filepath, exception)
     for rpm in rpm_list:
@@ -185,7 +185,7 @@ def sign_rpms_in_dir(username, projectname, path, chroot, opts, log):
                             .format([err[0] for err in errors]))
 
 
-def create_user_keys(username, projectname, opts):
+def create_user_keys(username, projectname, opts, try_indefinitely=False):
     """
     Generate a new key-pair at sign host
 
@@ -204,7 +204,7 @@ def create_user_keys(username, projectname, opts):
     keygen_url = "http://{}/gen_key".format(opts.keygen_host)
     query = dict(url=keygen_url, data=data, method="post")
     try:
-        request = SafeRequest(log=log)
+        request = SafeRequest(log=log, try_indefinitely=try_indefinitely)
         response = request.send(**query)
     except Exception as e:
         raise CoprKeygenRequestError(


### PR DESCRIPTION
Fix #2911
Fix #2942

When frontend is creating a new project, it creates an action to generate GPG keys. This may fail because of a temporary keygen downtime or network issues.

Once a SRPM is built, we try to use the GPG key and it doesn't exist, there is a fallback, trying to generate the key again. We can try longer.

To trigger this fallback, you can do:

    docker-compose stop keygen-httpd
    copr create test-srpm-key --chroot fedora-38-x86_64
    copr buildscm --clone-url ... test-srpm-key
    # Wait few minutes until the action fails
    docker-compose start keygen-httpd