### PR TITLE
beaker-tests-sanity: add -s so we can parse the build ID

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-build-batches.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-build-batches.sh
@@ -39,12 +39,12 @@ rlJournalStart
         rlRun parse_build_id
         BUILD_ID_1=$BUILD_ID
 
-        rlRun "copr-cli build $PROJECT $HELLO --with-build-id $BUILD_ID_1 --nowait"
+        rlRun -s "copr-cli build $PROJECT $HELLO --with-build-id $BUILD_ID_1 --nowait"
         rlRun parse_build_id
         BUILD_ID_2=$BUILD_ID
 
         rlRun "copr-cli add-package-scm $PROJECT --name testpkg --clone-url $COPR_HELLO_GIT --method tito"
-        rlRun "copr-cli build-package $PROJECT --name testpkg --after-build-id $BUILD_ID_1 --nowait"
+        rlRun -s "copr-cli build-package $PROJECT --name testpkg --after-build-id $BUILD_ID_1 --nowait"
         rlRun parse_build_id
         BUILD_ID_3=$BUILD_ID
 


### PR DESCRIPTION
Otherwise we are running watch-build on the same build three times:

    copr watch-build 2918252 2918252 2918252