### PR TITLE
frontend: fix /build/source-chroot/ endpoint

### DIFF
--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
@@ -186,7 +186,7 @@ class ListBuild(Resource):
         return {"items": builds, "meta": paginator.meta}
 
 
-@apiv3_builds_ns.route("/source-log/<int:build_id>")
+@apiv3_builds_ns.route("/source-chroot/<int:build_id>")
 class SourceChroot(Resource):
     @apiv3_builds_ns.doc(params=get_build_docs)
     @apiv3_builds_ns.marshal_with(source_chroot_model)


### PR DESCRIPTION
As reported by @nforro, this tracebacks because of not existing endpoint.

    from copr.v3 import Client as CoprClient
    copr_client = CoprClient.create_from_config_file()
    copr_client.build_proxy.get_source_chroot(8481944)

For some reason this endpoint was renamed from `/build/source-chroot` to `/build/source-log` in 7455d47. I suppose it was a typo?