### PR TITLE
utcnow() is deprecated

### DIFF
--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -18,12 +18,10 @@ from operator import methodcaller
 
 import traceback
 
-from datetime import datetime
+import datetime
 from threading import Thread
 
 import subprocess
-
-import pytz
 
 import munch
 from munch import Munch
@@ -452,21 +450,6 @@ def uses_devel_repo(front_url, username, projectname, project=None):
     return bool(project.get("devel_mode", False))
 
 
-# def log(lf, msg, quiet=None):
-#     if lf:
-#         now = datetime.datetime.utcnow().isoformat()
-#         try:
-#             with open(lf, "a") as lfh:
-#                 fcntl.flock(lfh, fcntl.LOCK_EX)
-#                 lfh.write(str(now) + ":" + msg + "\n")
-#                 fcntl.flock(lfh, fcntl.LOCK_UN)
-#         except (IOError, OSError) as e:
-#             sys.stderr.write(
-#                 "Could not write to logfile {0} - {1}\n".format(lf, str(e)))
-#     if not quiet:
-#         print(msg)
-#
-
 def register_build_result(opts=None, failed=False):
     """
     Remember fails to redis.
@@ -581,8 +564,7 @@ def utc_now():
     """
     :return datetime.datetime: Current utc datetime with specified timezone
     """
-    u = datetime.utcnow()
-    u = u.replace(tzinfo=pytz.utc)
+    u = datetime.datetime.now(datetime.UTC)
     return u
 
 

--- a/backend/run/copr-backend-analyze-results
+++ b/backend/run/copr-backend-analyze-results
@@ -5,7 +5,7 @@ Analyze the Copr Backend resultdir storage usage.
 """
 
 import argparse
-from datetime import datetime
+import datetime
 import json
 import os
 import shlex
@@ -150,7 +150,7 @@ def _main(arguments):
     except FileExistsError:
         pass
 
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.datetime.now(datetime.UTC).isoformat()
 
     full_du_log = os.path.join(
         datadir,

--- a/backend/run/copr-repo
+++ b/backend/run/copr-repo
@@ -299,7 +299,7 @@ def delete_builds(opts):
             with open(prune_log, "a+") as fd:
                 fd.write("{} pruned on {}, by PID {}\n".format(
                     rpm,
-                    datetime.datetime.utcnow(),
+                    datetime.datetime.now(datetime.UTC),
                     os.getpid(),
                 ))
         except OSError:


### PR DESCRIPTION
Addressing:
/usr/bin/copr-backend-analyze-results:153: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  timestamp = datetime.utcnow().isoformat()