### PR TITLE
resultdir-cleaner: remove old appstream failures

### DIFF
--- a/backend/run/copr-backend-resultdir-cleaner
+++ b/backend/run/copr-backend-resultdir-cleaner
@@ -94,9 +94,7 @@ def clean_in(resultdir, dry_run=True):
                 continue
 
             if subdir in ["tmp", "cache", "appdata"]:
-                # tmp => 95k * 7 inodes
-                # cache => 95k * 2 inodes
-                todo_directory(chroot_subdir_path, "APPSTREAMFAIL")
+                remove_old_dir(chroot_subdir_path, dry_run)
                 continue
 
             parts = subdir.split("-")


### PR DESCRIPTION
These are no longer that frequent as we disabled appstream-builder by default long time ago.

Relates: #3495