### PR TITLE
Don't upload RPM packages to Pulp as artifacts

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -151,28 +151,17 @@ class PulpClient:
         }
         return requests.patch(url, json=data, **self.request_params)
 
-    def create_content(self, repository, artifact, relative_path):
+    def create_content(self, repository, path):
         """
         Create content for a given artifact
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Content:-Packages/operation/content_rpm_packages_create
         """
         url = self.url("api/v3/content/rpm/packages/")
-        data = {
-            "repository": repository,
-            "artifact": artifact,
-            "relative_path": relative_path,
-        }
-        return requests.post(url, json=data, **self.request_params)
-
-    def upload_artifact(self, path):
-        """
-        Create an artifact
-        https://docs.pulpproject.org/pulpcore/restapi.html#tag/Artifacts/operation/artifacts_create
-        """
         with open(path, "rb") as fp:
-            url = self.url("api/v3/artifacts/")
-            data = {"file": fp}
-            return requests.post(url, files=data, **self.request_params)
+            data = {"repository": repository}
+            files = {"file": fp}
+            return requests.post(
+                url, data=data, files=files, **self.request_params)
 
     def delete_repository(self, repository):
         """

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -161,18 +161,8 @@ class PulpStorage(Storage):
                     continue
 
                 path = os.path.join(root, name)
-                response = self.client.upload_artifact(path)
-                if not response.ok:
-                    self.log.error("Failed to upload %s to Pulp", path)
-                    continue
-
-                artifact = response.json()["pulp_href"]
-                relative_path = os.path.join(
-                    self.owner, self.project, target_dir_name)
-
                 repository = self._get_repository(chroot)
-                response = self.client.create_content(
-                    repository, artifact, relative_path)
+                response = self.client.create_content(repository, path)
 
                 if not response.ok:
                     self.log.error("Failed to create Pulp content for: %s, %s",


### PR DESCRIPTION
Fix https://github.com/pulp/pulp_rpm/issues/3719

Instead of uploading RPM packages as artifacts in one API call, and then creating a content from them in a separate call, we will now create the content directly.

There are mutiple reasons to do so:

- One API call instead of two
- It fixes the issue with installing packages mentioned above
- @dkliban says there is an effort to not allow uploading artifacts on shared Pulp instances

There is only one disadvantage of doing this, we lose track of what RPM packages belong to a specific Copr build ID. We will use labels for this, once they are implemented.

See https://github.com/pulp/pulpcore/issues/3338#issuecomment-2255898417