### PR TITLE
backend: use correct (renamed) _discard_running_worker

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -900,7 +900,7 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         CancellableThreadTask(
             _keep_alive,
             self._cancel_task_check_request,
-            self._cancel_running_worker,
+            self._discard_running_worker,
             check_period=CANCEL_CHECK_PERIOD,
         ).run()
         if self.canceled:


### PR DESCRIPTION
Complements: 7afb039b2a7818723ce9c6ed10d27bd922a1b3d8