### PR TITLE
Change the pyp2spec invocation

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -79,7 +79,7 @@ Recommends: dist-git-client
 Suggests: tito
 Suggests: rubygem-gem2rpm
 Suggests: pyp2rpm
-Suggests: pyp2spec
+Suggests: pyp2spec >= 0.10.0
 %endif
 
 %description
@@ -112,7 +112,7 @@ Requires: podman
 # not supported
 %else
 Requires: pyp2rpm
-Requires: pyp2spec
+Requires: pyp2spec >= 0.10.0
 Requires: rubygem-gem2rpm
 Requires: scl-utils-build
 Requires: fedora-review >= 0.8

--- a/rpmbuild/copr_rpmbuild/providers/pypi.py
+++ b/rpmbuild/copr_rpmbuild/providers/pypi.py
@@ -56,7 +56,7 @@ class PyPIProvider(Provider):
             "pyp2spec",
             self.pypi_package_name,
             "--fedora-compliant",
-            "--top-level",
+            "--automode",
         ]
         if self.pypi_package_version:
             cmd += ["-v", self.pypi_package_version]


### PR DESCRIPTION
pyp2spec 0.10.0 changed the API around the specfile generation. For fully-automated environments as copr is, the automode newly includes convenient defaults to make the specfiles as close to buildability as possible.

FYI: pyp2spec 0.10.0 is currently in bodhi, so during the next 7 days it'll get to all active Fedoras.