### PR TITLE
Skip only if all macros in ExclusiveArch and ExcludeArch evaluated

### DIFF
--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -428,14 +428,24 @@ class Spec:
         """
         Evaluated %{exclusivearch} as a list
         """
-        return self.safe_attr("exclusivearch").split()
+        values = self.safe_attr("exclusivearch").split()
+        unknown = " ".join([x for x in values if x.startswith("%")])
+        if unknown:
+            log.warning("Unknown macros in ExclusiveArch: %s", unknown)
+            return []
+        return values
 
     @property
     def excludearch(self):
         """
         Evaluated %{excludearch} as a list
         """
-        return self.safe_attr("excludearch").split()
+        values = self.safe_attr("excludearch").split()
+        unknown = " ".join([x for x in values if x.startswith("%")])
+        if unknown:
+            log.warning("Unknown macros in ExcludeArch: %s", unknown)
+            return []
+        return values
 
     def safe_attr(self, name):
         """


### PR DESCRIPTION
Fix #3244

It can happen that our builder doesn't understand some architecture macro, e.g. `%{zig_arches}`. In such a case when it is used in `ExclusiveArch`, we shouldn't skip all chroots like we do now. A better approach is to be safe and avoid any skipping. Builds will fail in some chroots that should have been skipped but that can be workarounded by the user by manually submitting the build only for a subset of chroots.