### PR TITLE
change default logging level to INFO for check_for_anitya_version_upd…

### DIFF
--- a/frontend/coprs_frontend/run/check_for_anitya_version_updates.py
+++ b/frontend/coprs_frontend/run/check_for_anitya_version_updates.py
@@ -23,7 +23,7 @@ from coprs.exceptions import BadRequest
 logging.basicConfig(
     filename="{0}/check_for_anitya_version_updates.log".format(app.config.get("LOG_DIR")),
     format='[%(asctime)s][%(levelname)6s]: %(message)s',
-    level=logging.DEBUG)
+    level=logging.INFO)
 log = logging.getLogger(__name__)
 log.addHandler(logging.StreamHandler(sys.stdout))
 


### PR DESCRIPTION
…ates

This polutes a log a lot.
This may be useful info when you debug something, but it is overkill for normal situation.
INFO should be good enough for everyday.