### PR TITLE
frontend: add missing dialect ref for identifier_preparer

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/batches_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/batches_logic.py
@@ -31,7 +31,7 @@ def _lock_table(table):
     with db.engine.connect() as connection:
         connection.execute(text("LOCK TABLE {} IN EXCLUSIVE MODE;".format(
             # https://docs.sqlalchemy.org/en/13/core/internals.html#sqlalchemy.sql.compiler.IdentifierPreparer.quote
-            db.engine.identifier_preparer.quote(table)
+            db.engine.dialect.identifier_preparer.quote(table)
         )))
 
 


### PR DESCRIPTION
https://docs.sqlalchemy.org/en/20/core/internals.html#sqlalchemy.engine.Dialect.identifier_preparer

fixes traceback:

```
  File "/usr/share/copr/coprs_frontend/coprs/logic/batches_logic.py", line 45, in locked_table
    _lock_table(table_name)
  File "/usr/lib/python3.12/site-packages/backoff/_sync.py", line 105, in retry
    ret = target(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/copr/coprs_frontend/coprs/logic/batches_logic.py", line 34, in _lock_table
    db.engine.identifier_preparer.quote(table)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Engine' object has no attribute 'identifier_preparer'

```