### PR TITLE
frontend: eol-emails deterministic

### DIFF
--- a/frontend/coprs_frontend/coprs/mail.py
+++ b/frontend/coprs_frontend/coprs/mail.py
@@ -111,9 +111,10 @@ class OutdatedChrootMessage(Message):
         for copr, chroots in groups:
             block = "Project: {0}\n".format(copr.full_name)
             block += "Remaining time:\n"
-            for days, chroots in groupby(chroots, lambda x: x.delete_after_days):
+            for days, chroots in groupby(sorted(chroots, key=lambda x: x.delete_after_days),
+                                         lambda x: x.delete_after_days):
                 block += "  {0} days:\n".format(days)
-                for chroots in batched(chroots, 4):
+                for chroots in batched(sorted(chroots, key=lambda x: x.name), 4):
                     block += "    {0}\n".format(" ".join([x.name for x in chroots]))
 
             url = helpers.fix_protocol_for_frontend(

--- a/frontend/coprs_frontend/tests/test_mail.py
+++ b/frontend/coprs_frontend/tests/test_mail.py
@@ -67,8 +67,12 @@ class TestMail(CoprsTestCase):
         now = datetime.datetime.now()
         for chroot in chroots:
             # 7 days = 6d, 23h, 59m, ...
-            chroot.delete_after = now + datetime.timedelta(days=7 + 1)
-        chroots[3].delete_after = now + datetime.timedelta(days=5 + 1)
+            if chroot.copr.full_name == "user2/barcopr" \
+                    and chroot.name == "fedora-18-x86_64":
+                # special-case one chroot to make a message variation
+                chroot.delete_after = now + datetime.timedelta(days=5 + 1)
+            else:
+                chroot.delete_after = now + datetime.timedelta(days=7 + 1)
 
         app.config["SERVER_NAME"] = "localhost"
         app.config["DELETE_EOL_CHROOTS_AFTER"] = 123
@@ -94,7 +98,7 @@ class TestMail(CoprsTestCase):
                             "Project: user2/foocopr\n"
                             "Remaining time:\n"
                             "  7 days:\n"
-                            "    fedora-17-x86_64 fedora-17-i386 fedora-30-x86_64 fedora-31-x86_64\n"
+                            "    fedora-17-i386 fedora-17-x86_64 fedora-30-x86_64 fedora-31-x86_64\n"
                             "    fedora-32-x86_64 fedora-33-x86_64 fedora-34-x86_64 fedora-35-x86_64\n"
                             "    fedora-36-x86_64 fedora-37-x86_64\n"
                             "https://localhost/coprs/user2/foocopr/repositories/\n\n"


### PR DESCRIPTION
The list of chroots in the e-mail is now sorted deterministically; we report the soonest expiring first, then we sort alphabetically.

The testsuite is more deterministic too, `chroot[3]` was pointing to an unexpected chroot on my box.