### PR TITLE
Use fixture instead of deprecated yield_fixture

### DIFF
--- a/backend/tests/daemons/test_log.py
+++ b/backend/tests/daemons/test_log.py
@@ -15,13 +15,13 @@ from unittest.mock import patch, MagicMock
 from copr_backend.daemons.log import RedisLogHandler
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_logging():
     with mock.patch("copr_backend.daemons.log.logging") as mc_logging:
         yield mc_logging
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_setproctitle():
     with mock.patch("copr_backend.daemons.log.setproctitle") as mc_spt:
         yield mc_spt

--- a/backend/tests/daemons/unused_test_job_grab.py
+++ b/backend/tests/daemons/unused_test_job_grab.py
@@ -26,19 +26,19 @@ import copr_backend.actions
 
 MODULE_REF = "copr_backend.daemons.job_grab"
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_logging():
     with mock.patch("{}.logging".format(MODULE_REF)) as mc_logging:
         yield mc_logging
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_setproctitle():
     with mock.patch("{}.setproctitle".format(MODULE_REF)) as mc_spt:
         yield mc_spt
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_retask_queue():
     with mock.patch("{}.jobgrabcontrol.Channel".format(MODULE_REF)) as mc_queue:
         def make_queue(*args, **kwargs):
@@ -51,7 +51,7 @@ def mc_retask_queue():
         yield mc_queue
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_grc():
     with mock.patch("{}.get_redis_connection".format(MODULE_REF)) as handle:
         yield handle
@@ -119,7 +119,7 @@ class TestJobGrab(object):
         for handler in logging.root.handlers[:]:
             logging.root.removeHandler(handler)
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def mc_time(self):
         with mock.patch("{}.time".format(MODULE_REF)) as mc_time:
             mc_time.time.return_value = self.test_time

--- a/backend/tests/run/test_copr_prune_results.py
+++ b/backend/tests/run/test_copr_prune_results.py
@@ -18,22 +18,22 @@ sys.path.append('../../run')
 MODULE_REF = 'run.copr_prune_results'
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_runcmd():
     with mock.patch('{}.runcmd'.format(MODULE_REF)) as handle:
         yield handle
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_bcr():
     with mock.patch('{}.BackendConfigReader'.format(MODULE_REF)) as handle:
         yield handle
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_build_devel():
     with mock.patch('{}.uses_devel_repo'.format(MODULE_REF)) as handle:
         yield handle
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_pruner():
     with mock.patch('{}.Pruner'.format(MODULE_REF)) as handle:
         yield handle

--- a/backend/tests/test_frontend.py
+++ b/backend/tests/test_frontend.py
@@ -11,7 +11,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 import pytest
 
-@pytest.yield_fixture
+@pytest.fixture
 def post_req():
     with mock.patch("copr_common.request.post") as obj:
         yield obj
@@ -26,7 +26,7 @@ def f_request_method(request):
         yield (request.param, ctx)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_time():
     with mock.patch("copr_common.request.time") as obj:
         yield obj

--- a/cli/tests/cli_tests_lib.py
+++ b/cli/tests/cli_tests_lib.py
@@ -1,13 +1,15 @@
 import six
 
+# pylint: disable=ungrouped-imports
 if six.PY3:
     from unittest import mock
     from unittest.mock import MagicMock
+    from pytest import fixture
 else:
     import mock
     from mock import MagicMock
+    from pytest import yield_fixture as fixture
 
-import pytest
 
 config = {
     "username": "jdoe",
@@ -16,7 +18,7 @@ config = {
     "token": "abc",
 }
 
-@pytest.yield_fixture
+@fixture
 def f_test_config():
     with mock.patch('copr_cli.main.config_from_file',
                     return_value=config) as test_config:

--- a/cli/tests/test_distgit.py
+++ b/cli/tests/test_distgit.py
@@ -9,9 +9,12 @@ import pytest
 
 import copr
 # pylint: disable=unused-import
-from cli_tests_lib import f_test_config
-from cli_tests_lib import mock
-from cli_tests_lib import config as mock_config
+from cli_tests_lib import (
+    f_test_config,
+    mock,
+    config as mock_config,
+    fixture,
+)
 from copr_cli import main
 
 def _main(args, capsys):
@@ -50,7 +53,7 @@ class TestDistGitMethodBuild(object):
     }
 
     @staticmethod
