### PR TITLE
Message schemas: improve the notifications

### DIFF
--- a/messaging/copr_messaging/private/hierarchy.py
+++ b/messaging/copr_messaging/private/hierarchy.py
@@ -33,7 +33,8 @@ class _CoprMessage(message.Message):
     """
     Base class that all Copr messages should inherit from.
     """
-    def __str__(self):
+    def summary(self):
+        """A one-line, human-readable representation of this message."""
         return "Unspecified Copr message"
 
     def _str_prefix(self):

--- a/messaging/copr_messaging/private/hierarchy.py
+++ b/messaging/copr_messaging/private/hierarchy.py
@@ -28,7 +28,7 @@ class _CoprMessage(message.Message):
                 body = body['msg']
             kwargs['body'] = body
 
-        super(_CoprMessage, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     """
     Base class that all Copr messages should inherit from.
@@ -54,7 +54,7 @@ class _CoprMessage(message.Message):
 class _CoprProjectMessage(_CoprMessage):
     def _str_prefix(self):
         return '{0} in project "{1}"'.format(
-            super(_CoprProjectMessage, self)._str_prefix(),
+            super()._str_prefix(),
             self.project_full_name,
         )
 
@@ -85,7 +85,7 @@ class _CoprProjectMessage(_CoprMessage):
 class _BuildMessage(_CoprProjectMessage):
     def _str_prefix(self):
         return '{0}: build {1}'.format(
-            super(_BuildMessage, self)._str_prefix(),
+            super()._str_prefix(),
             self.build_id,
         )
 

--- a/messaging/copr_messaging/schema.py
+++ b/messaging/copr_messaging/schema.py
@@ -39,7 +39,8 @@ class BuildChrootEnded(_BuildChrootMessage):
         """
         raise NotImplementedError
 
-    def __str__(self):
+    def summary(self):
+        """A one-line, human-readable representation of this message."""
         return '{0}: chroot "{1}" ended as "{2}".'.format(
             super(BuildChrootEnded, self)._str_prefix(),
             self.chroot,
@@ -61,7 +62,8 @@ class BuildChrootStarted(_BuildChrootMessage):
     Representation of a message sent by Copr build system right before some Copr
     worker starts working on a build in a particular mock chroot.
     """
-    def __str__(self):
+    def summary(self):
+        """A one-line, human-readable representation of this message."""
         return '{0}: chroot "{1}" started.'.format(
             super(BuildChrootStarted, self)._str_prefix(),
             self.chroot,

--- a/messaging/copr_messaging/schema.py
+++ b/messaging/copr_messaging/schema.py
@@ -44,7 +44,7 @@ class BuildChrootEnded(_BuildChrootMessage):
     def summary(self):
         """A one-line, human-readable representation of this message."""
         return '{0}: chroot "{1}" ended as "{2}".'.format(
-            super(BuildChrootEnded, self)._str_prefix(),
+            super()._str_prefix(),
             self.chroot,
             self.status,
         )
@@ -67,7 +67,7 @@ class BuildChrootStarted(_BuildChrootMessage):
     def summary(self):
         """A one-line, human-readable representation of this message."""
         return '{0}: chroot "{1}" started.'.format(
-            super(BuildChrootStarted, self)._str_prefix(),
+            super()._str_prefix(),
             self.chroot,
         )
 

--- a/messaging/copr_messaging/schema.py
+++ b/messaging/copr_messaging/schema.py
@@ -20,6 +20,8 @@ This file contains schemas for messages sent by Copr project.
 
 import copy
 
+from fedora_messaging import message
+
 from copr_common.enums import StatusEnum
 
 from .private.hierarchy import _BuildChrootMessage, _CoprMessage
@@ -99,6 +101,12 @@ class BuildChrootStartedV1DontUse(_PreFMBuildMessage, BuildChrootStarted):
     duplicated the 'copr.build.start' message, so you should never use this.
     """
     topic = 'copr.chroot.start'
+
+    # Set the chroot message severity to DEBUG, which will not generate a notification in FMN by
+    # default. Those are always paired with a build message, so it makes more sense to notify on
+    # that one.
+    # Ref: https://fedora-messaging.readthedocs.io/en/stable/user-guide/messages.html#useful-accessors
+    severity = message.DEBUG
 
 
 class BuildChrootStartedV1Stomp(schema_stomp_old._OldStompChrootMessage,


### PR DESCRIPTION
This PR contains 2 changes:
- set the one-line description to be the summary instead of the `__str__` representation (which goes in the email body)
- set the chroot message severity to DEBUG, which will not generate a notification in FMN by default. Those are always paired with a build message, so it makes more sense to notify on that one.

Fixes: #3237 