### PR TITLE
cli: dont check dirname presence in action_build

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -325,7 +325,14 @@ class Commands(object):
         # Before we start uploading potentially large source RPM file, make sure
         # that the user has valid credentials and can build in the project.
         self.client.build_proxy.check_before_build(
-            username, projectname, project_dirname, buildopts)
+            ownername=username,
+            projectname=projectname,
+            # documentation says user can create directory with copr build, but
+            # /build/check-before-build endpoint checks for presence of this
+            # dirname even before creating it in this check.
+            project_dirname=None,
+            buildopts=buildopts,
+        )
 
         builds = []
         for pkg in args.pkgs:

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
@@ -228,7 +228,7 @@ def check_before_build():
     copr = get_copr()
 
     # Raises an exception if CoprDir doesn't exist
-    if data["project_dirname"]:
+    if data.get("project_dirname"):
         CoprDirsLogic.get_by_copr(copr, data["project_dirname"])
 
     # Permissions check


### PR DESCRIPTION
Copr build <projectname:dirname> should according to documentation create the dirname if does not exists, but the early check check_before_build in action_build actually runs /build/check-before-build endpoint even before the <projectname:dirname> has a chance to be created, thus complains about non-existent dirname.
Passing only projectname to the check should be enough for the check as is since the /build/check-before-build is called once more after dirname creation.

Fixes #2786