-    @pytest.yield_fixture
+    @fixture
     def f_patch_create_from_distgit(f_test_config, capsys):
         with mock.patch("copr.v3.proxies.build.BuildProxy.create_from_distgit") as patch:
             patch.return_value = [Munch({
@@ -102,7 +105,7 @@ class TestDistGitMethodPackage(object):
     success_stdout = "Create or edit operation was successful.\n"
 
     @staticmethod
-    @pytest.yield_fixture
+    @fixture
     def f_patch_package_distgit(f_test_config, capsys):
         with mock.patch("copr.v3.proxies.package.PackageProxy.add") as p1:
             with mock.patch("copr.v3.proxies.package.PackageProxy.edit") as p2:

--- a/cli/tests/test_mock_config.py
+++ b/cli/tests/test_mock_config.py
@@ -3,13 +3,12 @@ Unit tests for the `copr mock-config ...` command.
 """
 
 from munch import Munch
-import pytest
 
 from copr_cli import main
 
 import six
 
-from cli_tests_lib import mock, f_test_config
+from cli_tests_lib import mock, f_test_config, fixture
 
 
 class TestMockConfig():
@@ -77,7 +76,7 @@ best=1
             "isolation": "default"
         })
 
-    @pytest.yield_fixture
+    @fixture
     def f_get_build_config(self):
         method = (
             'copr.v3.proxies.project_chroot.'

--- a/dist-git/tests/test_crazy_merging.py
+++ b/dist-git/tests/test_crazy_merging.py
@@ -15,25 +15,25 @@ from copr_dist_git.package_import import import_package
 def scriptdir():
     return os.path.dirname(os.path.realpath(__file__))
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_setup_git_repo():
     with mock.patch("{}.setup_git_repo".format('copr_dist_git.package_import')) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_group():
     with mock.patch("os.setgid") as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_chroot():
     with mock.patch("os.chroot") as handle:
         yield handle
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def tmpdir():
     origdir = os.getcwd()
     tdir = tempfile.mkdtemp()
@@ -44,7 +44,7 @@ def tmpdir():
     shutil.rmtree(tdir, ignore_errors=True)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def git_repos(tmpdir):
     dirname = 'git_repos'
     os.mkdir(dirname)
@@ -52,7 +52,7 @@ def git_repos(tmpdir):
     shutil.rmtree('git_repos', ignore_errors=True)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def origin(git_repos):
     print("creating origin")
     modulename = 'bob/blah/quick-package'
@@ -76,7 +76,7 @@ def origin(git_repos):
     shutil.rmtree('work', ignore_errors=True)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def branches(origin):
     branches = ['f20', 'epel7', 'el6', 'fedora/26', 'rhel-7']
     middle_branches = ['el6', 'fedora/26']
@@ -97,7 +97,7 @@ def branches(origin):
     yield (origin, branches, middle_branches, border_branches)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def lookaside(tmpdir):
     assert 0 == os.system(
     """ set -e
@@ -107,7 +107,7 @@ def lookaside(tmpdir):
     shutil.rmtree('lookaside', ignore_errors=True)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def opts_basic(tmpdir, lookaside):
     class _:
         pass

--- a/dist-git/tests/test_importer.py
+++ b/dist-git/tests/test_importer.py
@@ -19,37 +19,37 @@ import copr_dist_git.import_task
 MODULE_REF = 'copr_dist_git.importer'
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_helpers():
     with mock.patch("{}.helpers".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_worker():
     with mock.patch("{}.Worker".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_import_package():
     with mock.patch("{}.import_package".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_time():
     with mock.patch("{}.time".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_get():
     with mock.patch("{}.get".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_post():
     with mock.patch("{}.post".format(MODULE_REF)) as handle:
         yield handle

--- a/dist-git/tests/test_package_import.py
+++ b/dist-git/tests/test_package_import.py
@@ -23,49 +23,49 @@ from copr_dist_git.helpers import distgit_cmd_path
 MODULE_REF = 'copr_dist_git.package_import'
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_os_setgid():
     with mock.patch("{}.os.setgid".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_subprocess_check_output():
     with mock.patch("{}.subprocess.check_output".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_helpers():
     with mock.patch("{}.helpers".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_shutil():
     with mock.patch("{}.shutil".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_sync_branch():
     with mock.patch("{}.sync_branch".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_refresh_cgit_listing():
     with mock.patch("{}.refresh_cgit_listing".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_setup_git_repo():
     with mock.patch("{}.setup_git_repo".format(MODULE_REF)) as handle:
         yield handle
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def mc_pyrpkg_commands():
     with mock.patch("{}.Commands".format(MODULE_REF)) as handle:
         yield handle

--- a/rpmbuild/tests/test_mock.py
+++ b/rpmbuild/tests/test_mock.py
@@ -17,7 +17,7 @@ except ImportError:
      import mock
      builtins = '__builtin__'
 
-@pytest.yield_fixture
+@pytest.fixture
 def f_mock_calls():
     p_popen = mock.patch('copr_rpmbuild.builders.mock.GentlyTimeoutedPopen')
 


### PR DESCRIPTION
Fix #3351

The deprecation warning even says "Use @pytest.fixture instead; they are the same".