### PR TITLE
backend: worker to not call keygen for source builds

### DIFF
--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -154,10 +154,6 @@ def sign_rpms_in_dir(username, projectname, path, chroot, opts, log):
     :raises: :py:class:`backend.exceptions.CoprSignError` failed to sign at least one package
     """
 
-    if chroot == 'srpm-builds':
-        log.info("Source builds are not signed")
-        return
-
     rpm_list = [
         os.path.join(path, filename)
         for filename in os.listdir(path)


### PR DESCRIPTION
In the commit d87321b4d6deb22211521db099760fb2fa560311 we skipped the "signing" job itself, but the problem also happens for downloading pubkey from copr-keygen.

Complements: d87321b4d6deb22211521db099760fb2fa560311
Fixes: #2942