### PR TITLE
common: fix misleading warning for non-copr users

### DIFF
--- a/common/copr_common/background_worker.py
+++ b/common/copr_common/background_worker.py
@@ -30,7 +30,7 @@ class BackgroundWorker:
         self.log.addHandler(logging.StreamHandler())
 
         if os.getuid() == 0:
-            self.log.error("this needs to be run as 'copr' user")
+            self.log.error("running as UID=0 (root), probably not expected")
             sys.exit(1)
 
         self.opts = None


### PR DESCRIPTION
E.g. resalloc agent spawner now uses this library, and corresponding deployments there's no 'copr' user.