### PR TITLE
beaker-tests-sanity: migrate test repositories from Pagure to GitHub

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/bz1457888.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/bz1457888.sh
@@ -51,7 +51,7 @@ rlJournalStart
         # The Bug 1457888 specifically concerns the Mock SCM method
         # but since it was deprecated and even removed from the code,
         # we are going to use its successor for this test
-        rlRun "copr-cli buildscm ${NAME_PREFIX}TestBug1457888 --clone-url https://pagure.io/module-macros.git --spec module-macros.spec" 0
+        rlRun "copr-cli buildscm ${NAME_PREFIX}TestBug1457888 --clone-url https://github.com/fedora-copr/copr-test-module-macros.git  --spec module-macros.spec" 0
         rlRun "copr-cli delete ${NAME_PREFIX}TestBug1457888"
     rlPhaseEnd
 

--- a/beaker-tests/Sanity/copr-cli-basic-operations/helpers
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/helpers
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-HELLO=https://pagure.io/copr/copr-test-sources/raw/master/f/hello-2.8-1.src.rpm
-EVIL_HELLO=https://pagure.io/copr/copr-test-sources/raw/master/f/evilhello-2.8-2.src.rpm
-SRPM_BUILDTAG=https://pagure.io/copr/copr-test-sources/raw/master/f/buildtag-0-0.src.rpm
-COPR_HELLO_GIT=https://pagure.io/copr/copr-hello.git
-COPR_HELLO_2_GIT=https://pagure.io/copr/copr-hello-2.git
+HELLO=https://github.com/fedora-copr/copr-test-sources/raw/main/hello-2.8-1.src.rpm
+EVIL_HELLO=https://github.com/fedora-copr/copr-test-sources/raw/main/evilhello-2.8-2.src.rpm
+SRPM_BUILDTAG=https://github.com/fedora-copr/copr-test-sources/raw/main/buildtag-0-0.src.rpm
+COPR_HELLO_GIT=https://github.com/fedora-copr/copr-test-hello.git
+COPR_HELLO_2_GIT=https://github.com/fedora-copr/copr-test-hello-2.git
 DNF_COPR_ID=tested-copr
 
 parse_build_id()

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-exclusivearch.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-exclusivearch.sh
@@ -8,7 +8,7 @@ HERE=$(dirname "$(realpath "$0")")
 source "$HERE/config"
 source "$HERE/helpers"
 
-exclusive_arch_package=https://pagure.io/copr/copr-test-sources/raw/master/f/exclusivearch-test-1-1.src.rpm
+exclusive_arch_package=https://github.com/fedora-copr/copr-test-sources/raw/main/exclusivearch-test-1-1.src.rpm
 
 rlJournalStart
     rlPhaseStartSetup

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-makesrpm-fail.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-makesrpm-fail.sh
@@ -21,7 +21,7 @@ rlJournalStart
         rlRun "copr-cli create $PROJECT --chroot $CHROOT" 0
 
         rlRun -s "copr-cli buildscm --method make_srpm \
---clone-url https://pagure.io/copr/copr-hello.git \
+--clone-url https://github.com/fedora-copr/copr-test-hello.git \
 --commit noluck-make-srpm $PROJECT" 4
         rlRun parse_build_id
         output=$(get_srpm_builder_log | grep "^stderr output$")

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
@@ -110,7 +110,7 @@ rlJournalStart
         # try to install - FAIL ( public project metadata not updated)
         rlRun "dnf install -y hello" 1
         # build 2nd package ( requires 1st package for the build)
-        rlRun "copr-cli build ${NAME_PREFIX}Project2 https://pagure.io/copr/copr-test-sources/raw/master/f/hello_beaker_test_2-0.0.1-1.src.rpm"
+        rlRun "copr-cli build ${NAME_PREFIX}Project2 https://github.com/fedora-copr/copr-test-sources/raw/main/hello_beaker_test_2-0.0.1-1.src.rpm"
         # try to install - FAIL ( public project metadata not updated)
         rlRun "dnf install -y hello_beaker_test_2" 1
         # re-enabling metadata generation


### PR DESCRIPTION
There was some temporary networking issue when I was running beaker tests. The issue seems to have resolved itself within an hour but I migrated all our test repositories to GitHub anyway.

Please note that I changed some of the repository names so that they all have a `copr-test-` prefix.