### PR TITLE
rpmbuild: no Jinja-vars in config_opts keys

### DIFF
--- a/rpmbuild/mock-custom-build.cfg.j2
+++ b/rpmbuild/mock-custom-build.cfg.j2
@@ -18,7 +18,7 @@ config_opts['macros']['{{ key }}'] = '{{ value }}'
 {%- endfor %}
 
 {% if repos %}
-config_opts[f"{config_opts.package_manager}.conf"] += """
+config_opts["dnf.conf"] += """
 {% for repo in repos %}
 [{{ repo["id"] }}]
 name='{{ repo["name"] }}'

--- a/rpmbuild/mock.cfg.j2
+++ b/rpmbuild/mock.cfg.j2
@@ -40,7 +40,7 @@ config_opts['module_setup_commands'] = {{ modules |pprint }}
 {%- endif %}
 
 {% if repos %}
-config_opts[f"{config_opts.package_manager}.conf"] += """
+config_opts["dnf.conf"] += """
 {% for repo in repos %}
 [{{ repo["id"] }}]
 name='{{ repo["name"] }}'


### PR DESCRIPTION
The Jinja statements are only expanded in the values of the config_opts dictionary, not in the keys. The new mock-core-configs version 40.2 contains a Jinja condition in the package_manager value. Therefore, we cannot simply use it as a key in config_opts.

Since yum.conf and dnf.conf are aliases (starting from Mock 2.1), and dnf5.conf (starting from Mock 5.0+), we can avoid using the variable as a key entirely.

Relates: https://github.com/rpm-software-management/mock/commit/5d620ad326d
Relates: https://github.com/rpm-software-management/mock/pull/1332

Fixes: #3146 