### PR TITLE
Add resalloc-webui container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@
 #   5001:5001 -- DistGit Apache
 #   5002:5002 -- Backend Nginx
 #     --:5003 -- Keygen Apache (obtaining keys)
+#   5005:5000 -- Resalloc WebUI
 #
 # Other ports:
 #   5009:5432 -- PostgreSQL database
@@ -62,9 +63,24 @@ services:
     hostname: resalloc
     depends_on:
       - database
-    command: /usr/bin/resalloc-server
     stdin_open: true
     tty: true
+    volumes:
+      - resalloc:/persistent
+
+  resalloc-webui:
+    build:
+      context: docker/resalloc
+    hostname: resalloc-webui
+    depends_on:
+      - resalloc
+    command: python3 -c "from resallocwebui.app import app; app.run(host='0.0.0.0')"
+    stdin_open: true
+    tty: true
+    ports:
+      - "5005:5000"
+    volumes:
+      - resalloc:/persistent
 
   redis:
     image: centos/redis-32-centos7
@@ -172,3 +188,4 @@ volumes:
   dist-git:
   database:
   redis:
+  resalloc:

--- a/docker/resalloc/Dockerfile
+++ b/docker/resalloc/Dockerfile
@@ -12,6 +12,7 @@ RUN dnf install -y ansible \
                    resalloc \
                    resalloc-aws \
                    resalloc-server \
+                   resalloc-webui \
                    sqlite \
                    findutils \
                    openssh-clients \
@@ -20,5 +21,6 @@ RUN dnf install -y ansible \
 # copy filesystem setup
 COPY files/ /
 
-RUN cd $(rpm -ql resalloc-server |grep alembic.ini |xargs dirname) \
-    && alembic-3 upgrade head
+CMD cd $(rpm -ql resalloc-server |grep alembic.ini |xargs dirname) \
+    && alembic-3 upgrade head \
+    && /usr/bin/resalloc-server

--- a/docker/resalloc/files/etc/resallocserver/server.yaml
+++ b/docker/resalloc/files/etc/resallocserver/server.yaml
@@ -7,7 +7,7 @@
 #db_url: 'postgresql://resalloc@/resalloc'
 #For PostgreSQL listening on host/port, using password.
 #db_url: 'postgresql://resalloc:pass@localhost:5432/resalloc'
-db_url: 'sqlite:////var/lib/resallocserver/db.sqlite'
+db_url: 'sqlite:////persistent/db.sqlite'
 
 logdir: '/var/log/resallocserver'
 


### PR DESCRIPTION
Available at http://127.0.0.1:5005/

When running the `resalloc-webui` container for the first time, it will probably be necessary to manually rebuild the `resalloc` container first, to create the database on a shared volume.

    docker-compose up -d --build resalloc