### PR TITLE
Messaging: Set the agent_name, usernames and groups properties

### DIFF
--- a/messaging/copr_messaging/private/hierarchy.py
+++ b/messaging/copr_messaging/private/hierarchy.py
@@ -159,6 +159,19 @@ class _BuildMessage(_CoprProjectMessage):
             release=release,
         )
 
+    @property
+    def usernames(self):
+        """
+        List of usernames that are affected by the action that caused this message.
+
+        Those users will be notified by FMN if they chose to receive their notifications.
+        """
+        usernames = [self.submitter, self.body.get("owner")]
+        # filter out nones and groups and deduplicate
+        usernames = set(u for u in usernames if isinstance(u, str) and not u.startswith("@"))
+        # return it sorted
+        return list(sorted(usernames))
+
 
 class _BuildChrootMessage(_BuildMessage):
     @property

--- a/messaging/copr_messaging/private/hierarchy.py
+++ b/messaging/copr_messaging/private/hierarchy.py
@@ -160,6 +160,15 @@ class _BuildMessage(_CoprProjectMessage):
         )
 
     @property
+    def submitter(self):
+        """The username of the person who submitted the build."""
+        username = self._raw_submitter
+        if isinstance(username, str) and ":" in username:
+            # This is namespaced, such as github.com:foobar
+            return None
+        return username
+
+    @property
     def usernames(self):
         """
         List of usernames that are affected by the action that caused this message.

--- a/messaging/copr_messaging/private/schema_old.py
+++ b/messaging/copr_messaging/private/schema_old.py
@@ -129,8 +129,8 @@ class _PreFMBuildMessage(_BuildChrootMessage):
         return self.body.get('pkg')
 
     @property
-    def submitter(self):
-        """The username of the person who submitted the build."""
+    def _raw_submitter(self):
+        """The username of the person who submitted the build. May be namespaced."""
         return self.body.get('user')
 
     def _evr(self):

--- a/messaging/copr_messaging/private/schema_old.py
+++ b/messaging/copr_messaging/private/schema_old.py
@@ -128,6 +128,11 @@ class _PreFMBuildMessage(_BuildChrootMessage):
     def package_name(self):
         return self.body.get('pkg')
 
+    @property
+    def submitter(self):
+        """The username of the person who submitted the build."""
+        return self.body.get('user')
+
     def _evr(self):
         evr = self.body.get('version')
         if not evr:

--- a/messaging/copr_messaging/private/schema_stomp_old.py
+++ b/messaging/copr_messaging/private/schema_stomp_old.py
@@ -139,3 +139,8 @@ class _OldStompChrootMessage(_BuildChrootMessage):
     def package_name(self):
         name, _, _, _ = self._nevr()
         return name
+
+    @property
+    def submitter(self):
+        """The username of the person who submitted the build."""
+        return self.body.get('submitter')

--- a/messaging/copr_messaging/private/schema_stomp_old.py
+++ b/messaging/copr_messaging/private/schema_stomp_old.py
@@ -141,6 +141,6 @@ class _OldStompChrootMessage(_BuildChrootMessage):
         return name
 
     @property
-    def submitter(self):
-        """The username of the person who submitted the build."""
+    def _raw_submitter(self):
+        """The username of the person who submitted the build. May be namespaced."""
         return self.body.get('submitter')

--- a/messaging/copr_messaging/schema.py
+++ b/messaging/copr_messaging/schema.py
@@ -46,6 +46,15 @@ class BuildChrootEnded(_BuildChrootMessage):
             self.status,
         )
 
+    @property
+    def agent_name(self):
+        """The username who caused the action that generated this message."""
+        # The canceled status can be caused by the submitter but also any other
+        # that has build or admin access. To be safe we don't set it as the
+        # agent_name.
+        # The other statuses are not caused by the user who started the build
+        return None
+
 
 class BuildChrootStarted(_BuildChrootMessage):
     """
@@ -57,6 +66,11 @@ class BuildChrootStarted(_BuildChrootMessage):
             super(BuildChrootStarted, self)._str_prefix(),
             self.chroot,
         )
+
+    @property
+    def agent_name(self):
+        """The username who caused the action that generated this message."""
+        return self.submitter
 
 
 class BuildChrootStartedV1(_PreFMBuildMessage, BuildChrootStarted):

--- a/messaging/copr_messaging/tests/test_schema.py
+++ b/messaging/copr_messaging/tests/test_schema.py
@@ -112,6 +112,12 @@ class BuildChrootStartedV1Test(unittest.TestCase):
         message = self.msg_class(body=self.fedmsg_message["msg"])
         assert message.agent_name == "churchyard"
 
+    def test_agent_name_namespaced(self):
+        body = copy.deepcopy(self.fedmsg_message["msg"])
+        body["user"] = "github.com:churchyard"
+        message = self.msg_class(body=body)
+        assert message.agent_name is None
+
     def test_usernames(self):
         message = self.msg_class(body=self.fedmsg_message["msg"])
         assert message.usernames == ["churchyard"]

--- a/messaging/copr_messaging/tests/test_schema.py
+++ b/messaging/copr_messaging/tests/test_schema.py
@@ -108,6 +108,14 @@ class BuildChrootStartedV1Test(unittest.TestCase):
         assert message.package_release == '1.fc31'
         assert message.package_epoch is None
 
+    def test_agent_name(self):
+        message = self.msg_class(body=self.fedmsg_message["msg"])
+        assert message.agent_name == "churchyard"
+
+    def test_usernames(self):
+        message = self.msg_class(body=self.fedmsg_message["msg"])
+        assert message.usernames == ["churchyard"]
+
 
 class BuildChrootEndedV1Test(BuildChrootStartedV1Test):
     msg_class = schema.BuildChrootEndedV1
@@ -150,6 +158,21 @@ class BuildChrootEndedV1Test(BuildChrootStartedV1Test):
         assert message.package_release == '1.fc30'
         assert message.package_epoch is None
 
+    def test_agent_name(self):
+        message = self.msg_class(body=self.fedmsg_message["msg"])
+        assert message.agent_name is None
+
+    def test_agent_name_canceled(self):
+        body = copy.deepcopy(self.fedmsg_message["msg"])
+        body["status"] = 2
+        message = self.msg_class(body=body)
+        # The submitter isn't the only one that can cancel a build.
+        assert message.agent_name is None
+
+    def test_usernames(self):
+        message = self.msg_class(body=self.fedmsg_message["msg"])
+        assert message.usernames == ["kbaig"]
+
 
 class BuildChrootStartedV1DontUseTest(BuildChrootStartedV1Test):
     msg_class = schema.BuildChrootStartedV1DontUse
@@ -191,6 +214,14 @@ class BuildChrootStartedV1DontUseTest(BuildChrootStartedV1Test):
         assert message.package_version == "20190626_1356"
         assert message.package_release == "0"
         assert message.package_epoch == '10'
+
+    def test_agent_name(self):
+        message = self.msg_class(body=self.fedmsg_message["msg"])
+        assert message.agent_name == "praiskup"
+
+    def test_usernames(self):
+        message = self.msg_class(body=self.fedmsg_message["msg"])
+        assert message.usernames == ["praiskup"]
 
 
 class BuildChrootStompOldStartTest(unittest.TestCase):


### PR DESCRIPTION
This sets a few properties that are standard in Fedora Messaging schemas and will allow notifications to be emitted by FMN.