### PR TITLE
docker-compose obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ You can use [Docker](https://docs.docker.com/) to run your local test environmen
 ```
 git clone https://github.com/fedora-copr/copr.git
 cd copr
-sudo docker-compose build
-sudo docker-compose up -d
+docker compose up -d
 ```
 
 For more information see [our wiki page](https://docs.pagure.org/copr.copr/contribute.html?highlight=contribute).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You can use [Docker](https://docs.docker.com/) to run your local test environmen
 ```
 git clone https://github.com/fedora-copr/copr.git
 cd copr
-docker-compose up -d
+sudo docker-compose build
+sudo docker-compose up -d
 ```
 
 For more information see [our wiki page](https://docs.pagure.org/copr.copr/contribute.html?highlight=contribute).


### PR DESCRIPTION
docker required build and admin mode execute

if not execute docker build return error

```
WARNING: Image for service keygen-httpd was built because it did not already exist. To rebuild this image you must use `docker-compose build` or `docker-compose up --build`.
Creating copr_database_1 ... 
Creating copr_keygen-signd_1 ... 
Creating copr_distgit_1      ... 
Creating copr_keygen-httpd_1 ... 
Creating copr_distgit-httpd_1 ... error
Creating copr_redis_1         ... 
Creating copr_builder_1       ... 

Creating copr_keygen-httpd_1  ... error
Creating copr_database_1      ... done
Creating copr_keygen-signd_1  ... done
Creating copr_distgit_1       ... done

ERROR: for copr_keygen-httpd_1  Cannot create container for service keygen-httpdCreating copr_redis_1         ... done
Creating copr_builder_1       ... done
Creating copr_resalloc_1      ... done
Creating copr_backend-log_1   ... done
Creating copr_backend-action_1 ... done
Creating copr_backend_httpd_1  ... done
Creating copr_backend-build_1  ... done

ERROR: for distgit-httpd  Cannot create container for service distgit-httpd: failed to mkdir /var/lib/docker/volumes/copr_dist-git/_data/cache/lookaside/pkgs: mkdir /var/lib/docker/volumes/copr_dist-git/_data/cache/lookaside/pkgs: file exists

ERROR: for keygen-httpd  Cannot create container for service keygen-httpd: failed to mkdir /var/lib/docker/volumes/copr_copr-keygen/_data/phrases: mkdir /var/lib/docker/volumes/copr_copr-keygen/_data/phrases: file exists
ERROR: Encountered errors while bringing up the project.
```