### PR TITLE
common: use 'copr-common/<version>' as http user agent

### DIFF
--- a/common/copr_common/request.py
+++ b/common/copr_common/request.py
@@ -4,6 +4,7 @@ Common Copr code for dealing with HTTP requests
 
 import json
 import time
+import pkg_resources
 from requests import get, post, put, RequestException
 
 
@@ -17,6 +18,13 @@ class SafeRequest:
 
     # Prolong the sleep time before asking frontend again
     SLEEP_INCREMENT_TIME = 5
+
+    # Use package name and version for the user agent
+    package_name = 'copr-common'
+    user_agent = {
+        'name': package_name,
+        'version': pkg_resources.require(package_name)[0].version
+    }
 
     def __init__(self, auth=None, log=None, try_indefinitely=False, timeout=2 * 60):
         self.auth = auth
@@ -50,7 +58,10 @@ class SafeRequest:
                                              **kwargs)
 
     def _send_request(self, url, method, data=None, **kwargs):
-        headers = {"content-type": "application/json"}
+        headers = {
+            "content-type": "application/json",
+            "User-Agent": "{name}/{version}".format(**SafeRequest.user_agent),
+        }
         auth = ("user", self.auth) if self.auth else None
 
         try:


### PR DESCRIPTION
When copr retrieves an SRPM from a URL it uses a `User-Agent` string of the form `python-requests/2.28.2`, being the default provided by the Python 'requests' library.

Unfortunately my shared hosting provider has started rejecting requests using this user agent string because it is associated with bots performing a de facto DOS attack on the server.

Arguably this frustrating balancing act for the web server host is not copr's fault. However, it feels like providing a more application-specific user agent string would, apart from working around this problem, be a good idea in its own right and give web hosts an accurate indication of the nature of the automated requests they receive.

This patch provides a user agent string of the form `copr-common/<version>` and works around the problem described.

I imagine this is a property that could conceivably be configurable.

### Before

```
[03/Feb/2024:21:47:31 +0000] "GET /...-2.fc39.src.rpm HTTP/1.1" 403 5712 "-" "python-requests/2.28.2"
```
Leading to:

```
Network error: Request client error on https://...-2.fc39.src.rpm: 403 Forbidden
```

### After
```
[03/Feb/2024:21:52:00 +0000] "GET /...-2.fc39.src.rpm HTTP/1.1" 200 568069 "-" "copr-common/0.21.1.dev0"
```

### Risks

This may be a move in a game of whack-a-mole if on another set of web servers this shifts the agent string from an allowed to disallowed match. However, the approach may have merits in its own right.