### PR TITLE
ci: enable automatic merging of pull requests

### DIFF
--- a/.github/workflows/auto-merger.yml
+++ b/.github/workflows/auto-merger.yml
@@ -1,0 +1,100 @@
+name: Auto Merger
+on:
+  schedule:
+    # Workflow runs every 45 minutes
+    - cron: '*/45 * * * *'
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'Pull Request number/s ; when not provided, the workflow will run for all open PRs'
+        required: true
+        default: '0'
+
+permissions:
+  contents: read
+
+jobs:
+  # Get all open PRs
+  gather-pull-requests:
+    if: github.repository == 'fedora-copr/copr'
+    runs-on: ubuntu-latest
+
+    outputs:
+      pr-numbers: ${{ steps.get-pr-numbers.outputs.result }}
+      pr-numbers-manual: ${{ steps.parse-manual-input.outputs.result }}
+
+    steps:
+      - id: get-pr-numbers
+        if: inputs.pr-number == '0'
+        name: Get all open PRs
+        uses: actions/github-script@v6
+        with:
+          # !FIXME: this is not working if there is more than 100 PRs opened
+          script: |
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+            return pullRequests.map(pr => pr.number);
+
+      - id: parse-manual-input
+        if: inputs.pr-number != '0'
+        name: Parse manual input
+        run: |
+          # shellcheck disable=SC2086
+          echo "result="[ ${{ inputs.pr-number }} ]"" >> $GITHUB_OUTPUT
+        shell: bash
+
+  validate-pr:
+    name: 'Validation of Pull Request #${{ matrix.pr-number }}'
+    needs: [ gather-pull-requests ]
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        pr-number: ${{ inputs.pr-number == 0 && fromJSON(needs.gather-pull-requests.outputs.pr-numbers) || fromJSON(needs.gather-pull-requests.outputs.pr-numbers-manual) }}
+
+    permissions:
+      # required for merging PRs
+      contents: write
+      # required for PR comments and setting labels
+      pull-requests: write
+
+    steps:
+      # Fetch Pull Request metadata (title, body, labels, etc.)
+      - id: metadata
+        name: Gather Pull Request Metadata
+        uses: redhat-plumbers-in-action/gather-pull-request-metadata@v1
+        with:
+          pr-number: ${{ matrix.pr-number }}
+
+      # Validate the pull request (CI, review, etc.)
+      - if: ${{ !cancelled() }}
+        id: pull-request-validator
+        name: Pull Request Validator
+        uses: redhat-plumbers-in-action/pull-request-validator@v2
+        with:
+          pr-metadata: ${{ steps.metadata.outputs.metadata }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Merge the PR if all checks passed
+      - id: auto-merge
+        name: Auto Merge
+        uses: redhat-plumbers-in-action/auto-merge@v2
+        with:
+          pr-metadata: ${{ steps.metadata.outputs.metadata }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Always show the results in PR sticky comment
+      - if: ${{ !cancelled() }}
+        name: Show results in PR comment
+        uses: redhat-plumbers-in-action/issue-commentator@v1
+        with:
+          issue: ${{ fromJSON(steps.metadata.outputs.metadata).number }}
+          message: |
+            ${{ steps.pull-request-validator.outputs.status && steps.pull-request-validator.outputs.status || '' }}
+            ${{ steps.auto-merge.outputs.status && steps.auto-merge.outputs.status || '' }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-merger.yml
+++ b/.github/workflows/auto-merger.yml
@@ -78,6 +78,7 @@ jobs:
         uses: redhat-plumbers-in-action/pull-request-validator@v2
         with:
           pr-metadata: ${{ steps.metadata.outputs.metadata }}
+          required-approvals: '2'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Merge the PR if all checks passed


### PR DESCRIPTION
PR that meets the following criteria will be automatically merged:

- Passing CI
- Approved by at least one reviewer
- No Draft or WIP title
- No conflicts

The merging workflow runs on schedule every 45 minutes. It can be executed manually on demand from the Actions tab. It internally uses several GitHub Actions to perform the merge.

- https://github.com/redhat-plumbers-in-action/gather-pull-request-metadata to gather PR metadata
- https://github.com/redhat-plumbers-in-action/pull-request-validator to check reviews and CI status
- https://github.com/redhat-plumbers-in-action/auto-merge to perform the merge
- https://github.com/redhat-plumbers-in-action/issue-commentator to comment on PRs about the merge status

---

I have tested the workflow on https://github.com/jamacku/copr/pull/1

A working example can be found at https://github.com/redhat-plumbers/systemd-rhel10/pull/45#issuecomment-2410935343. It contains a few more pieces, but merging logic is also present.

---

There are a few limitations/requirements:

- When merging PR this way, it doesn't trigger `on: push` workflows - https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
- Maintainers who approve PRs need to have member visibility set to public; otherwise, GitHub Action will not see that they are members eligible to review PRs.

/cc @xsuchy 