### PR TITLE
keygen: drop support for python2

### DIFF
--- a/keygen/copr-keygen.spec
+++ b/keygen/copr-keygen.spec
@@ -21,7 +21,6 @@ BuildRequires: systemd
 BuildRequires: python3-devel
 BuildRequires: python3-copr-common >= %copr_common_version
 BuildRequires: python3-setuptools
-BuildRequires: python3-six
 BuildRequires: python3-flask
 
 # doc
@@ -41,7 +40,6 @@ Requires:   passwd
 Recommends: logrotate
 Requires:   python3-copr-common >= %copr_common_version
 Requires:   python3-setuptools
-Requires:   python3-six
 Requires:   python3-flask
 
 # tests
@@ -64,7 +62,6 @@ Obsoletes:  copr-doc < 1.38
 BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 BuildRequires: python3-requests
-BuildRequires: python3-six
 BuildRequires: python3-flask
 BuildRequires: python3-sphinx
 BuildRequires: python3-sphinxcontrib-httpdomain

--- a/keygen/requirements.txt
+++ b/keygen/requirements.txt
@@ -1,6 +1,5 @@
 sphinxcontrib-httpdomain
 flask
-six
 mock
 pytest
 pytest-cov

--- a/keygen/setup.py
+++ b/keygen/setup.py
@@ -5,7 +5,6 @@ import sys
 
 requires = [
     'flask',
-    'six',
     'sphinxcontrib-httpdomain',
 ]
 

--- a/keygen/tests/test_handles.py
+++ b/keygen/tests/test_handles.py
@@ -1,10 +1,6 @@
 import json
-import six
 
-if six.PY3:
-    from unittest import mock
-else:
-    import mock
+from unittest import mock
 
 
 from copr_keygen import app

--- a/keygen/tests/test_logic.py
+++ b/keygen/tests/test_logic.py
@@ -5,14 +5,8 @@ import tempfile
 import shutil
 import os
 
-import six
-
-if six.PY3:
-    from unittest import mock
-    from unittest.mock import patch
-else:
-    import mock
-    from mock import patch
+from unittest import mock
+from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
Python3 is in RHEL8+