### PR TITLE
backend, rpmbuild: remove static methods from tests

### DIFF
--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -67,8 +67,7 @@ class TestHelpers(object):
         split = ("ed", "1.14.2", "5.fc30", "2", "x86_64")
         assert format_filename(zero_epoch=True, *split) == "ed-2:1.14.2-5.fc30.x86_64"
 
-    @staticmethod
-    def test_walk_limited():
+    def test_walk_limited(self):
         paths = [
             "user1/foo/srpm-builds/111/foo-1.src.rpm",
             "user1/foo/srpm-builds/111/foo-1.log",
@@ -109,8 +108,7 @@ class TestHelpers(object):
             assert files == []
 
 
-    @staticmethod
-    def test_recursive_copy_and_link_rpms():
+    def test_recursive_copy_and_link_rpms(self):
 
         def _write(filename, contents):
             with open(filename, "w", encoding="utf-8") as fd:

--- a/backend/tests/test_modifyrepo.py
+++ b/backend/tests/test_modifyrepo.py
@@ -375,9 +375,8 @@ class TestModifyRepo(object):
         call = popen.call_args_list[0]
         assert call[0][0] == ['copr-repo', '--batched', '/some/dir', '--add', 'xxx']
 
-    @staticmethod
     @mock.patch("copr_backend.helpers.subprocess.Popen")
-    def test_copr_repo_do_stat(popen):
+    def test_copr_repo_do_stat(self, popen):
         """ do_stat=True adds --do-stat option """
         popen.return_value.communicate.return_value = ("", "")
         popen.return_value.returncode = 0
@@ -488,9 +487,8 @@ class TestModifyRepo(object):
         task_dict = self.redis.hgetall(keys[0])
         assert task_dict["status"] == "success"
 
-    @staticmethod
     @mock.patch("copr_backend.helpers.subprocess.Popen")
-    def test_copr_repo_rpms_to_remove_in_call(popen):
+    def test_copr_repo_rpms_to_remove_in_call(self, popen):
         """ check that list of rpm files to be removed is added to copr-repo call """
         popen.return_value.communicate.return_value = ("","")
         popen.return_value.returncode = 0

--- a/backend/tests/test_sign.py
+++ b/backend/tests/test_sign.py
@@ -151,10 +151,9 @@ class TestSign(object):
         with pytest.raises(CoprSignError):
             _sign_one(fake_path, self.usermail, "sha256", MagicMock())
 
-    @staticmethod
     @mock.patch("copr_backend.sign.time.sleep")
     @mock.patch("copr_backend.sign.Popen")
-    def test_call_sign_bin_repeatedly(mc_popen, _sleep):
+    def test_call_sign_bin_repeatedly(self, mc_popen, _sleep):
         """
         Test that we attempt to run /bin/sign multiple times if it returns
         non-zero exit status

--- a/rpmbuild/tests/test_distgit_client.py
+++ b/rpmbuild/tests/test_distgit_client.py
@@ -197,8 +197,7 @@ class TestDistGitDownload(object):
             _load_config(modified_dir)
             assert "Duplicate prefix /redhat" in str(err)
 
-    @staticmethod
-    def test_no_git_config():
+    def test_no_git_config(self):
         with pytest.raises(RuntimeError) as err:
             _detect_clone_url()
             assert "is not a git" in str(err)


### PR DESCRIPTION
Fix #3197
Fix RHBZ 2272042
Fix RHBZ 2272044

There is no reason for those methods to be static. Seems mostly like a typo.