### PR TITLE
backend: do not use six

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -4,8 +4,8 @@ Pulp doesn't provide an API client, we are implementing it for ourselves
 
 import os
 import tomllib
+from urllib.parse import urlencode
 import requests
-from six.moves.urllib.parse import urlencode
 
 
 class PulpClient:


### PR DESCRIPTION
six module is not required and cannot be installed. And we are python3 only anyway. So remove it.