### PR TITLE
Actually assign fallback value from self.username

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -210,7 +210,7 @@ class Commands(object):
             owner = m.group(2)
             if not owner:
                 try:
-                    self.username
+                    owner = self.username
                 except:
                     log.error("Wrong chroot path format '%s'. Use the full "
                               "'<owner>/<project>/<chroot>' format or "
@@ -621,7 +621,7 @@ class Commands(object):
         username = args.username
         if not username:
             try:
-                self.username
+                username = self.username
             except:
                 log.error("The 'username|@groupname' not specified.  Either "
                           "specify it, or authenticate to list your projects.")


### PR DESCRIPTION
Several places that intend to use self.username did not actually assign the return value. This fixes `copr list` without  username argument.