### PR TITLE
    frontend: automatically EOL lifeless rolling chroots

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -217,8 +217,8 @@ latex_elements = {
 # [howto/manual]).
 latex_documents = [
     (
-        'index', 'copr.tex', u'Copr Documentation',
-        u'clime \\textless{}clime@redhat.com\\textgreater{}',
+        'index', 'copr.tex', 'Copr Documentation',
+        'Copr Team \\textless{}copr-team@redhat.com\\textgreater{}',
         'manual'
     ),
 ]
@@ -249,8 +249,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (
-        'index', 'Copr', u'Copr Documentation',
-        [u'clime <clime@redhat.com>'],
+        'index', 'Copr', 'Copr Documentation',
+        ['Copr Team <copr-team@redhat.com>'],
         1
     )
 ]
@@ -266,8 +266,8 @@ man_pages = [
 # dir menu entry, description, category)
 texinfo_documents = [
     (
-        'index', 'Copr', u'Copr Documentation',
-        u'clime <clime@redhat.com>', 'COPR',
+        'index', 'Copr', 'Copr Documentation',
+        'Copr Team <copr-team@redhat.com>', 'COPR',
         'RPM Build System',
         'Miscellaneous'
     ),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -281,6 +281,31 @@ rst_epilog = """
 .. |se| raw:: html
 
     </strike>
+
+.. |br| raw:: html
+
+    <br/>
+
+.. |p_red| raw:: html
+
+    <p style="background-color: #f1948a;">
+
+.. |p_end| raw:: html
+
+    </p>
+
+.. |p_yel| raw:: html
+
+    <p style="background-color: #ffbf00;">
+
+.. |p_gre| raw:: html
+
+    <p style="background-color: #80ff00;">
+
+.. |p_gra| raw:: html
+
+    <p style="background-color: #d1e0e0;">
+
 """
 
 # Documents to append as an appendix to all manuals.

--- a/doc/developer_documentation.rst
+++ b/doc/developer_documentation.rst
@@ -40,6 +40,7 @@ Misc
 
    Brainstorming <brainstorming>
    Populate DB <seeddb>
+   Chroot EOL implementation <developer_documentation/eol-logic>
 
 
 The design and diagrams

--- a/doc/developer_documentation/eol-logic.rst
+++ b/doc/developer_documentation/eol-logic.rst
@@ -1,0 +1,48 @@
+.. _eol_logic:
+
+Handling EOL CoprChroot entries
+-------------------------------
+
+There are currently three cases when we schedule a CoprChroot for removal but
+preserve the data for some time to allow users to recover:
+
+    1. User disables the chroot in a project ("unclicks" the checkbox).  We give
+       them 14 days "preservation period" to reverse the decision without
+       forcing them to rebuild everything.
+    2. Copr Admin makes a chroot EOL, e.g., `fedora-38-x86_64` because the
+       Fedora 38 version goes EOL.  We keep the builds for several months, and
+       users can extend the preservation period.
+    3. We disable rolling chroots (e.g., Fedora Rawhide or Fedora ELN) after a
+       reasonable period of inactivity.
+
+There are three database fields used for handling the EOL/preservation policies:
+``CoprChroot.deleted`` (bool), ``CoprChroot.delete_after`` (timestamp),
+and ``MockChroot.is_active`` (bool, 1:N mapped to ``CoprChroot``).  The
+following table describes certain implications behind the logic:
+
+
+.. table:: Logical implications per in-DB chroot state
+
+
+    =========   ============    ======= ====================    =========       ===========
+    is_active   delete_after    deleted e-mail |br|             can build       State && |br| Description
+                                        notifications
+    =========   ============    ======= ====================    =========       ===========
+    yes         yes             yes     no                      no              |p_yel| ``preserved`` manual removal |p_end|
+    yes         no              yes     --                      no              |p_red| ``deleted`` manual removal or rolling removal (or EOL removal, and reactivated) |p_end|
+    yes         yes             no      yes                     yes             |p_yel| ``preserved`` rolling |p_end|
+    yes         no              no      --                      yes             |p_gre| ``active`` normal chroot state |p_end|
+    no          yes             yes     no                      no              |p_yel| ``preserved`` (deleted manualy, then mock chroot EOL or deactivation) |p_end|
+    no          no              yes     --                      no              |p_red| ``deleted`` manually OR rolling deleted, and THEN EOLed/deactivated by Copr admin |p_end|
+    no          yes             no      yes                     no              |p_yel| ``preserved`` mock chroot EOLed by Copr admin |p_end|
+    no          no              no      --                      no              |p_gra| ``deactivated`` deactivated by Copr admin, data preserved |p_end|
+    =========   ============    ======= ====================    =========       ===========
+
+There's also a chroot state ``expired``, which is a special state of
+the ``preserved`` state.  It is "still preserved", but the time for removal is
+already there, namely ``now() >= delete_after``.
+
+Note that when ``e-mail notifications`` are ``yes``, the time for removal has
+come (``now() >= delete_after``) and we **were not** able to send the
+notification e-mail, we **don't** remove the chroot data.  **No unexpected
+removals.**

--- a/doc/how_to_manage_chroots.rst
+++ b/doc/how_to_manage_chroots.rst
@@ -20,6 +20,7 @@ Chroots can be easily managed with these few commands.
     copr-frontend branch-fedora <new-branched-version>
     copr-frontend rawhide-to-release <rawhide-chroot> <newly-created-chroot>
     copr-frontend chroots-template [--template PATH]
+    copr-frontend eol-lifeless-rolling-chroots
 
 However, `enablement process upon Fedora branching <#branching-process>`_ and also
 `chroot deactivation when Fedora reaches it's EOL phase <#eol-deactivation-process>`_, are not that simple.
@@ -114,6 +115,22 @@ disabled and users can't build new packages in it anymore.
 
 When it is done, `send an information email to a mailing list <#mailing-lists>`_.
 See the :ref:`the disable chroots template <disable_chroots_template>`.
+
+
+Rawhide (and other rolling) chroots EOL
+---------------------------------------
+
+Run ``copr-frontend eol-lifeless-rolling-chroots`` to mark existing rolling Copr
+chroots for the future removal/deactivation — if they appear lifeless.  You
+might want to run this daily in the ``copr-frontend-optional`` cron-job file.
+The logic in this command checks that no build happened in particular rolling
+chroot for a long time, so likely no work is being done there, and the old built
+packages are _likely_ non-installable anyway (as the rolling distro moves
+forward with dependencies, but no dependency resolution is being done with
+RPMs).  If such a chroot is marked EOL, this command applies the same
+notification policy/process as with the :ref:`eol_deactivation_process` so users
+can keep the chroot alive (either by prolonging the chroot, or triggering a new
+build).
 
 
 .. _managing_chroot_comments:

--- a/frontend/conf/cron.daily/copr-frontend-optional
+++ b/frontend/conf/cron.daily/copr-frontend-optional
@@ -2,6 +2,7 @@
 
 # Optional Copr frontend tasks to be executed daily.
 
+#runuser -c 'copr-frontend eol-lifeless-rolling-chroots' - copr-fe
 #runuser -c 'copr-frontend notify-outdated-chroots' - copr-fe
 #runuser -c 'copr-frontend delete-outdated-chroots' - copr-fe
 #/usr/libexec/copr_dump_db.sh /var/lib/copr/data/db_dumps/

--- a/frontend/coprs_frontend/alembic/versions/d23f84f87130_eol_rolling_builds.py
+++ b/frontend/coprs_frontend/alembic/versions/d23f84f87130_eol_rolling_builds.py
@@ -1,0 +1,30 @@
+"""
+record last copr_chroot build, allow marking Rawhide as rolling
+Create Date: 2024-05-13 08:56:31.557843
+"""
+
+import time
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import text
+
+revision = 'd23f84f87130'
+down_revision = '2d1feab6b2d8'
+
+def upgrade():
+    op.add_column('mock_chroot', sa.Column('rolling', sa.Boolean(), nullable=True))
+    op.add_column('copr_chroot', sa.Column('last_build_timestamp', sa.Integer(), nullable=True))
+    conn = op.get_bind()
+    conn.execute(
+        text("update copr_chroot set last_build_timestamp = :start_stamp;"),
+        {"start_stamp": int(time.time())},
+    )
+    op.create_index('copr_chroot_rolling_last_build_idx', 'copr_chroot',
+                    ['mock_chroot_id', 'last_build_timestamp', 'delete_after'],
+                    unique=False)
+
+
+def downgrade():
+    op.drop_index('copr_chroot_rolling_last_build_idx', table_name='copr_chroot')
+    op.drop_column('copr_chroot', 'last_build_timestamp')
+    op.drop_column('mock_chroot', 'rolling')

--- a/frontend/coprs_frontend/commands/alter_chroot.py
+++ b/frontend/coprs_frontend/commands/alter_chroot.py
@@ -51,13 +51,6 @@ def func_alter_chroot(chroot_names, action):
                         copr_chroot.delete_after = None
                         copr_chroot.delete_notify = None
                     else:
-                        if copr_chroot.deleted:
-                            # If the chroot was unclicked (deleted) from
-                            # a project, we don't want to run the whole EOL
-                            # machinery. The `delete_after` should be already
-                            # set and we want to keep it as is
-                            assert copr_chroot.delete_after
-                            continue
                         copr_chroot.delete_after = delete_after_timestamp
 
         except exceptions.MalformedArgumentException:

--- a/frontend/coprs_frontend/commands/eol_lifeless_rolling_chroots.py
+++ b/frontend/coprs_frontend/commands/eol_lifeless_rolling_chroots.py
@@ -1,0 +1,14 @@
+"""
+copr-frontend eol-lifeless-rolling-chroots command
+"""
+
+import click
+from coprs.logic.outdated_chroots_logic import OutdatedChrootsLogic
+
+@click.command()
+def eol_lifeless_rolling_chroots():
+    """
+    Go through all rolling CoprChroots and check whether they shouldn't be
+    scheduled for future removal.
+    """
+    OutdatedChrootsLogic.trigger_rolling_eol_policy()

--- a/frontend/coprs_frontend/config/copr.conf
+++ b/frontend/coprs_frontend/config/copr.conf
@@ -207,6 +207,16 @@ HIDE_IMPORT_LOG_AFTER_DAYS = 14
 # failed builds.  Currently only integrated with the Fedora Copr instance.
 #LOG_DETECTIVE_BUTTON = False
 
+# After a given _INACTIVITY_WARNING period (DAYS), when no new build appeared
+# in a rolling chroot, we start the "rolling" EOL policy.  It means that — after
+# the next _INACTIVITY_REMOVAL DAYS — the chroot gets disabled, and the
+# corresponding builds are removed to save storage.  This is only applicable to
+# MockChroots.rolling = True, and the command
+# `copr-frontend eol-lifeless-rolling-chroots` must be executed periodically via
+# cron or similar.
+#ROLLING_CHROOTS_INACTIVITY_WARNING = 180
+#ROLLING_CHROOTS_INACTIVITY_REMOVAL = 180
+
 #############################
 ##### DEBUGGING Section #####
 

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -198,6 +198,10 @@ class Config(object):
 
     LOG_DETECTIVE_BUTTON = False
 
+    ROLLING_CHROOTS_INACTIVITY_WARNING = 180
+    ROLLING_CHROOTS_INACTIVITY_REMOVAL = 180
+
+
 class ProductionConfig(Config):
     DEBUG = False
     # SECRET_KEY = "put_some_secret_here"

--- a/frontend/coprs_frontend/coprs/helpers.py
+++ b/frontend/coprs_frontend/coprs/helpers.py
@@ -202,6 +202,8 @@ class ChrootDeletionStatus(metaclass=EnumType):
     When a chroot is marked as EOL or when it is unclicked from a project,
     it goes through several stages before its data is finally deleted.
     Each `models.CoprChroot` is in one of the following states.
+
+    See https://docs.pagure.org/copr.copr/developer_documentation/eol-logic.html
     """
     # pylint: disable=too-few-public-methods
     vals = {
@@ -213,14 +215,10 @@ class ChrootDeletionStatus(metaclass=EnumType):
         # marked as EOL and its data is never going to be deleted.
         "deactivated": 1,
 
-        # There are multiple possible scenarios for chroots in this state:
-        # 1) The standard preservation period is not over yet. Its length
-        #    differs on whether the chroot is EOL or was unclicked from
-        #    a project but the meaning is same for both cases
-        #
-        # 2) If the chroot is EOL and we wasn't able to send a notification
-        #    about it.
-        #
+        # Preserved state.  There are multiple possible scenarios for chroots in
+        # this state:
+        # 1) The standard preservation period is not over yet.
+        # 2) If the chroot is EOL, but we weren't able to notify the user.
         # 3) Any other constraint that disallows the chroot to be deleted yet.
         #    At this moment there shouldn't be any.
         "preserved": 2,

--- a/frontend/coprs_frontend/coprs/logic/actions_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/actions_logic.py
@@ -399,6 +399,7 @@ class ActionsLogic(object):
             created_on=int(time.time()),
             copr_id=copr_chroot.copr.id,
         )
+        copr_chroot.deleted = True
         db.session.add(action)
         return action
 

--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -1473,6 +1473,7 @@ class BuildChrootsLogic(object):
             copr_chroot = coprs_logic.CoprChrootsLogic.get_by_mock_chroot_id(
                 build.copr, mock_chroot.id
             ).one()
+        copr_chroot.build_submitted()
         return models.BuildChroot(
             mock_chroot=mock_chroot,
             copr_chroot=copr_chroot,

--- a/frontend/coprs_frontend/manage.py
+++ b/frontend/coprs_frontend/manage.py
@@ -35,6 +35,7 @@ import commands.update_graphs
 import commands.vacuum_graphs
 import commands.notify_outdated_chroots
 import commands.delete_outdated_chroots
+import commands.eol_lifeless_rolling_chroots
 import commands.clean_expired_projects
 import commands.clean_old_builds
 import commands.delete_orphans
@@ -89,6 +90,7 @@ commands_list =	[
     "vacuum_graphs",
     "notify_outdated_chroots",
     "delete_outdated_chroots",
+    "eol_lifeless_rolling_chroots",
     "clean_expired_projects",
     "clean_old_builds",
     "delete_orphans",

--- a/frontend/coprs_frontend/tests/coprs_test_case.py
+++ b/frontend/coprs_frontend/tests/coprs_test_case.py
@@ -217,7 +217,8 @@ def foo():
         self.mc3.distgit_branch = self.mc2.distgit_branch
 
         self.mc4 = models.MockChroot(
-            os_release="fedora", os_version="rawhide", arch="i386", is_active=True)
+            os_release="fedora", os_version="rawhide", arch="i386",
+            is_active=True, rolling=True)
         self.mc4.distgit_branch = models.DistGitBranch(name='master')
 
         self.mc_basic_list = [self.mc1, self.mc2, self.mc3, self.mc4]

--- a/frontend/coprs_frontend/tests/test_logic/test_coprs_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_coprs_logic.py
@@ -212,8 +212,16 @@ class TestCoprChrootsLogic(CoprsTestCase):
 
         # A chroot is not EOL but was unclicked from a project by its owner
         self.c2.copr_chroots[0].mock_chroot.is_active = True
+        self.c2.copr_chroots[0].deleted = True
         self.c2.copr_chroots[0].delete_after = datetime.today() + timedelta(days=1)
         assert outdated.all() == []
+
+        # A rolling chroot is inactive
+        self.c2.copr_chroots[0].mock_chroot.is_active = True
+        self.c2.copr_chroots[0].deleted = False
+        self.c2.copr_chroots[0].delete_after = datetime.today() + timedelta(days=1)
+        assert len(outdated.all()) == 1
+
 
     def test_filter_outdated_to_be_deleted(self, f_users, f_coprs, f_mock_chroots, f_db):
         outdated = CoprChrootsLogic.filter_to_be_deleted(CoprChrootsLogic.get_multiple())


### PR DESCRIPTION
Implements: https://github.com/fedora-copr/debate/blob/main/2024-04-23-rawhide-chroots-eol.md
Fixes: #2933

- [x] Expiry/prolong works
- [x] Prolong with new build works
- [x] Users are notified about EOLed rolling chroots
- [x] Chroots are deleted eventually
- [ ] anything else??
