### PR TITLE
rpmbuild: add copr-builder-rhsm-subscribe script

### DIFF
--- a/rpmbuild/bin/copr-builder-rhsm-subscribe
+++ b/rpmbuild/bin/copr-builder-rhsm-subscribe
@@ -1,0 +1,48 @@
+#! /usr/bin/python3
+
+"""
+Run `subscription-manager register` without having the --activation key in
+/proc/self/environ or /proc/self/comm.
+"""
+
+import argparse
+import getpass
+import sys
+
+from subscription_manager.scripts.subscription_manager import main as rhsm
+
+
+def read_key():
+    """
+    Read key from stdin if not a tty.  Never export as env-var.
+    """
+    if sys.stdin.isatty():
+        key = getpass.getpass("rhsm key: ")
+    else:
+        key = sys.stdin.read()
+    return key.strip()
+
+
+def _arg_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--org-id", required=True)
+    parser.add_argument("--system-name", required=True)
+    return parser
+
+
+def _main():
+    opts = _arg_parser().parse_args()
+    a_key = read_key()
+    sys.argv = [
+        "subscription-manager", "register", "--force",
+        "--org", opts.org_id,
+        "--name", opts.system_name,
+        "--activationkey", a_key,
+    ]
+    # Call subscription-manager's internal method to avoid polluting the
+    # /proc/self/cmdline with the key credential!
+    rhsm()
+
+
+if __name__ == "__main__":
+    _main()

--- a/rpmbuild/bin/copr-builder-rhsm-subscribe-daemon
+++ b/rpmbuild/bin/copr-builder-rhsm-subscribe-daemon
@@ -1,0 +1,44 @@
+#! /bin/bash
+
+# Try to run subscription-manager register repeatedly (till it succeeds),
+# without polluting environment variables or command-line options with
+# passwords/keys.
+
+if test $# -ne 2; then
+cat <<EOHELP >&2
+Usage: $0 ORG_ID SYSTEM_NAME <<<"\$password"
+
+Provide the activation_key on stdin!
+EOHELP
+exit 1
+fi
+
+opt_org_id=$1
+opt_system=$2
+
+try_indefinitely()
+{
+    cmd=( "$@" )
+    while :; do
+        if "${cmd[@]}"; then
+            break
+        fi
+        sleep 5
+    done
+}
+
+test "$(id -u)" = 0 || {
+    echo >&2 "run as root"
+    exit 1
+}
+
+test -t 0 && echo -n "RH Activation Key: "
+read -r -s opt_pass
+
+register()
+{
+    copr-builder-rhsm-subscribe --org-id "$opt_org_id" --system-name "$opt_system" <<<"$opt_pass"
+}
+
+try_indefinitely register
+touch /run/copr-builder/rhsm-subscribed

--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -44,6 +44,7 @@ BuildRequires: python3-pyyaml
 
 BuildRequires: /usr/bin/argparse-manpage
 BuildRequires: python-rpm-macros
+BuildRequires: systemd-rpm-macros
 
 %if "%{?python}" == "python2"
 BuildRequires: python2-configparser
@@ -61,6 +62,7 @@ Requires: python3-backoff >= 1.9.0
 Requires: python3-pyyaml
 
 Requires: mock >= 5.0
+Requires(pre): mock-filesystem
 Requires: git
 Requires: git-svn
 # for the /bin/unbuffer binary
@@ -230,8 +232,7 @@ EOF
 
 install -d %{buildroot}%{_mandir}/man1
 install -p -m 644 man/copr-rpmbuild.1 %{buildroot}/%{_mandir}/man1/
-install -p -m 755 bin/copr-builder %buildroot%_bindir
-install -p -m 755 bin/copr-builder-cleanup %buildroot%_bindir
+install -p -m 755 bin/copr-builder* %buildroot%_bindir
 install -p -m 755 bin/copr-sources-custom %buildroot%_bindir
 install -p -m 755 bin/copr-rpmbuild-cancel %buildroot%_bindir
 install -p -m 755 bin/copr-rpmbuild-log %buildroot%_bindir
@@ -249,6 +250,11 @@ install -p -m 755 copr-update-builder %buildroot%_bindir
     install -p -m 644 "$line" "$dir"
   done
 )
+
+mkdir %{buildroot}%{_tmpfilesdir}
+cat > %{buildroot}%{_tmpfilesdir}/copr-builder.conf <<EOF
+d /run/copr-builder 0775 root mock -
+EOF
 
 
 %files
@@ -278,9 +284,13 @@ install -p -m 755 copr-update-builder %buildroot%_bindir
 %_bindir/copr-builder
 %_bindir/copr-update-builder
 %_bindir/copr-builder-cleanup
+%_bindir/copr-builder-rhsm-subscribe
+%_bindir/copr-builder-rhsm-subscribe-daemon
 %_sysconfdir/copr-builder
 %dir %mock_config_overrides
 %doc %mock_config_overrides/README
+%ghost %attr(775,root,mock) %dir %_rundir/copr-builder
+%_tmpfilesdir/copr-builder.conf
 
 
 %changelog


### PR DESCRIPTION
This allows us to specify RHSM password so it is not visible on `ps aux` output