### PR TITLE
frontend: make alembic working on F39+

### DIFF
--- a/frontend/coprs_frontend/alembic/env.py
+++ b/frontend/coprs_frontend/alembic/env.py
@@ -1,3 +1,5 @@
+import sys
+import os
 from alembic import context
 from logging.config import fileConfig
 
@@ -13,13 +15,11 @@ fileConfig(config.config_file_name)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-import sys
-import os
 
 # alembic doesn't include cwd by default
 sys.path.append(os.getcwd())
 
-from coprs import db
+from coprs import app, db  # pylint: disable=wrong-import-position
 target_metadata = db.metadata
 
 # other values from the config, defined by the needs of env.py,
@@ -66,7 +66,8 @@ def run_migrations_online():
     finally:
         connection.close()
 
-if context.is_offline_mode():
-    run_migrations_offline()
-else:
-    run_migrations_online()
+with app.app_context():
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()

--- a/frontend/coprs_frontend/alembic/versions/4d06318043d3_add_buildchroot_id_and_coprchroot_id.py
+++ b/frontend/coprs_frontend/alembic/versions/4d06318043d3_add_buildchroot_id_and_coprchroot_id.py
@@ -10,11 +10,12 @@ import time
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.orm import declarative_base
 
 revision = '4d06318043d3'
 down_revision = '6f83ea2ba416'
 
-Base = sa.ext.declarative.declarative_base()
+Base = declarative_base()
 
 FIRST_TIME = time.time()
 

--- a/frontend/coprs_frontend/alembic/versions/65a172e3f102_unquote_counter_stat_urls.py
+++ b/frontend/coprs_frontend/alembic/versions/65a172e3f102_unquote_counter_stat_urls.py
@@ -6,9 +6,13 @@ Revises: 004a017535dc
 Create Date: 2022-09-14 23:28:35.890110
 """
 
+import os
+import sys
 import sqlalchemy as sa
 from alembic import op
-from coprs.models import CounterStat
+
+sys.path.append(os.getcwd())
+from coprs.models import CounterStat  # pylint: disable=wrong-import-position
 
 
 revision = '65a172e3f102'


### PR DESCRIPTION
All the migrations need to have correct path set, if something from copr_frontend needs to be loaded.

The `env.py` Base needs to be loaded differently with the new Flask-SQLAlchemy version on F39.