### PR TITLE
backend: add support for pulp domains

### DIFF
--- a/backend/tests/test_pulp.py
+++ b/backend/tests/test_pulp.py
@@ -1,0 +1,39 @@
+"""
+Test Pulp client
+"""
+
+# pylint: disable=attribute-defined-outside-init
+
+from copr_backend.pulp import PulpClient
+
+
+class TestPulp:
+
+    def setup_method(self, _method):
+        self.config = {
+            "api_root": "/pulp/",
+            "base_url": "http://pulp.fpo:24817",
+            "cert": "",
+            "domain": "default",
+            "dry_run": False,
+            "format": "json",
+            "key": "",
+            "password": "1234",
+            "timeout": 0,
+            "username": "admin",
+            "verbose": 0,
+            "verify_ssl": True,
+        }
+
+    def test_url(self):
+        client = PulpClient(self.config)
+        assert self.config["domain"] == "default"
+        assert client.url("api/v3/artifacts/")\
+            == "http://pulp.fpo:24817/pulp/api/v3/artifacts/"
+
+        assert client.url("api/v3/repositories/rpm/rpm/?")\
+            == "http://pulp.fpo:24817/pulp/api/v3/repositories/rpm/rpm/?"
+
+        self.config["domain"] = "copr"
+        assert client.url("api/v3/artifacts/")\
+            == "http://pulp.fpo:24817/pulp/copr/api/v3/artifacts/"


### PR DESCRIPTION
The pulp.stage.devshift.net instance has domains enabled while our STG instance has them disabled. As long as it is easy to support both cases, I'd do that.