### PR TITLE
Don't check that specfile matches the repository name

### DIFF
--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -19,7 +19,7 @@ BuildRequires: systemd
 BuildRequires: python3-devel
 BuildRequires: python3-munch
 BuildRequires: python3-requests
-BuildRequires: python3-rpkg >= 1.66-6
+BuildRequires: python3-rpkg >= 1.67-1
 BuildRequires: python3-pytest
 BuildRequires: python3-copr-common >= %copr_common_version
 BuildRequires: python3-oslo-concurrency

--- a/dist-git/copr_dist_git/package_import.py
+++ b/dist-git/copr_dist_git/package_import.py
@@ -223,7 +223,8 @@ def import_package(opts, namespace, branches, srpm_path, pkg_name):
 
         try:
             if not branch_commits:
-                upload_files = commands.import_srpm(srpm_path)
+                upload_files = commands.import_srpm(
+                    srpm_path, check_specfile_matches_repo_name=False)
                 # in case of importing, the content of directory in `reponame`
                 # changes. To update the state of `Commands` class isn't an easy
                 # process - look how much logic pyrpkg.cli.cliClient.load_cmd has

--- a/dist-git/tests/generate_quick_package
+++ b/dist-git/tests/generate_quick_package
@@ -2,7 +2,7 @@
 
 : ${dummy_version="$(date +"%Y%m%d_%H%M")"}
 
-spec=qiuck-package.spec
+spec=quick-package.spec
 tarball=tarball.tar.gz
 
 cat > "$spec" <<EOF

--- a/dist-git/tests/test_crazy_merging.py
+++ b/dist-git/tests/test_crazy_merging.py
@@ -127,7 +127,7 @@ def get_srpm(version):
     assert 0 == os.system("""set -e
     mkdir -p srpm_dir && cd srpm_dir
     export dummy_version={version}
-    {script_dir}/generate_qiuck_package
+    {script_dir}/generate_quick_package
     """.format(script_dir=scriptdir(), version=version))
 
     srpm_path = os.path.join(os.getcwd(), 'srpm_dir',


### PR DESCRIPTION
Fix #3365

The rpkg-1.67-1 first introduced this check which was implemented in
https://pagure.io/rpkg/pull-request/700

At first I thought the check is valid and we only have incorrectly named spec files and repositories in our tests. But rpkg-1.67-1 actually breaks importing even for our real usage. This leads me to think that when they compare the spec and repo name, they forget to strip a namespace from the repo name.