### PR TITLE
docker: create /var/lock/copr-dist-git directory

### DIFF
--- a/docker/distgit/Dockerfile
+++ b/docker/distgit/Dockerfile
@@ -35,6 +35,9 @@ RUN sed -i 's/Listen 80/Listen 5001/' /etc/httpd/conf/httpd.conf
 RUN mkdir /tmp/copr-dist-git
 RUN chown copr-dist-git:packager /tmp/copr-dist-git
 
+RUN mkdir /var/lock/copr-dist-git/
+RUN chown copr-dist-git:copr-dist-git /var/lock/copr-dist-git/
+
 # copy filesystem setup and setup ownership and permissions
 COPY files/ /
 RUN chmod 644 /etc/copr/copr-dist-git.conf


### PR DESCRIPTION
Otherwise the import command:

    copr-distgit-process-import --build-id 7252586 --worker-id import_worker:7252586

Fails with the following error:

    FileNotFoundError: [Errno 2] No such file or directory: '/var/lock/copr-dist-git/_@_var_@_lib_@_dist-git_@_cache_@_lookaside_@_pkgs_@_frostyx_@_test-devel_@_copr-cli.lock'