### PR TITLE
frontend: run the check for anitya updates script under app context

### DIFF
--- a/frontend/coprs_frontend/run/check_for_anitya_version_updates.py
+++ b/frontend/coprs_frontend/run/check_for_anitya_version_updates.py
@@ -237,6 +237,7 @@ def main():
 
 if __name__ == '__main__':
     try:
-        main()
+        with app.app_context():
+            main()
     except Exception as e:
         log.exception(str(e))


### PR DESCRIPTION
Fix #3056

We are seeing the following error in the logs:

    RuntimeError: Working outside of application context.
    This typically means that you attempted to use functionality that needed
    the current application. To solve this, set up an application context
    with app.app_context(). See the documentation for more information.