### PR TITLE
Regenerate devel repository when multiple builds are deleted

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/actions_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/actions_logic.py
@@ -224,6 +224,7 @@ class ActionsLogic(object):
             # We can pick any random build because the assumption is, they are
             # all from the same project
             "storage": builds[0].copr.storage if builds else None,
+            "devel": builds[0].copr.devel_mode,
         }
 
         build_ids = []

--- a/frontend/coprs_frontend/tests/test_logic/test_builds_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_builds_logic.py
@@ -312,6 +312,7 @@ class TestBuildsLogic(CoprsTestCase):
             },
             'build_ids': [1, 2, 5],
             'storage': StorageEnum.backend,
+            'devel': False,
         }
 
         with pytest.raises(NoResultFound):


### PR DESCRIPTION
Fix #3507

The issue was introduced in PR #3330. We previously did this on the backend:

    devel = uses_devel_repo(self.front_url, ownername, projectname)

It looks like an unnecessary request, so I am sending the attribute as a part of the action data.