### PR TITLE
Fix traceback caused by None timeout

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -790,8 +790,10 @@ class BuildsLogic(object):
 
         if "timeout" in build_options:
             build.timeout = build_options["timeout"]
+        elif package and package.timeout:
+            build.timeout = package.timeout
         else:
-            build.timeout = package.timeout if package else app.config["DEFAULT_BUILD_TIMEOUT"]
+            build.timeout = app.config["DEFAULT_BUILD_TIMEOUT"]
 
         return build
 


### PR DESCRIPTION
Running `runtest-custom-method.sh`, we are seeing this failure in backend.log:

    Unexpected exception (in /usr/lib/python3.12/site-packages/copr_backend/background_worker_build.py:431)

The problematic line is

    timestamp = self.job.started_on + self.job.timeout + 60 * 60

and the hidden exception is

    TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'

The `self.job.timeout` is taken from the frontend task, if it is set. The problem is when frontend sets it to `None`.