### PR TITLE
rpmbuild: in F41 do not depend on yum

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -91,7 +91,7 @@ Summary: copr-rpmbuild with all weak dependencies
 Requires: %{name} = %{version}-%{release}
 Requires: dist-git-client
 
-%if 0%{?fedora}
+%if 0%{?fedora} && 0%{?fedora} < 41
 # replacement for yum/yum-utils, to be able to work with el* chroots
 # bootstrap_container.
 Requires: dnf-yum


### PR DESCRIPTION
Addressing F41 installation issue:
 Problém 9: problém s nainstalovaným balíčkem dnf5-5.2.5.0-20240829005832.58.gbe2e6bef.fc40.x86_64
  - package dnf5-5.2.5.0-20240809005713.33.g98e6b01b.fc41.x86_64 from copr:copr.fedorainfracloud.org:rpmsoftwaremanagement:dnf5-unstable obsoletes yum < 5 provided by yum-4.21.1-1.fc41.noarch from fedora
  - package dnf5-5.2.5.0-2.fc41.x86_64 from fedora obsoletes yum < 5 provided by yum-4.21.1-1.fc41.noarch from fedora
  - package copr-builder-0.73-3.fc41.x86_64 from fedora requires dnf-yum, but none of the providers can be installed
  - problém s nainstalovaným balíčkem copr-builder-0.73-1.fc40.x86_64
  - yum-4.21.1-1.fc40.noarch from @System  does not belong to a distupgrade repository
  - dnf5-5.2.5.0-20240829005832.58.gbe2e6bef.fc40.x86_64 from @System  does not belong to a distupgrade repository
  - copr-builder-0.73-1.fc40.x86_64 from @System  does not belong to a distupgrade repository

Note that this means that we are unable to install older chroots (EL8-) without bootstrap. I.e. building EL8 package will require bootstrap.