### PR TITLE
backend, dist-git, frontend, keygen: keep logs 6 weeks instead of 13

### DIFF
--- a/backend/conf/logrotate/copr-backend
+++ b/backend/conf/logrotate/copr-backend
@@ -2,7 +2,7 @@
 
 /var/log/copr-backend/*.log {
     weekly
-    rotate 13
+    rotate 6
     copytruncate
     compress
     notifempty
@@ -12,7 +12,7 @@
 
 /var/log/copr-backend/workers/worker-*.log {
     weekly
-    rotate 13
+    rotate 6
     copytruncate
     compress
     notifempty

--- a/dist-git/conf/logrotate
+++ b/dist-git/conf/logrotate
@@ -2,7 +2,7 @@
 
 /var/log/copr-dist-git/*.log {
     weekly
-    rotate 13
+    rotate 6
     copytruncate
     compress
     notifempty

--- a/frontend/conf/logrotate
+++ b/frontend/conf/logrotate
@@ -2,7 +2,7 @@
 
 /var/log/copr-frontend/*.log {
     weekly
-    rotate 13
+    rotate 6
     copytruncate
     compress
     notifempty

--- a/keygen/configs/logrotate
+++ b/keygen/configs/logrotate
@@ -1,6 +1,6 @@
 /var/log/copr-keygen/*.log {
     weekly
-    rotate 13
+    rotate 6
     copytruncate
     compress
     notifempty


### PR DESCRIPTION
The log files consume a lot of storage (7G Fedora Copr backend).  We probably never analyzed older logs than 6 weeks, so lets shorten the "keep" period.

Fixes: #2944