### PR TITLE
Add more logging to the copr-builder-ready script

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -255,6 +255,7 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         # generalize it into a separate package that we could eventually use
         # here.
         cmd = "copr-builder-ready " + self.job.chroot
+        self.log.info("Running remote command: %s", cmd)
         rc, stdout, stderr = self.ssh.run_expensive(
             cmd, subprocess_timeout=660)
         self.log.info(stdout)

--- a/rpmbuild/bin/copr-builder-ready
+++ b/rpmbuild/bin/copr-builder-ready
@@ -88,6 +88,9 @@ def main():
     check_mock_config(chroot)
     if subscription_required(chroot):
         wait_for_subscription()
+    else:
+        print("Red Hat subscription not needed for {0}".format(chroot))
+    print("Builder is ready to be used")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
So it doesn't have an empty stdout when everything went fine, e.g.

```
[2024-10-16 22:31:55,344][  INFO][PID:3774651] Checking that builder machine is OK
[2024-10-16 22:31:56,157][  INFO][PID:3774651] 
[2024-10-16 22:31:56,158][  INFO][PID:3774651] Filling build.info file with builder info
```