### PR TITLE
cli: remove dependency on simplejson

### DIFF
--- a/cli/copr-cli.spec
+++ b/cli/copr-cli.spec
@@ -32,7 +32,6 @@ BuildRequires: util-linux
 %if %{with python3}
 Requires:      python3-copr >= %min_python_copr_version
 Requires:      python3-jinja2
-Requires:      python3-simplejson
 Requires:      python3-humanize
 Requires:      python3-koji
 
@@ -46,12 +45,10 @@ BuildRequires: python3-humanize
 BuildRequires: python3-pytest
 BuildRequires: python3-responses
 BuildRequires: python3-setuptools
-BuildRequires: python3-simplejson
 BuildRequires: python3-munch
 %else
 Requires:      python-copr >= %min_python_copr_version
 Requires:      python-jinja2
-Requires:      python-simplejson
 Requires:      python-humanize
 
 BuildRequires: pytest
@@ -62,7 +59,6 @@ BuildRequires: python-humanize
 BuildRequires: python-mock
 BuildRequires: python2-responses
 BuildRequires: python-setuptools
-BuildRequires: python-simplejson
 BuildRequires: python-munch
 %endif
 

--- a/cli/copr_cli/util.py
+++ b/cli/copr_cli/util.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
+import json
 import humanize
-import simplejson
 
 
 try:
@@ -66,4 +66,4 @@ def serializable(result):
 
 
 def json_dumps(result):
-    return simplejson.dumps(serializable(result), indent=4, sort_keys=True, for_json=True)
+    return json.dumps(serializable(result), indent=4, sort_keys=True)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -16,7 +16,6 @@ This part is a command line interface to use copr."""
 requires = [
     'copr',
     'humanize',
-    'simplejson',
     'jinja2',
     'setuptools',
 ]


### PR DESCRIPTION
Fix #2539

The output of `json.dumps` and `simplejson.dumps` is equivalent for listing builds and listing packages. I am removing the `for_json` parameter because there is not equivalent. However it shouldn't make any difference because:

> If for_json is true (not the default), objects with a for_json()
> method will use the return value of that method for encoding as JSON
> instead of the object.

We don't define any `for_json` methods for our objects.