### PR TITLE
frontend: update download stats footnote

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/overview.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/overview.html
@@ -82,7 +82,7 @@
       {% endfor %}
       </tbody>
     </table>
-    <p class="text-muted"><small> * Total number of packages downloaded in the last seven days.</small></p>
+    <p class="text-muted"><small> * Total number of downloaded packages.</small></p>
 
     {% if copr.repos_list %}
     <h3>External Repository List</h3>


### PR DESCRIPTION
Fix #2601

The number used to show download stats within the last week but currently we only show total downloads.