### PR TITLE
fix race condition when creating new record for repo stat counter

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/stat_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/stat_logic.py
@@ -40,23 +40,17 @@ class CounterStatLogic(object):
         """
         try:
             csl = CounterStatLogic.get(name).one()
-            csl.counter = CounterStat.counter + count
-            db.session.add(csl)
         except NoResultFound:
             try:
                 csl = CounterStatLogic.add(name, counter_type)
-                csl.counter = count
                 db.session.add(csl)
                 db.session.commit()
-                db.session.refresh(csl)
             except IntegrityError:
                 # race condition - someone was faster
-                # try again first block
-                csl = CounterStatLogic.get(name).one()
-                csl.counter = CounterStat.counter + count
-                db.session.add(csl)
-
-        return csl
+                pass
+        db.session.query(CounterStat).filter(CounterStat.name==name).\
+            update({"counter": CounterStat.counter + count})
+        db.session.commit()
 
     @classmethod
     def get_copr_repo_dl_stat(cls, copr):


### PR DESCRIPTION
Previously we claimed that this method does commit. But it did just add() - and that does not commit. We do a commit now. And during a commit we check for integrity error. If that happens that means somebody inserted it just second ago. So lets try read again.

Fixes: #3073