### PR TITLE
doc: remove non existent parameter from docstring

### DIFF
--- a/python/copr/v3/proxies/build_chroot.py
+++ b/python/copr/v3/proxies/build_chroot.py
@@ -28,7 +28,6 @@ class BuildChrootProxy(BaseProxy):
         Return a list of build chroots
 
         :param int build_id:
-        :param str chrootname:
         :param pagination:
         :return: Munch
         """


### PR DESCRIPTION
The parameter `chrootname` is mentioned in the docstring but the parameter does not exist in the function.