### PR TITLE
Make coprdirs have their repo available in the buildroot

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-coprdir.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-coprdir.sh
@@ -1,0 +1,67 @@
+#! /bin/bash
+#
+# Copyright (c) 2024 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation, either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see http://www.gnu.org/licenses/.
+
+
+# Include Beaker environment
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+# Load config settings
+HERE=$(dirname "$(realpath "$0")")
+source "$HERE/config"
+source "$HERE/helpers"
+
+
+quick_package_script ()
+{
+    cp "$HERE/files/quick-package.sh" script
+    echo "$1" >> script
+}
+
+
+rlJournalStart
+    rlPhaseStartSetup
+        setup_checks
+        rlAssertRpm "jq"
+        setupProjectName "coprdir"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        # Test that CoprDirs have their own repositories in the buildroot
+        tmp=`mktemp -d`
+        rlRun "copr-cli create --chroot $CHROOT $PROJECT"
+
+        # For an ease of implementation, the dependency and the package that
+        # requires it are both `hello`. In a real life the first package would
+        # be something like `python-copr` or `python-copr-common`, and the
+        # second package would be something like `copr-cli` or `copr-backend`.
+
+        # This is the dependency (e.g. python-copr)
+        rlRun "curl https://src.fedoraproject.org/rpms/hello/raw/rawhide/f/hello.spec > $tmp/hello-1.spec"
+        rlRun "sed -i '1s/^/Epoch: 6\n/' $tmp/hello-1.spec"
+        rlRun "copr-cli build $PROJECT:custom:foo $tmp/hello-1.spec"
+
+        # And this is the package that builds on top of it (e.g. copr-cli)
+        rlRun "curl https://src.fedoraproject.org/rpms/hello/raw/rawhide/f/hello.spec > $tmp/hello-2.spec"
+        rlRun "sed -i '1s/^/BuildRequires: hello >= 6:\n/' $tmp/hello-2.spec"
+        rlRun "copr-cli build $PROJECT:custom:foo $tmp/hello-2.spec"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        cleanProject
+    rlPhaseEnd
+rlJournalPrintText
+rlJournalEnd

--- a/doc/user_documentation.rst
+++ b/doc/user_documentation.rst
@@ -646,10 +646,8 @@ submit one build directly into the project, one build to the
 subproject.
 
 The subproject builds are isolated from each other but they can all
-see builds from the main ``test`` project repository. For the time
-being, the builds in the ``test:custom:foo`` subproject don't see
-other builds from the same subproject. This is not a design choice but
-rather a missing feature.
+see builds from their own repository and from the main ``test`` project
+repository.
 
 The subproject name has to start with the project name. It is followed
 by either ``:custom:`` or ``:pr:`` and a suffix. The suffix can be

--- a/frontend/coprs_frontend/coprs/logic/complex_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/complex_logic.py
@@ -582,8 +582,9 @@ class ProjectForking(object):
 
 class BuildConfigLogic(object):
     @classmethod
-    def generate_build_config(cls, copr, chroot_id):
+    def generate_build_config(cls, coprdir, chroot_id):
         """ Return dict with proper build config contents """
+        copr = coprdir.copr
         chroot = None
         for i in copr.active_copr_chroots:
             if i.mock_chroot.name == chroot_id:
@@ -608,6 +609,13 @@ class BuildConfigLogic(object):
                 "id": "copr_base_devel",
                 "baseurl": copr.repo_url + "/{}/devel/".format(chroot_id),
                 "name": "Copr buildroot",
+            })
+
+        if not coprdir.main:
+            repos.append({
+                "id": "copr_coprdir",
+                "baseurl": coprdir.repo_url + "/{}/".format(chroot_id),
+                "name": "Coprdir repository",
             })
 
         # None value of the priority won't show in API

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_build_chroots.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_build_chroots.py
@@ -37,7 +37,8 @@ def to_dict(build_chroot):
 
 
 def build_config(build_chroot):
-    config = BuildConfigLogic.generate_build_config(build_chroot.build.copr, build_chroot.name)
+    config = BuildConfigLogic.generate_build_config(
+        build_chroot.build.copr_dir, build_chroot.name)
     copr_chroot = CoprChrootsLogic.get_by_name_or_none(build_chroot.build.copr, build_chroot.name)
     dict_data = {
         "repos": config.get("repos"),

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_project_chroots.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_project_chroots.py
@@ -51,7 +51,8 @@ def to_dict(project_chroot):
 
 
 def to_build_config_dict(project_chroot):
-    config = BuildConfigLogic.generate_build_config(project_chroot.copr, project_chroot.name)
+    config = BuildConfigLogic.generate_build_config(
+        project_chroot.copr.main_dir, project_chroot.name)
     config_dict = {
         "chroot": project_chroot.name,
         "repos": config["repos"],

--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -181,7 +181,8 @@ def get_build_record(task, for_backend=False):
     if modules:
         build_record["modules"] = {'toggle': modules}
 
-    build_config = BuildConfigLogic.generate_build_config(task.build.copr, task.mock_chroot.name)
+    build_config = BuildConfigLogic.generate_build_config(
+        task.build.copr_dir, task.mock_chroot.name)
     build_record["repos"] = build_config.get("repos")
     build_record["buildroot_pkgs"] = build_config.get("additional_packages")
     build_record["with_opts"] = build_config.get("with_opts")

--- a/frontend/coprs_frontend/tests/test_logic/test_complex_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_complex_logic.py
@@ -254,11 +254,11 @@ class TestProjectForking(CoprsTestCase):
                        "/results/user1/foocopr/fedora-18-x86_64/",
             "priority": None,
         }
-        build_config = bcl.generate_build_config(self.c1, "fedora-18-x86_64")
+        build_config = bcl.generate_build_config(self.c1.main_dir, "fedora-18-x86_64")
         assert build_config["repos"] == [main_repo]
 
         self.c1.repos = "copr://non/existing"
-        build_config = bcl.generate_build_config(self.c1, "fedora-18-x86_64")
+        build_config = bcl.generate_build_config(self.c1.main_dir, "fedora-18-x86_64")
 
         # We put the link there, even though baseurl points to 404.  The build
         # will later fail on downloading the repository and user will be


### PR DESCRIPTION
This is useful in general but especially for pull requests that build multiple packages which depend on each other (e.g. `python-copr` and `copr-cli`). Up until now, it had to be workarounded by building the dependency into the main copr repository.