### PR TITLE
alembic: fix a migration syntax warning

### DIFF
--- a/frontend/coprs_frontend/alembic/versions/65a172e3f102_unquote_counter_stat_urls.py
+++ b/frontend/coprs_frontend/alembic/versions/65a172e3f102_unquote_counter_stat_urls.py
@@ -22,7 +22,7 @@ down_revision = '004a017535dc'
 def upgrade():
     session = sa.orm.sessionmaker(bind=op.get_bind())()
     rows = (session.query(CounterStat)
-            .filter(CounterStat.name.like("%\%40%"))
+            .filter(CounterStat.name.like("%\\%40%"))
             .all())
 
     for stat in rows:


### PR DESCRIPTION
The SyntaxWarning appeared in every `alembic up/down..` call.

In [1]: print("%\%40%")
<>:1: SyntaxWarning: invalid escape sequence '\%'
<ipython-input-1-b80c71bbab44>:1: SyntaxWarning: invalid escape sequence '\%'
  print("%\%40%")
%\%40%

In [2]: print("%\\%40%")
%\%40%