### PR TITLE
backend: implement timeout fail-safe in case copr-rpmbuild hangs up

### DIFF
--- a/backend/tests/test_background_worker_build.py
+++ b/backend/tests/test_background_worker_build.py
@@ -716,8 +716,10 @@ def test_average_step():
 
 @_patch_bwbuild_object("time.sleep", mock.MagicMock())
 @_patch_bwbuild_object("time.time")
-def test_retry_for_ssh_tail_failure(mc_time, f_build_rpm_case,
+@_patch_bwbuild_object("BuildBackgroundWorker._build_timeouted")
+def test_retry_for_ssh_tail_failure(mc_timeouted, mc_time, f_build_rpm_case,
                                     caplog):
+    mc_timeouted.return_value = False
     mc_time.side_effect = list(range(500))
     class _SideEffect:
         counter = 0


### PR DESCRIPTION
Fix #3343

I am not 100% sure this PR will fully prevent issues like #3343 but I am trying to address cases like this here.

Normally, copr-rpmbuild is responsible for terminating itself when the build timeout is reached. This is indicated by the "Copr timeout => sending INT" message in the builder-live.log.

This proves itself to not be reliable enough because sometimes the whole copr-rpmbuild process hangs up, doesn't terminate itself, and the build gets stuck in the running state for months. This PR implements a fail-safe mechanism on backend, which waits a short period of time after the timeout is reached and then terminates the build.

Backend terminates the timeouted builds by connecting to the broken builders and running `copr-rpmbuild-cancel` on them. This successfully terminated the currently stuck builds mentioned by #3343.