### PR TITLE
backend: manpage for copr-backend-resultdir-cleaner && logger fix

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -24,6 +24,7 @@ Source1:    https://github.com/fedora-copr/%{tests_tar}/archive/v%{tests_version
 
 BuildArch:  noarch
 BuildRequires: asciidoc
+BuildRequires: argparse-manpage
 BuildRequires: createrepo_c >= 0.16.1
 BuildRequires: libappstream-glib-builder
 BuildRequires: libxslt
@@ -131,7 +132,8 @@ only.
 %build
 make -C docs %{?_smp_mflags} html
 %py3_build
-
+PYTHONPATH=`pwd` argparse-manpage --pyfile run/copr-backend-resultdir-cleaner \
+    --function _get_arg_parser > copr-backend-resultdir-cleaner.1
 
 %install
 %py3_install
@@ -179,6 +181,9 @@ install -d %{buildroot}%{_pkgdocdir}/examples/%{_sysconfdir}/logstash.d
 cp -a conf/logstash/copr_backend.conf %{buildroot}%{_pkgdocdir}/examples/%{_sysconfdir}/logstash.d/copr_backend.conf
 
 cp -a docs/build/html %{buildroot}%{_pkgdocdir}/
+
+install -d %{buildroot}%{_mandir}/man1
+install -p -m 644 copr-backend-resultdir-cleaner.1 %{buildroot}/%{_mandir}/man1/
 
 
 %check
@@ -229,12 +234,12 @@ useradd -r -g copr -G lighttpd -s /bin/bash -c "COPR user" copr
 %config(noreplace) %{_sysconfdir}/cron.weekly/copr-backend
 %{_datadir}/logstash/patterns/lighttpd.pattern
 
-
 %config(noreplace) %attr(0600, root, root)  %{_sysconfdir}/sudoers.d/copr
+
+%{_mandir}/man1/copr-backend*.1*
 
 %files doc
 %license LICENSE
-%doc
 %{_pkgdocdir}/
 %exclude %{_pkgdocdir}/lighttpd
 

--- a/backend/run/copr-backend-resultdir-cleaner
+++ b/backend/run/copr-backend-resultdir-cleaner
@@ -171,14 +171,13 @@ def clean_in(resultdir, dry_run=True):
 
 def _main():
     logging.basicConfig(level=logging.DEBUG)
-    setup_script_logger(LOG, "/var/log/copr-backend/resultdir-cleaner.log")
+    config_file = os.environ.get("BACKEND_CONFIG", "/etc/copr/copr-be.conf")
+    opts = BackendConfigReader(config_file).read()
+    setup_script_logger(LOG, os.path.join(opts["log_dir"], "resultdir-cleaner.log"))
     args = _get_arg_parser().parse_args()
     dry_run = not args.real_run
     if dry_run:
         LOG.warning("Just doing dry run, run with --real-run")
-
-    config_file = os.environ.get("BACKEND_CONFIG", "/etc/copr/copr-be.conf")
-    opts = BackendConfigReader(config_file).read()
 
     clean_in(opts.destdir, dry_run=dry_run)
 

--- a/backend/run/copr-backend-resultdir-cleaner
+++ b/backend/run/copr-backend-resultdir-cleaner
@@ -73,6 +73,10 @@ def clean_in(resultdir, dry_run=True):
             # to the [backend] prune_days=N config.
             continue
 
+        if os.path.basename(chroot_dir) == "modules":
+            todo_directory(chroot_dir, "MODULES")
+            continue
+
         for subdir in chroot_subdirs:
             chroot_subdir_path = os.path.join(chroot_dir, subdir)
 

--- a/backend/run/copr-backend-resultdir-cleaner
+++ b/backend/run/copr-backend-resultdir-cleaner
@@ -1,7 +1,7 @@
 #! /usr/bin/python3
 
 """
-Cleanup the old chroot_scan folders
+Cleanup the files in resultdir that are no longer needed.
 """
 
 import logging
@@ -17,19 +17,23 @@ from copr_common.helpers import script_requires_user
 from copr_backend.helpers import BackendConfigReader
 
 
-logging.basicConfig(level=logging.DEBUG)
 LOG = logging.getLogger(__name__)
-setup_script_logger(LOG, "/var/log/copr-backend/resultdir-cleaner.log")
-
 OLDER_THAN = time.time() - 24*3600*14
 
-parser = argparse.ArgumentParser(
-    description=("TBD")
-)
-parser.add_argument(
-    "--real-run",
-    action='store_true',
-    help=("Also perform the changes, not just checks"))
+
+def _get_arg_parser():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Traverse the Copr Backend result directory and remove things "
+            "that are no longer needed → outdated log files, not uncleaned "
+            "temporary directories, etc."))
+    parser.add_argument(
+        "--real-run",
+        action='store_true',
+        help=(
+            "Perform the real removals (by default the tool just prints "
+            "what would normally happen = \"dry run\")."))
+    return parser
 
 
 def remove_old_dir(directory, dry_run):
@@ -162,7 +166,9 @@ def clean_in(resultdir, dry_run=True):
 
 
 def _main():
-    args = parser.parse_args()
+    logging.basicConfig(level=logging.DEBUG)
+    setup_script_logger(LOG, "/var/log/copr-backend/resultdir-cleaner.log")
+    args = _get_arg_parser().parse_args()
     dry_run = not args.real_run
     if dry_run:
         LOG.warning("Just doing dry run, run with --real-run")


### PR DESCRIPTION
Build the manual page from an updated --help output.  The logger needs to be initialized in `_main`, otherwise the log-file can mistakenly be created under the `root` user before the `script_requires_user()` check is done.