### PR TITLE
Webhook request history

### DIFF
--- a/frontend/coprs_frontend/alembic/versions/06b208e317a3_create_webhook_history_table.py
+++ b/frontend/coprs_frontend/alembic/versions/06b208e317a3_create_webhook_history_table.py
@@ -7,7 +7,6 @@ Create Date: 2024-07-24 22:04:51.810724
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import UUID
 
 
 # revision identifiers, used by Alembic.
@@ -22,7 +21,7 @@ def upgrade():
                    sa.Column("id", sa.Integer()),
                    sa.Column("timestamp", sa.DateTime(timezone=True),
                              nullable=False, server_default=sa.func.now()),
-                   sa.Column("webhook_uuid", UUID(as_uuid=True), nullable=True),
+                   sa.Column("webhook_uuid", sa.Text(), nullable=True),
                    sa.Column("user_agent",sa.Text(), nullable=True),
                    sa.PrimaryKeyConstraint("id")
     )

--- a/frontend/coprs_frontend/alembic/versions/06b208e317a3_create_webhook_history_table.py
+++ b/frontend/coprs_frontend/alembic/versions/06b208e317a3_create_webhook_history_table.py
@@ -1,0 +1,37 @@
+"""
+create webhook history table
+
+Revision ID: 06b208e317a3
+Create Date: 2024-07-24 22:04:51.810724
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+# revision identifiers, used by Alembic.
+revision = '06b208e317a3'
+down_revision = 'd23f84f87130'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table("webhook_history",
+                   sa.Column("id", sa.Integer()),
+                   sa.Column("timestamp", sa.DateTime(timezone=True),
+                             nullable=False, server_default=sa.func.now()),
+                   sa.Column("webhook_uuid", UUID(as_uuid=True), nullable=True),
+                   sa.Column("user_agent",sa.Text(), nullable=True),
+                   sa.PrimaryKeyConstraint("id")
+    )
+
+    op.add_column("build",
+                  sa.Column("webhook_history_id",
+                  sa.Integer,
+                  sa.ForeignKey("webhook_history.id"), nullable=True))
+
+def downgrade():
+    op.drop_table("webhook_history")
+    op.drop_column("build","webhook_history_id")

--- a/frontend/coprs_frontend/coprs/helpers.py
+++ b/frontend/coprs_frontend/coprs/helpers.py
@@ -8,6 +8,7 @@ import string
 import json
 import posixpath
 import re
+import time
 from os.path import normpath
 from urllib.parse import urlparse, parse_qs, urlunparse, urlencode
 

--- a/frontend/coprs_frontend/coprs/helpers.py
+++ b/frontend/coprs_frontend/coprs/helpers.py
@@ -8,7 +8,6 @@ import string
 import json
 import posixpath
 import re
-import time
 from os.path import normpath
 from urllib.parse import urlparse, parse_qs, urlunparse, urlencode
 

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -23,7 +23,6 @@ from sqlalchemy import outerjoin, text, DateTime
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import column_property, validates
 from sqlalchemy.event import listens_for
-from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import func
 from libravatar import libravatar_url
 
@@ -1573,13 +1572,15 @@ class Build(db.Model, helpers.Serializer):
         for bch in self.build_chroots:
             bch.backend_enqueue()
 
+
 class WebhookHistory(db.Model):
     '''Represents a Webhook UUID & a build initiated by it.'''
     id = db.Column(db.Integer, primary_key=True)
     timestamp = db.Column(DateTime(timezone=True), server_default=func.now())
     # Null values are possible via custom webhook implementation that do not pass a UUID or User Agent.
     user_agent = db.Column(db.Text,nullable=True)
-    webhook_uuid = db.Column(UUID(as_uuid=True), nullable=True)
+    webhook_uuid = db.Column(db.Text, nullable=True)
+
 
 class DistGitBranch(db.Model, helpers.Serializer):
     """

