### PR TITLE
Custom Webhook now adds a record in Webhook History table

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/settings/integrations.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/settings/integrations.html
@@ -75,15 +75,21 @@
                 <thead>
                   <tr>
                     <th>Timstamp</th>
-                    <th>Webhook ID</th>
+                    <th>Forge-generated Webhook UUID</th>
                     <th>User Agent</th>
                   </tr>
                 </thead>
                 {% for webhook in webhook_history %}
                 <tr>
-                    <td  class="webhook_timestamp" data-toggle="tooltip" title="{{webhook.created_on|localized_time(g.user.timezone)}}">{{webhook.created_on|localized_time(g.user.timezone)}} ({{webhook.created_on|time_ago()}})</td>
-                    <td>{{webhook.webhook_uuid}} </td>
-                    <td>{{webhook.user_agent}}</td>
+                    <td  class="webhook_timestamp" data-toggle="tooltip" title="{{webhook.created_on|localized_time(g.user.timezone)}}">{{webhook.created_on|localized_time(g.user.timezone)}} ({{webhook.created_on|time_ago()}} ago)</td>
+                    <td>{% if webhook.webhook_uuid is none %} No UUID received
+                        {% else %}{{ webhook.webhook_uuid }}
+                        {% endif %}
+                   </td>
+                    <td>{% if webhook.user_agent is none %} Not Set 
+                        {% else %} {{webhook.user_agent}}
+                        {% endif %}
+                    </td>
                 </tr>
                 {% endfor %}
             </table>

--- a/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
+++ b/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
@@ -85,8 +85,8 @@ def package_name_required(route):
 def add_webhook_history_record(webhook_uuid, user_agent=None,
                                builds_initiated_via_hook=None):
     """
-    This methods adds info of an intercepted webhook to webhook_history db
-    along with the initiated build number(s).
+    This method adds info of an intercepted webhook to webhook_history db
+    and updates the Build table with the corresponding webhook_history ID.
     """
     if builds_initiated_via_hook is None:
         log.debug("No build initiated. Webhook not logged to db.")
@@ -96,9 +96,6 @@ def add_webhook_history_record(webhook_uuid, user_agent=None,
                                           webhook_uuid=webhook_uuid,
                                           user_agent=user_agent)
     db.session.add(webhook_record)
-
-    if not isinstance(builds_initiated_via_hook, list):
-        builds_initiated_via_hook = [builds_initiated_via_hook]
 
     for build in builds_initiated_via_hook:
         build.webhook_history = webhook_record
@@ -350,7 +347,7 @@ def custom_build_submit(copr, package, copr_dir=None):
         return "BUILD_REQUEST_ERROR\n", 500
 
     user_agent = flask.request.headers.get('User-Agent')
-    add_webhook_history_record(None, user_agent, build)
+    add_webhook_history_record(None, user_agent, [build])
 
     # Return the build ID, so (e.g.) the CI process (e.g. Travis job) knows
     # what build results to wait for.


### PR DESCRIPTION
Custom Webhooks are not expected to send a UUID. Instead the UI checks for `None` passed for Webhook UUID and prints "Custom Webhook" instead. See below, 
![image](https://github.com/user-attachments/assets/bb2bd878-dc7a-442a-85e1-4a77e4c7d00c)

Fix #3455 