### PR TITLE
Point Copr repositories to Pulp

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -696,12 +696,6 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         :param pkg: path to the source package
 
         """
-
-        # Ideally, we would like to have this decision in our storage classes
-        if self.job.storage == StorageEnum.pulp:
-            self.log.info("Not going to sign pkgs, Pulp will take care of that")
-            return
-
         self.log.info("Going to sign pkgs from source: %s in chroot: %s",
                       self.job.task_id, self.job.chroot_dir)
 
@@ -1019,12 +1013,12 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
 
         # raise error if build failed
         try:
-            self._upload_results_to_storage()
             self._check_build_success()
             # Build _succeeded_.  Do the tasks for successful run.
             failed = False
             if self.opts.do_sign:
                 self._sign_built_packages()
+            self._upload_results_to_storage()
             self._do_createrepo()
             self._parse_results()
             build_details = self._get_build_details(self.job)

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -205,6 +205,11 @@ class Config(object):
     # Possible options are "backend" and "pulp"
     DEFAULT_STORAGE = "backend"
 
+    # If build results for (some) projects are stored in Pulp, what is the
+    # shared part of the URL for all repositories, e.g.
+    # https://pulp.stage.devshift.net/api/pulp-content/copr
+    PULP_CONTENT_URL = None
+
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -663,13 +663,35 @@ class Copr(db.Model, helpers.Serializer, CoprSearchRelatedData):
 
     @property
     def repo_url(self):
-        return "/".join([app.config["BACKEND_BASE_URL"],
-                         u"results",
-                         self.full_name])
+        """
+        URL for a project repository
+        """
+        return "/".join([self.results_url, self.full_name])
 
     @property
     def repo_id(self):
         return "-".join([self.owner_name.replace("@", "group_"), self.name])
+
+    @property
+    def pubkey_url(self):
+        """
+        URL for the project public GPG key
+        """
+        return "/".join([
+            app.config["BACKEND_BASE_URL"],
+            "results",
+            self.full_name,
+            "pubkey.gpg",
+        ])
+
+    @property
+    def results_url(self):
+        """
+        URL for the project results directory
+        """
+        if self.storage == StorageEnum.pulp:
+            return app.config["PULP_CONTENT_URL"]
+        return "/".join([app.config["BACKEND_BASE_URL"], "results"])
 
     @property
     def modules_url(self):
@@ -849,8 +871,10 @@ class CoprDir(db.Model):
 
     @property
     def repo_url(self):
-        return "/".join([app.config["BACKEND_BASE_URL"],
-                         u"results", self.full_name])
+        """
+        URL for a CoprDir repository
+        """
+        return "/".join([self.copr.results_url, self.full_name])
 
     @property
     def repo_id(self):

--- a/frontend/coprs_frontend/coprs/templates/coprs/copr_dir.repo
+++ b/frontend/coprs_frontend/coprs/templates/coprs/copr_dir.repo
@@ -1,7 +1,11 @@
 [{{ repo_id }}]
 name={{ name }}
 {{- " (" + arch + ")" if arch }}
+{% if not pulp %}
 baseurl={{ url | fix_url_https_backend }}
+{% else %}
+baseurl={{ url }}
+{% endif %}
 type=rpm-md
 skip_if_unavailable=True
 gpgcheck={{ config.REPO_GPGCHECK | default("1")}}

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_rpmrepo.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_rpmrepo.py
@@ -6,7 +6,6 @@
 
 from flask_restx import Resource, Namespace
 
-from coprs import app
 from coprs.logic.coprs_logic import (
     CoprsLogic,
     CoprDirsLogic,
@@ -48,7 +47,8 @@ def get_project_rpmrepo_metadata(copr):
     repos_info = ReposLogic.repos_for_copr(copr, repo_dl_stat)
 
     data = {
-        "results_url": "/".join([app.config["BACKEND_BASE_URL"], "results"]),
+        "results_url": copr.results_url,
+        "pubkey_url": copr.pubkey_url,
     }
 
     repos = data['repos'] = {}

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
@@ -21,6 +21,7 @@ from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter
 
+from copr_common.enums import StorageEnum
 from coprs import app
 from coprs import cache
 from coprs import db
@@ -861,14 +862,15 @@ def render_repo_template(copr_dir, mock_chroot, arch=None, cost=None, runtime_de
         copr_dir.copr, copr_dir.name, multilib=arch,
         dep_idx=runtime_dep, dependent=dependent)
 
+    pulp = copr_dir.copr.storage == StorageEnum.pulp
     url = os.path.join(copr_dir.repo_url, '') # adds trailing slash
     repo_url = generate_repo_url(mock_chroot, url, arch)
-    pubkey_url = urljoin(url, "pubkey.gpg")
-
+    pubkey_url = copr_dir.copr.pubkey_url
     return flask.render_template("coprs/copr_dir.repo", copr_dir=copr_dir,
                                  url=repo_url, pubkey_url=pubkey_url,
                                  repo_id=repo_id, arch=arch, cost=cost,
-                                 name=name, repo_priority=copr_dir.copr.repo_priority)
+                                 name=name, pulp=pulp,
+                                 repo_priority=copr_dir.copr.repo_priority)
 
 
 def _render_external_repo_template(dep, copr_dir, mock_chroot, dep_idx):

--- a/frontend/coprs_frontend/tests/test_apiv3/test_rpmrepo.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_rpmrepo.py
@@ -21,7 +21,9 @@ U1_DATA = {'dependencies': [],
            'fedora-21': {'arch': _ARCH },
            'fedora-22': {'arch': _ARCH },
            'fedora-23': {'arch': _ARCH }},
- 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results'}
+ 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results',
+ 'pubkey_url': ('http://copr-be-dev.cloud.fedoraproject.org/results/'
+                'user1/foocopr/pubkey.gpg')}
 
 
 U2_DATA = {'delete_after_days': 179,
@@ -40,14 +42,18 @@ U2_DATA = {'delete_after_days': 179,
  'repos': {'fedora-18': {'arch': {'x86_64': {'delete_after_days': 9,
                                              'opts': {}}}},
            'fedora-rawhide': {'arch': {'i386': {'opts': {}}}}},
- 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results'}
+ 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results',
+ 'pubkey_url': ('http://copr-be-dev.cloud.fedoraproject.org/results/'
+                'user2/barcopr/pubkey.gpg')}
 
 
 DIRS = {'dependencies': [],
  'directories': {'test': {}, 'test:pr:1123': {'delete_after_days': 39}},
  'repos': {'fedora-17': {'arch': {'i386': {'opts': {}},
                                   'x86_64': {'opts': {}}}}},
- 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results'}
+ 'results_url': 'http://copr-be-dev.cloud.fedoraproject.org/results',
+ 'pubkey_url': ('http://copr-be-dev.cloud.fedoraproject.org/results/'
+                'user1/test/pubkey.gpg')}
 
 
 class TestApiRPMRepo(CoprsTestCase):


### PR DESCRIPTION
Fix #3375

Of course only for Copr projects that has configured to have their storage in Pulp, not all Copr projects.

There are three possible options how to implement this.

1. The Most straightforward is to not generate repofiles ourselves and let Pulp
   do it. The downside is that we would have to pass additional parameters (it
   is possible though) such as repo priority, module hotfixes attribute, etc,
   and figure out how to count repo downloads
2. Generate repofiles ourselves, only point to `baseurl` in Pulp. This IMHO the
   best option for keeping compatibility between storage on the backend and in
   Pulp, so I implement this option in this PR.
3. Adding a Lighttpd redirect for `baseurl` of the Pulp-stored projects to Pulp
   content URL. This will be needed in the future to ensure that users don't
   have to re-enable Copr repositories, once those projects are migrated to
   Pulp. But this will be hard to implement, so we decided to do it when the
   time comes.