--- a/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
+++ b/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
@@ -1,3 +1,7 @@
+import logging
+import os
+import tempfile
+import shutil
 from typing import Optional
 
 import flask
@@ -20,10 +24,6 @@ from coprs.exceptions import (
 
 from coprs.views.webhooks_ns import webhooks_ns
 
-import logging
-import os
-import tempfile
-import shutil
 
 log = logging.getLogger(__name__)
 
@@ -80,7 +80,9 @@ def package_name_required(route):
 
     return decorated_function
 
-def add_webhook_history_record(webhook_uuid, user_agent='Not Set', builds_initiated_via_hook=None):
+
+def add_webhook_history_record(webhook_uuid, user_agent='Not Set',
+                               builds_initiated_via_hook=None):
     """
     This methods adds info of an intercepted webhook to webhook_history db
     along with the initiated build number(s).
@@ -96,6 +98,7 @@ def add_webhook_history_record(webhook_uuid, user_agent='Not Set', builds_initia
 
     for build in builds_initiated_via_hook:
         build.webhook_history_id = webhookRecord.id
+
 
 @webhooks_ns.route("/bitbucket/<int:copr_id>/<uuid>/", methods=["POST"])
 @webhooks_ns.route("/bitbucket/<int:copr_id>/<uuid>/<string:pkg_name>/", methods=["POST"])
@@ -134,9 +137,10 @@ def webhooks_bitbucket_push(copr_id, uuid, pkg_name: Optional[str] = None):
     builds_initiated_via_webhook = []
     for package in packages:
         build = BuildsLogic.rebuild_package(package, {'committish': committish},
-                                    submitted_by=actor)
+                                            submitted_by=actor)
         builds_initiated_via_webhook.append(build)
-    add_webhook_history_record(webhook_uuid,user_agent,builds_initiated_via_webhook)
+    add_webhook_history_record(webhook_uuid, user_agent,
+                               builds_initiated_via_webhook)
 
     db.session.commit()
 
@@ -188,10 +192,11 @@ def webhooks_git_push(copr_id: int, uuid, pkg_name: Optional[str] = None):
     builds_initiated_via_webhook = []
     for package in packages:
         build = BuildsLogic.rebuild_package(package, {'committish': committish},
-                                    submitted_by=sender)
+                                            submitted_by=sender)
         builds_initiated_via_webhook.append(build)
 
-    add_webhook_history_record(webhook_uuid, user_agent, builds_initiated_via_webhook)
+    add_webhook_history_record(webhook_uuid, user_agent,
+                               builds_initiated_via_webhook)
     db.session.commit()
 
     return "OK", 200
@@ -243,9 +248,10 @@ def webhooks_gitlab_push(copr_id: int, uuid, pkg_name: Optional[str] = None):
     builds_initiated_via_webhook = []
     for package in packages:
         build = BuildsLogic.rebuild_package(package, {'committish': committish},
-                                    submitted_by=submitter)
-        builds_initiated_via_webhook.append(build.id)
-    add_webhook_history_record(webhook_uuid, user_agent, builds_initiated_via_webhook)
+                                            submitted_by=submitter)
+        builds_initiated_via_webhook.append(build)
+    add_webhook_history_record(webhook_uuid, user_agent,
+                               builds_initiated_via_webhook)
 
     db.session.commit()
 

--- a/frontend/coprs_frontend/tests/test_webhooks.py
+++ b/frontend/coprs_frontend/tests/test_webhooks.py
@@ -123,7 +123,11 @@ class TestGithubWebhook(CoprsTestCase):
                        "subdirectory": "", "committish": "", "spec": "",
                        "srpm_build_method": "rpkg"}
         self.pHook.source_json = json.dumps(source_json)
-        headers = {'X-GitHub-Event': 'push'}
+        headers = {
+            'X-GitHub-Event': 'push',
+            'X-GitHub-Delivery': 'foo-bar-baz-qux',
+            'User-Agent': 'test client',
+        }
         self.pHook.webhook_rebuild = True
         hook_payload = {
             "ref": "refs/heads/master",
@@ -146,6 +150,11 @@ class TestGithubWebhook(CoprsTestCase):
         assert r.data.decode('ascii') == 'OK'
         assert r.status_code == 200
         assert len(package.builds) == 1
+
+        history = self.models.WebhookHistory.query.all()
+        assert len(history) == 1
+        assert history[0].user_agent == "test client"
+        assert history[0].webhook_uuid == "foo-bar-baz-qux"
 
     def test_bad_uuid(self, f_hook_package, f_db):
         r = self.github_post(
@@ -188,7 +197,11 @@ class TestGitlabWebhook(CoprsTestCase):
                        "subdirectory": "", "committish": "", "spec": "",
                        "srpm_build_method": "rpkg"}
         self.pHook.source_json = json.dumps(source_json)
-        headers = {'X-Gitlab-Event': 'Push Hook'}
+        headers = {
+            'X-Gitlab-Event': 'Push Hook',
+            'X-Gitlab-Webhook-UUID': 'foo-bar-baz-qux',
+            'User-Agent': 'test client',
+        }
         self.pHook.webhook_rebuild = True
         hook_payload = {
             "object_kind": "push",
@@ -210,6 +223,11 @@ class TestGitlabWebhook(CoprsTestCase):
         assert r.data.decode('ascii') == 'OK'
         assert r.status_code == 200
         assert len(package.builds) == 1
+
+        history = self.models.WebhookHistory.query.all()
+        assert len(history) == 1
+        assert history[0].user_agent == "test client"
+        assert history[0].webhook_uuid == "foo-bar-baz-qux"
 
     def test_bad_uuid(self, f_hook_package, f_db):
         r = self.gitlab_post(
@@ -252,7 +270,11 @@ class TestBitbucketWebhook(CoprsTestCase):
                        "subdirectory": "", "committish": "", "spec": "",
                        "srpm_build_method": "rpkg"}
         self.pHook.source_json = json.dumps(source_json)
-        headers = {'X-Event-Key': 'repo:push'}
+        headers = {
+            'X-Event-Key': 'repo:push',
+            'X-Hook-UUID': 'foo-bar-baz-qux',
+            'User-Agent': 'test client',
+        }
         self.pHook.webhook_rebuild = True
         hook_payload = {
             "object_kind": "push",
@@ -294,6 +316,11 @@ class TestBitbucketWebhook(CoprsTestCase):
         assert r.data.decode('ascii') == 'OK'
         assert r.status_code == 200
         assert len(package.builds) == 1
+
+        history = self.models.WebhookHistory.query.all()
+        assert len(history) == 1
+        assert history[0].user_agent == "test client"
+        assert history[0].webhook_uuid == "foo-bar-baz-qux"
 
     def test_bad_uuid(self, f_hook_package, f_db):
         r = self.bitbucket_post(


### PR DESCRIPTION
This is a two part PR. 
1. To implement the database side of things(models, migrations and data insertion up webhook arrival).
2. To implement the UI which is to display the webhook history records in one of a chosen Project page.

Here's what I've done so far, 
1. Add a new table named `webhook_history` to `coprdb` DB. 
   - It has three Columns. 
   - `id` : An auto incrementing primary key.
   - `hook_uuid` : This is extracted from the webhook POST request. 
   - `build_id` : Build number that was initiated by a webhook. 
   - Note: A webhook may initiate multiple builds this implies there may be multiple records inserted with the same `hook_id`. 

2. A function named `def addHookHistoryRecord(hook_uuid, builds_initiated_via_hook)` is used to insert a record in `webhook_history` table. As of now, I am calling it only within Github webhook handler. 

3. Migration script using Alembic. 

4. There are NO tests as of now. I expect changes so holding that for now. 

Closes #304 