### PR TITLE
doc: add video tutorial page

### DIFF
--- a/doc/user_documentation.rst
+++ b/doc/user_documentation.rst
@@ -24,7 +24,8 @@ If you don't have an SRPM yet, see https://rpm-packaging-guide.github.io/ for in
 Tutorial
 --------
 
-Refer to :ref:`screenshots_tutorial` for guidance on interacting with `copr.fedoraproject.org <http://copr.fedoraproject.org/>`_.
+Refer to :ref:`screenshots_tutorial` or :ref:`video_tutorial` for
+guidance on interacting with `copr.fedoraproject.org <http://copr.fedoraproject.org/>`_.
 
 
 How to enable copr repository?

--- a/doc/video_tutorial.rst
+++ b/doc/video_tutorial.rst
@@ -1,0 +1,29 @@
+:orphan:
+
+.. _video_tutorial:
+
+Video tutorial
+==============
+
+Collection of video tutorials on how to use Copr.
+
+Using Copr CLI
+--------------
+
+This tutorial will show you how to use ``copr-cli``.
+
+1. `Authentication <https://www.youtube.com/watch?v=SUjPjYbB84Y>`_
+2. `Project management <https://www.youtube.com/watch?v=BTP-dYehC34>`_
+3. `Submitting builds <https://www.youtube.com/watch?v=7dYs5hUaA1Y>`_
+4. Introspecting builds
+5. Building from PyPI, RubyGems, and others
+6. Custom build method
+7. Working with packages
+
+Workflows
+---------
+
+Copr-related packaging workflows:
+
+- `Submitting Copr packages into Fedora <https://www.youtube.com/watch?v=w3e3W00KqVI>`_
+- Packit and automatic rebuilds


### PR DESCRIPTION
My Saturday hike got canceled and I got the whole weekend for myself, so I started working on one of the things that used to be in my _compass_ for a long time - a series of short videos about Copr.

I listed them on a documentation page so they can be easily linked together and teased what topics will get covered in the future.

What do you think?

At this moment, the videos are marked on youtube as "unlisted" and haven't shared them anywhere yet in case you had some critical feedback. Also, they don't have pretty thumbnails yet.