### PR TITLE
rpmbuild: do not require qemu-user-static on rhel

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -63,7 +63,9 @@ Requires: git
 Requires: git-svn
 # for the /bin/unbuffer binary
 Requires: expect
-%if !0%{?openEuler}
+%if 0%{?openEuler} > 0 || 0%{?rhel} > 0
+# qemu-user-static is not supported
+%else
 Requires: qemu-user-static
 %endif
 Requires: sed

--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -106,7 +106,9 @@ Requires: nosync
 %endif
 Requires: openssh-clients
 Requires: podman
-%if !0%{?openEuler}
+%if 0%{?openEuler} > 0 || 0%{?rhel} > 0
+# not supported
+%else
 Requires: pyp2rpm
 Requires: pyp2spec
 Requires: rubygem-gem2rpm


### PR DESCRIPTION
Resolves: RHBZ#2313879