### PR TITLE
docker: point PULP_CONTENT_URL to a local container

### DIFF
--- a/docker/frontend/files/etc/copr/copr.conf
+++ b/docker/frontend/files/etc/copr/copr.conf
@@ -162,3 +162,5 @@ USAGE_TREEMAP_TEAMS = {
 # OIDC_AUTH_URL=""
 # OIDC_TOKEN_URL=""
 # OIDC_USERINFO_URL=""
+
+PULP_CONTENT_URL = "http://localhost:5006/pulp/content/"


### PR DESCRIPTION
This is where repodata and RPM packages can be downloaded from