### PR TITLE
Copr community is moving from IRC to Matrix

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,7 +31,7 @@ The main subsections of this wiki:
 Communication
 -------------
 
-Copr is discussed on #fedora-buildsys on libera.chat
+Copr is discussed on `Fedora Build System Matrix channel <https://matrix.to/#/#buildsys:fedoraproject.org>`_.
 
 Copr also has a mailing list for discussion: copr-devel@lists.fedorahosted.org `(signup) <https://fedorahosted.org/mailman/listinfo/copr-devel>`_ `(archives) <https://lists.fedorahosted.org/archives/list/copr-devel@lists.fedorahosted.org/>`_
 

--- a/frontend/coprs_frontend/coprs/templates/contact_us.html
+++ b/frontend/coprs_frontend/coprs/templates/contact_us.html
@@ -1,6 +1,6 @@
 <dt><h3>Contact us</h3></dt>
 <dd>
   <ul>
-    <li> <a href="https://web.libera.chat">#fedora-buildsys @ libera.chat</a> </li>
+    <li> <a href="https://matrix.to/#/#buildsys:fedoraproject.org">Fedora Build System on Matrix</a> </li>
   </ul>
 </dd>

--- a/python/docs/index.rst
+++ b/python/docs/index.rst
@@ -19,7 +19,7 @@ Contact
 
 If you have any questions, please contact us:
 
-    - IRC: #fedora-buildsys@libera.chat
+    - `on Matrix <https://matrix.to/#/#buildsys:fedoraproject.org>`_
     - mailing list: copr-devel@lists.fedorahosted.org
       [`signup <https://fedorahosted.org/mailman/listinfo/copr-devel>`_]
       [`archives <https://lists.fedorahosted.org/pipermail/copr-devel/>`_]


### PR DESCRIPTION
This is because of the IRC <-> Matrix bridge isn't working: https://communityblog.fedoraproject.org/matrix-to-libera-chat-irc-bridge-unavailable/

And it seems that Fedora teams are advised to move (certainly Fedora Infra team, corresponding meetings, etc. is):
https://pagure.io/fedora-infrastructure/issue/11460

Resolves: #3006
Complements: #3047