### PR TITLE
frontend: show Webhook History under Settings->Integrations

### DIFF
--- a/frontend/coprs_frontend/alembic/versions/bb52d9f878f5_change_webhook_history_timestamp_column_.py
+++ b/frontend/coprs_frontend/alembic/versions/bb52d9f878f5_change_webhook_history_timestamp_column_.py
@@ -1,0 +1,26 @@
+"""
+Change Webhook History timestamp column type from DateTime to Integer UNIX timestamp
+
+Revision ID: bb52d9f878f5
+Create Date: 2024-09-19 18:07:28.504280
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import func
+
+
+# revision identifiers, used by Alembic.
+revision = 'bb52d9f878f5'
+down_revision = '06b208e317a3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('webhook_history', sa.Column('created_on', sa.Integer(), nullable=True))
+    op.drop_column('webhook_history', 'timestamp')
+
+def downgrade():
+    op.add_column('webhook_history', sa.Column('timestamp', sa.DateTime(timezone=True), server_default=func.now()))
+    op.drop_column('webhook_history', 'created_on')

--- a/frontend/coprs_frontend/coprs/logic/webhooks_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/webhooks_logic.py
@@ -1,0 +1,22 @@
+"""
+    Module for Webhooks History related backend logic.
+"""
+
+from coprs import db, models
+class WebhooksLogic:
+    """
+        Class to retrieve Webhook History records from database.
+    """
+    @classmethod
+    def get_all_webhooks(cls, copr):
+        """
+        Returns all webhooks received for a copr in newest first order.
+        """
+        builds = (db.session.query(models.Build).join(models.WebhookHistory)
+                            .filter(models.Build.webhook_history is not None,
+                                    models.Build.copr_id == copr.id).all())
+
+        #Remove any duplicates from the webhook history list.
+        webhook_history = {x.webhook_history for x in builds}
+
+        return webhook_history

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -19,11 +19,10 @@ import zlib
 
 import modulemd_tools.yaml
 
-from sqlalchemy import outerjoin, text, DateTime
+from sqlalchemy import outerjoin, text
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import column_property, validates
 from sqlalchemy.event import listens_for
-from sqlalchemy.sql import func
 from libravatar import libravatar_url
 
 from flask import url_for
@@ -1576,7 +1575,7 @@ class Build(db.Model, helpers.Serializer):
 class WebhookHistory(db.Model):
     '''Represents a Webhook UUID & a build initiated by it.'''
     id = db.Column(db.Integer, primary_key=True)
-    timestamp = db.Column(DateTime(timezone=True), server_default=func.now())
+    created_on = db.Column(db.Integer, nullable=True)
     # Null values are possible via custom webhook implementation that do not pass a UUID or User Agent.
     user_agent = db.Column(db.Text,nullable=True)
     webhook_uuid = db.Column(db.Text, nullable=True)

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/settings/integrations.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/settings/integrations.html
@@ -1,6 +1,6 @@
 {% extends "coprs/detail/settings.html" %}
 
-{% from "_helpers.html" import render_field, render_form_errors, copr_url %}
+{% from "_helpers.html" import render_field, render_form_errors, copr_url, initialize_datatables %}
 
 {% set selected_monitor_tab = "integrations" %}
 {%block settings_breadcrumb %}Integrations{% endblock %}
@@ -66,6 +66,31 @@
         </div>
         <div class="well well-sm">
             {{ custom_dir_url }}
+        </div>
+
+        <h3>Webhook History</h3>
+        <div>
+            {% if webhook_history %}
+            <table class="datatable dataTable table table-striped table-bordered">
+                <thead>
+                  <tr>
+                    <th>Timstamp</th>
+                    <th>Webhook ID</th>
+                    <th>User Agent</th>
+                  </tr>
+                </thead>
+                {% for webhook in webhook_history %}
+                <tr>
+                    <td  class="webhook_timestamp" data-toggle="tooltip" title="{{webhook.created_on|localized_time(g.user.timezone)}}">{{webhook.created_on|localized_time(g.user.timezone)}} ({{webhook.created_on|time_ago()}})</td>
+                    <td>{{webhook.webhook_uuid}} </td>
+                    <td>{{webhook.user_agent}}</td>
+                </tr>
+                {% endfor %}
+            </table>
+            {% else %}
+                <p>No webhook received recently.</p>
+            {% endif %}
+            {{initialize_datatables(order="desc")}}
         </div>
     </div>
 </div>

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
@@ -32,6 +32,7 @@ from coprs.exceptions import ObjectNotFound, BadRequest, CoprHttpException
 from coprs.logic.coprs_logic import CoprsLogic, PinnedCoprsLogic, MockChrootsLogic
 from coprs.logic.stat_logic import CounterStatLogic
 from coprs.logic.modules_logic import ModulesLogic, ModulemdGenerator, ModuleBuildFacade
+from coprs.logic.webhooks_logic import WebhooksLogic
 from coprs.mail import send_mail, LegalFlagMessage, PermissionRequestMessage, PermissionChangeMessage
 
 from coprs.logic.complex_logic import ComplexLogic, ReposLogic
@@ -470,10 +471,12 @@ def render_copr_integrations(copr, pagure_form):
           copr.webhook_secret,
     ) + "<PACKAGE_NAME>/"
 
+    webhook_history = WebhooksLogic.get_all_webhooks(copr)
+
     return flask.render_template(
         "coprs/detail/settings/integrations.html",
         copr=copr, bitbucket_url=bitbucket_url, github_url=github_url,
-        gitlab_url=gitlab_url, custom_url=custom_url,
+        gitlab_url=gitlab_url, custom_url=custom_url, webhook_history=webhook_history,
         custom_dir_url=custom_dir_url, pagure_form=pagure_form)
 
 

--- a/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
+++ b/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import time
 import shutil
 from typing import Optional
 
@@ -91,7 +92,8 @@ def add_webhook_history_record(webhook_uuid, user_agent='Not Set',
         log.debug("No build initiated. Webhook not logged to db.")
         return
 
-    webhookRecord = models.WebhookHistory(webhook_uuid=webhook_uuid,
+    webhookRecord = models.WebhookHistory(created_on=int(time.time()),
+                                          webhook_uuid=webhook_uuid,
                                           user_agent=user_agent)
     db.session.add(webhookRecord)
     db.session.commit()


### PR DESCRIPTION
This is part 2 of PR #3342 that implements a table under Settings -> Integration page displaying data from `webhook_history` table. See image below for demo.
![image](https://github.com/user-attachments/assets/fe9b1660-2b8b-451f-947b-a88537f28ea8)
