### PR TITLE
doc: add high_performance_builders to user documentation menu

### DIFF
--- a/doc/user_documentation.rst
+++ b/doc/user_documentation.rst
@@ -597,6 +597,12 @@ settings, ``copr-cli create --disable_createrepo`` in CLI, and ``devel_mode`` in
 the API. They are all the same feature.
 
 
+High Performance Builders
+-------------------------
+
+About more powerful builders see :ref:`high_performance_builders`.
+
+
 Modularity
 ----------
 


### PR DESCRIPTION
The page of high_performance_builders is referenced only from FAQ. I have hard time finding it. Lets put it in main document and notably to the left menu where it is discoverable.