### PR TITLE
rpmbuild: copr-distgit-client depends on python-six

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -156,6 +156,7 @@ Summary: Utility to download sources from dist-git
 
 Requires: %{_bindir}/git
 Requires: curl
+Requires: %{python_pfx}-six
 %if 0%{?fedora} || 0%{?rhel} > 9
 Requires: %{python_pfx}-rpmautospec
 BuildRequires: %{python_pfx}-rpmautospec


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/copr-distgit-client", line 7, in <module>
    from copr_distgit_client import main
  File "/usr/lib/python3.12/site-packages/copr_distgit_client.py", line 14, in <module>
    from six.moves.urllib.parse import urlparse
ModuleNotFoundError: No module named 'six'