### PR TITLE
common: fix chroot_to_branch default

### DIFF
--- a/common/copr_common/helpers.py
+++ b/common/copr_common/helpers.py
@@ -43,6 +43,7 @@ def chroot_to_branch(chroot):
     Get a git branch name from chroot. Follow the fedora naming standard.
     """
     name, version, _arch = chroot.rsplit("-", 2)
+    abbrev = name
     if name == "fedora":
         if version == "rawhide":
             return "master"


### PR DESCRIPTION
For non-special-cases, we want to use the `name-` part from chroot name as the abbreviation.  Fixes traceback:

$ ./manage.py create_chroot epel-7-i386
INFO:__main__:Running command: ./manage.py create_chroot epel-7-i386 Traceback (most recent call last):
  File "/copr/coprs_frontend/./manage.py", line 143, in <module>
    app.cli()
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/copr/coprs_frontend/./manage.py", line 109, in wrapper
    sys.exit(bool(function(*args, **kwargs)))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/copr/coprs_frontend/commands/create_chroot.py", line 68, in create_chroot
    return create_chroot_function(chroot_names, branch, activated, comment)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/copr/coprs_frontend/commands/create_chroot.py", line 33, in create_chroot_function
    branch = chroot_to_branch(chroot_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/copr/common/copr_common/helpers.py", line 57, in chroot_to_branch
    return "{}{}".format(abbrev, version)
                         ^^^^^^

Complements: fc73a835add