### PR TITLE
docker: remove legacy link and version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,6 @@
 # Other ports:
 #   5009:5432 -- PostgreSQL database
 
-version: '3'
-
 # this should be dolved by python3-daemon >= 3.0.0
 # https://bugzilla.redhat.com/show_bug.cgi?id=2307635
 x-ulimits: &ulimits_settings
@@ -128,8 +126,6 @@ services:
     depends_on:
       - database
       - redis
-    links:
-      - database
     stdin_open: true
     tty: true
     ports:


### PR DESCRIPTION
version: https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete

---

link: https://docs.docker.com/engine/network/links/

having link in compose file result in error:
Error response from daemon: bad parameter: link is not supported Error: executing /usr/libexec/docker/cli-plugins/docker-compose up -d: exit status 1