### PR TITLE
doc: check that our services don't use the going-to-be-deactivated chroot

### DIFF
--- a/doc/how_to_manage_chroots.rst
+++ b/doc/how_to_manage_chroots.rst
@@ -93,6 +93,12 @@ When everything is done, `send an information email to a mailing list <#mailing-
 EOL deactivation process
 ------------------------
 
+.. warning::
+
+   Before deactivating chroots, please make sure other services such as
+   `Fedora Review Service <https://github.com/FrostyX/fedora-review-service/blob/main/conf/fedora-review-service-prod.yaml>`_
+   doesn't depend on them.
+
 When some Fedora version reaches the end of its release cycle and is marked as EOL, you can safely disable its chroots.
 Though we want to keep the chroots enabled for a short period of time (few weeks) even after EOL, so our users can
 comfortably deal with it. It can be done like this


### PR DESCRIPTION
For the third time, I forgot to disable EOL chroots from the Fedora Review Service before they were disabled from Copr, causing an unexpected outage.

Until it starts using
https://github.com/rpm-software-management/fedora-distro-aliases this documentation change should prevent any further instances of this issue.