### PR TITLE
docker: increment fedora images to 39

### DIFF
--- a/build_aux/Containerfile.unittest
+++ b/build_aux/Containerfile.unittest
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM fedora:39
 
 RUN dnf update -y && dnf install python-pytest-cov copr-dist-git rpmdevtools python3-copr copr-cli dnf-plugins-core -y
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:39
 MAINTAINER copr-devel@lists.fedorahosted.org
 
 ARG ADDITIONAL_COPR_REPOSITORIES="@copr/copr-dev"
@@ -46,8 +46,7 @@ RUN setcap cap_net_raw,cap_net_admin+p /usr/bin/ping
 RUN ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -q
 
 # setup root user
-RUN echo 'root:passwd' | chpasswd && \
-    mkdir /root/.ssh && chmod 700 /root /root/.ssh
+RUN echo 'root:passwd' | chpasswd && chmod 700 /root /root/.ssh
 
 # setup copr user
 RUN set -x ; \

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:39
 MAINTAINER copr-devel@lists.fedorahosted.org
 
 ARG ADDITIONAL_COPR_REPOSITORIES="@copr/copr-dev"

--- a/docker/distgit/Dockerfile
+++ b/docker/distgit/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:39
 MAINTAINER copr-devel@lists.fedorahosted.org
 
 ARG ADDITIONAL_COPR_REPOSITORIES="@copr/copr-dev"

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:39
 MAINTAINER copr-devel@lists.fedorahosted.org
 
 ARG ADDITIONAL_COPR_REPOSITORIES="@copr/copr-dev"

--- a/docker/keygen/Dockerfile
+++ b/docker/keygen/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:39
 
 MAINTAINER copr-devel@lists.fedorahosted.org
 

--- a/docker/resalloc/Dockerfile
+++ b/docker/resalloc/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37
+FROM registry.fedoraproject.org/fedora:39
 MAINTAINER copr-devel@lists.fedorahosted.org
 
 # Deployment instructions are described here


### PR DESCRIPTION
We have centos7 images for postgres and nginx which are fairly old images - should we e.g. build our own in quay with rocky linux 9?

Fixes #2945