### PR TITLE
frontend/oidc: add OIDC_UNIQUE_PREFERRED_USERNAMES

### DIFF
--- a/frontend/coprs_frontend/config/copr.conf
+++ b/frontend/coprs_frontend/config/copr.conf
@@ -160,6 +160,21 @@ HIDE_IMPORT_LOG_AFTER_DAYS = 14
 # OIDC_SCOPES = "" # e.g. "openid username profile email"
 # OIDC_TOKEN_AUTH_METHOD="client_secret_post" # possible: client_secret_post, client_secret_basic, none
 
+# The "claim" (for our purposes: a piece of information in the
+# UserInfo returned by an OIDC provider) to use as a unique
+# username.  There are two supported values:
+#
+#  - "username" (the default): a non-standard Ipsilon extension
+#    that provides unique user names.
+#
+#  - "preferred_username": a claim that is specified in the OpenID
+#    Connect standard, but one that the standard forbids Relying
+#    Parties from using for this purpose since they are not
+#    guaranteed to be unique.  This option is offered regardless,
+#    since oftentimes this claim is unique to a specific user in
+#    practice.
+# OIDC_USERNAME_CLAIM = "username"
+
 # We have supported two types of OIDC client register
 # 1. dynamic register
 # 2. static register

--- a/frontend/coprs_frontend/coprs/auth.py
+++ b/frontend/coprs_frontend/coprs/auth.py
@@ -11,6 +11,7 @@ from coprs import oid
 from coprs import app
 from coprs.exceptions import CoprHttpException, AccessRestricted
 from coprs.logic.users_logic import UsersLogic
+from coprs.oidc import oidc_username_from_userinfo
 
 
 class UserAuth:
@@ -391,8 +392,9 @@ class OpenIDConnect:
 
         zoneinfo = userinfo['zoneinfo'] if 'zoneinfo' in userinfo \
             and userinfo['zoneinfo'] else None
+        username = oidc_username_from_userinfo(app.config, userinfo)
 
-        user = UserAuth.get_or_create_user(userinfo['username'], userinfo['email'], zoneinfo)
+        user = UserAuth.get_or_create_user(username, userinfo['email'], zoneinfo)
         GroupAuth.update_user_groups(user, OpenIDConnect.groups_from_userinfo(userinfo))
         return user
 

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -175,6 +175,21 @@ class Config(object):
     # OIDC is opt-in
     OIDC_LOGIN = False
 
+    # The "claim" (for our purposes: a piece of information in the
+    # UserInfo returned by an OIDC provider) to use as a unique
+    # username.  There are two supported values:
+    #
+    #  - "username" (the default): a non-standard Ipsilon extension
+    #    that provides unique user names.
+    #
+    #  - "preferred_username": a claim that is specified in the OpenID
+    #    Connect standard, but one that the standard forbids Relying
+    #    Parties from using for this purpose since they are not
+    #    guaranteed to be unique.  This option is offered regardless,
+    #    since oftentimes this claim is unique to a specific user in
+    #    practice.
+    OIDC_USERNAME_CLAIM = "username"
+
     PACKAGES_COUNT = False
 
     EXTRA_BUILDCHROOT_TAGS = []

--- a/frontend/coprs_frontend/coprs/oidc.py
+++ b/frontend/coprs_frontend/coprs/oidc.py
@@ -25,17 +25,10 @@ def oidc_enabled(config):
         app.logger.error("OIDC_LOGIN or OIDC_PROVIDER_NAME is empty")
         return False
 
-    if not config.get("OIDC_CLIENT"):
-        app.logger.error("OIDC_CLIENT is empty")
-        return False
-
-    if not config.get("OIDC_SECRET"):
-        app.logger.error("OIDC_SECRET is empty")
-        return False
-
-    if not config.get("OIDC_SCOPES"):
-        app.logger.error("OIDC_SCOPES is empty")
-        return False
+    for key in ["OIDC_CLIENT", "OIDC_SECRET", "OIDC_SCOPES"]:
+        if not config.get(key):
+            app.logger.error("%s is empty", key)
+            return False
 
     if not config.get("OIDC_TOKEN_AUTH_METHOD"):
         app.logger.warning("OIDC_SCOPES is empty, using default method: client_secret_basic")

--- a/frontend/coprs_frontend/coprs/views/misc.py
+++ b/frontend/coprs_frontend/coprs/views/misc.py
@@ -17,7 +17,7 @@ from coprs.logic.users_logic import UsersLogic
 from coprs.exceptions import ObjectNotFound
 from coprs.measure import checkpoint_start
 from coprs.auth import FedoraAccounts, UserAuth, OpenIDConnect
-from coprs.oidc import oidc_enabled
+from coprs.oidc import oidc_enabled, oidc_username_from_userinfo
 from coprs import oidc
 
 @app.before_request
@@ -115,7 +115,7 @@ def oidc_auth():
     oidc.copr.authorize_access_token()
     userinfo = oidc.copr.userinfo()
     user = OpenIDConnect.user_from_userinfo(userinfo)
-    flask.session["oidc"] = userinfo['username']
+    flask.session["oidc"] = oidc_username_from_userinfo(app.config, userinfo)
     return do_create_or_login(user)
 
 


### PR DESCRIPTION
The current OpenID Connect code assumes the existence of a non-standard field in the UserInfo returned by the provider, limiting the ability to use non-Ipsilon OIDC providers; however, the standard forbids using corresponding standardised field (preferred_username) as a unique user identifier, a property on which Copr relies.

This commit adds a fall back path to the OIDC code that will use preferred_username anyway if the administrator asserts that the values will be unique in practice with a new configuration option.  The upshot of this change is that administrators can now use OIDC providers like Gitea/Forgejo.

Fixes #3008.