### PR TITLE
Store payload in Webhook History & make webhook ID clickable to show corresponding payload

### DIFF
--- a/frontend/coprs_frontend/alembic/versions/046fb5ed2cf3_add_new_column_to_store_webhook_payload.py
+++ b/frontend/coprs_frontend/alembic/versions/046fb5ed2cf3_add_new_column_to_store_webhook_payload.py
@@ -1,0 +1,24 @@
+"""
+add new column to store Webhook payload
+
+Revision ID: 046fb5ed2cf3
+Create Date: 2024-10-07 05:53:50.891339
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '046fb5ed2cf3'
+down_revision = 'bb52d9f878f5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('webhook_history', sa.Column('payload', sa.Text())) 
+
+
+def downgrade():
+    op.drop_column('webhook_history', 'payload')

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -1603,6 +1603,7 @@ class WebhookHistory(db.Model):
     # Null values are possible via custom webhook implementation that do not pass a UUID or User Agent.
     user_agent = db.Column(db.Text,nullable=True)
     webhook_uuid = db.Column(db.Text, nullable=True)
+    payload = db.Column (db.Text, nullable=True)
 
 
 class DistGitBranch(db.Model, helpers.Serializer):

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/settings/integrations.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/settings/integrations.html
@@ -82,7 +82,15 @@
                 {% for webhook in webhook_history %}
                 <tr>
                     <td  class="webhook_timestamp" data-toggle="tooltip" title="{{webhook.created_on|localized_time(g.user.timezone)}}">{{webhook.created_on|localized_time(g.user.timezone)}} ({{webhook.created_on|time_ago()}})</td>
-                    <td>{{webhook.webhook_uuid}} </td>
+                    <td data-toggle="tooltip" title="Show JSON payload">
+                        {% if webhook.payload is not none %} 
+                            <a href="#" onclick="showJson(this);" data-json="{{webhook.payload}}">
+                            {{webhook.webhook_uuid}}
+                            </a>
+                        {% else %}
+                            {{webhook.webhook_uuid}}
+                        {% endif %}
+                    </td>
                     <td>{{webhook.user_agent}}</td>
                 </tr>
                 {% endfor %}
@@ -94,5 +102,15 @@
         </div>
     </div>
 </div>
+
+<script>
+    function showJson(element) {
+        const jsonData = element.getAttribute('data-json');
+        if(jsonData === "null") return;
+        const newTab = window.open();
+        newTab.document.write('<pre>' + JSON.stringify(JSON.parse(jsonData), null, 2) + '</pre>');
+        newTab.document.close();
+    }
+</script>
 
 {% endblock %}

--- a/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
+++ b/frontend/coprs_frontend/coprs/views/webhooks_ns/webhooks_general.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import time
 import shutil
+import json
 from typing import Optional
 
 import flask
@@ -83,7 +84,7 @@ def package_name_required(route):
 
 
 def add_webhook_history_record(webhook_uuid, user_agent='Not Set',
-                               builds_initiated_via_hook=None):
+                               builds_initiated_via_hook=None, payload=None):
     """
     This methods adds info of an intercepted webhook to webhook_history db
     along with the initiated build number(s).
@@ -94,7 +95,7 @@ def add_webhook_history_record(webhook_uuid, user_agent='Not Set',
 
     webhookRecord = models.WebhookHistory(created_on=int(time.time()),
                                           webhook_uuid=webhook_uuid,
-                                          user_agent=user_agent)
+                                          user_agent=user_agent, payload=payload)
     db.session.add(webhookRecord)
     db.session.commit()
 
@@ -198,7 +199,7 @@ def webhooks_git_push(copr_id: int, uuid, pkg_name: Optional[str] = None):
         builds_initiated_via_webhook.append(build)
 
     add_webhook_history_record(webhook_uuid, user_agent,
-                               builds_initiated_via_webhook)
+                               builds_initiated_via_webhook, json.dumps(payload))
     db.session.commit()
 
     return "OK", 200


### PR DESCRIPTION
In this PR, 

1. Webhook Payload is stored in Webhook History table. 
2. The Webhook ID is rendered as a link to open the payload in new tab. The JSON data is passed as a HTML Data Attribute along with the markup.
![image](https://github.com/user-attachments/assets/3c52ab86-5129-4bac-b971-fbdf454720d4)
3. Payload opened in new tab using javascript function `showJson`,
![image](https://github.com/user-attachments/assets/0658e24f-7b83-4df4-8591-40bdaf5ad246)

Reference,
https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes

Fixed #634 

<!-- issue-commentator = {"comment-id":"2647927007"} -->