### PR TITLE
releng: tito --test builds to have higher NVRs than released versions

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -4,3 +4,4 @@ tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s
 fetch_sources = True
+test_version_suffix = .test


### PR DESCRIPTION
Historically, Tito only modified the Release tag for `--test` builds. Now, we also bump the Version field to ensure that Mock built from Git revisions always has a higher NVR than (previously) released packages.

https://github.com/rpm-software-management/tito/releases/tag/tito-0.6.27-1