### PR TITLE
backend: remove fake jobs and pass specific arguments to storage calls

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -105,6 +105,12 @@ class PulpClient:
         url += self._urlencode({"name": name, "offset": 0, "limit": 1})
         return requests.get(url, **self.request_params)
 
+    def get_task(self, task):
+        """
+        Get a detailed information about a task
+        """
+        url = self.config["base_url"] + task
+        return requests.get(url, **self.request_params)
     def _urlencode(self, query):
         """
         Join a dict into URL query string but don't encode special characters

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -5,6 +5,7 @@ Pulp doesn't provide an API client, we are implementing it for ourselves
 import os
 import tomllib
 import requests
+from six.moves.urllib.parse import urlencode
 
 
 class PulpClient:
@@ -91,7 +92,7 @@ class PulpClient:
         # There is no endpoint for querying a single repository by its name,
         # even Pulp CLI does this workaround
         url = self.url("api/v3/repositories/rpm/rpm/?")
-        url += self._urlencode({"name": name, "offset": 0, "limit": 1})
+        url += urlencode({"name": name, "offset": 0, "limit": 1})
         return requests.get(url, **self.request_params)
 
     def get_distribution(self, name):
@@ -102,7 +103,7 @@ class PulpClient:
         # There is no endpoint for querying a single repository by its name,
         # even Pulp CLI does this workaround
         url = self.url("api/v3/distributions/rpm/rpm/?")
-        url += self._urlencode({"name": name, "offset": 0, "limit": 1})
+        url += urlencode({"name": name, "offset": 0, "limit": 1})
         return requests.get(url, **self.request_params)
 
     def get_task(self, task):
@@ -111,15 +112,6 @@ class PulpClient:
         """
         url = self.config["base_url"] + task
         return requests.get(url, **self.request_params)
-    def _urlencode(self, query):
-        """
-        Join a dict into URL query string but don't encode special characters
-        https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode
-        Our repository names are e.g. frostyx/test-pulp/fedora-39-x86_64.
-        The standard urlencode would change the slashes to %2F making Pulp to
-        not find the project when filtering by name.
-        """
-        return "&".join([f"{k}={v}" for k, v in query.items()])
 
     def create_distribution(self, name, repository, basepath=None):
         """

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -189,7 +189,14 @@ class PulpStorage(Storage):
                            repository, response.text)
             return False
 
-        publication = response.json()["results"][0]["pulp_href"]
+        task = response.json()["task"]
+        response = self.client.get_task(task)
+        if not response.ok:
+            self.log.error("Failed to get Pulp task %s because of %s",
+                           task, response.text)
+            return False
+
+        publication = response.json()["created_resources"][0]
         distribution_name = self._distribution_name(chroot)
         distribution = self._get_distribution(chroot)
 


### PR DESCRIPTION
There is one small exception and that is `publish_repository` which takes `**kwargs` for parameters that differ across storages.