### PR TITLE
rpmbuild: don't try to log that logger is not ready yet

### DIFF
--- a/rpmbuild/bin/copr-rpmbuild-log
+++ b/rpmbuild/bin/copr-rpmbuild-log
@@ -48,7 +48,7 @@ def _tail_log(config):
 
     for fname in [pidfile, live_log]:
         if not os.path.exists(fname):
-            LOG.warning("File %s doesn't exist, yet", fname)
+            print("File {0} doesn't exist, yet".format(fname))
             return
 
     with open(pidfile, "r") as pidfd:


### PR DESCRIPTION
This causes a recursion error, crashing the whole script

    File "/usr/lib64/python3.12/logging/__init__.py", line 1762, in callHandlers
      hdlr.handle(record)
    File "/usr/lib64/python3.12/logging/__init__.py", line 1700, in handle
      self.callHandlers(record)
    File "/usr/lib64/python3.12/logging/__init__.py", line 1762, in callHandlers
      hdlr.handle(record)
    File "/usr/lib64/python3.12/logging/__init__.py", line 1695, in handle
      maybe_record = self.filter(record)
                     ^^^^^^^^^^^^^^^^^^^
    RecursionError: maximum recursion depth exceeded