### PR TITLE
backend: self-identify the resalloc resource in logs

### DIFF
--- a/backend/tests/test_vm_alloc.py
+++ b/backend/tests/test_vm_alloc.py
@@ -24,6 +24,15 @@ def test_ticket(_rcon):
     assert host.check_ready()
     assert host.hostname == "1.1.1.1"
 
+    host.ticket.output = (
+        "---\n"
+        "host: 1.2.3.4\n"
+        "name: copr_pool_123456\n"
+    )
+    assert host.check_ready()
+    assert host.hostname == "1.2.3.4"
+    assert host.name == "copr_pool_123456"
+
     host.ticket.closed = True
     with pytest.raises(RemoteHostAllocationTerminated):
         assert host.check_ready()


### PR DESCRIPTION
If the `cmd_new` (pools.yaml config) commands returns a YAML-formatted output, try to parse 'host' and 'name' fields.  The 'name' in particular should match the RESALLOC_NAME.