### PR TITLE
docker: install pulp-cli to the backend container

### DIFF
--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -30,6 +30,7 @@ RUN set -ex ; \
                    nginx \
                    findutils \
                    tini \
+                   pulp-cli \
 # to get more entropy for generation of gpg keys
                    rng-tools \
 # for unbuffer package


### PR DESCRIPTION
We don't need the `pulp-cli` tool to upload builds results to Pulp but it is useful for manual queries and debugging if something goes wrong.