### PR TITLE
frontend: avoid a duplicated "exists" check

### DIFF
--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_projects.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_projects.py
@@ -242,7 +242,6 @@ class ProjectAdd(Resource):
                 selected_chroots=form.selected_chroots,
                 description=form.description.data,
                 instructions=form.instructions.data,
-                check_for_duplicates=True,
                 unlisted_on_hp=form.unlisted_on_hp.data,
                 build_enable_net=form.enable_net.data,
                 group=group,
@@ -278,7 +277,7 @@ class ProjectAdd(Resource):
                 "(race condition)"
             ) from ierr
         except (
-            DuplicateException,
+            DuplicateException,  # TODO: can this happen? and exist_ok?
             NonAdminCannotCreatePersistentProject,
             NonAdminCannotDisableAutoPrunning,
         ) as err:


### PR DESCRIPTION
The commit 609d36988fb307193c77c872b726323bfca0647b only partly resolved the TOCTOU effects (which we are not fixing here either).  The problem being fixed now is that we duplicated the duplication check,
- once in the `validate_on_submit()`, then
- using the `add(check_for_duplicates=True)`. The later check is wrong though, because it raises an exception that is not handled properly (exist_ok=True ignored).

Complements: fdff0c826fe8ffa407f50d4006e617961a6fe046
Complements: 609d36988fb307193c77c872b726323bfca0647b
Fixes: #3471