### PR TITLE
Implement a check for every storage whether a repository is available

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -348,10 +348,11 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
             # we don't need copr_base repodata for srpm builds
             return
 
-        repodata = os.path.join(self.job.chroot_dir, "repodata/repomd.xml")
         waiting_since = time.time()
         while time.time() - waiting_since < 60:
-            if os.path.exists(repodata):
+            exists = self.storage.repository_exists(
+                self.job.project_dirname, self.job.chroot)
+            if exists:
                 return
 
             # Either (a) the very first copr-repo run in this chroot dir

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -195,7 +195,7 @@ class PulpStorage(Storage):
         self.client = PulpClient.create_from_config_file()
 
     def init_project(self, dirname, chroot):
-        repository = self._repository_name(chroot)
+        repository = self._repository_name(chroot, dirname)
         response = self.client.create_repository(repository)
         if not response.ok and "This field must be unique" not in response.text:
             self.log.error("Failed to create a Pulp repository %s because of %s",
@@ -206,7 +206,7 @@ class PulpStorage(Storage):
         # mentioned by its href, not name
         repository = self._get_repository(chroot)
 
-        distribution = self._distribution_name(chroot)
+        distribution = self._distribution_name(chroot, dirname)
         response = self.client.create_distribution(distribution, repository)
         if not response.ok and "This field must be unique" not in response.text:
             self.log.error("Failed to create a Pulp distribution %s because of %s",


### PR DESCRIPTION
Otherwise, builds in Pulp projects will fail with this:

    Waiting for copr_base repository
    Waiting for copr_base repository
    Backend process error: Giving up waiting for copr_base repository

So far it worked only because we didn't create Pulp projects directly but rather migrated existing projects into Pulp and therefore this path existed on the backend.