### PR TITLE
backend: migrate os.listdir() to os.scandir() to increase performance

### DIFF
--- a/backend/copr_backend/actions.py
+++ b/backend/copr_backend/actions.py
@@ -442,13 +442,14 @@ class BuildModule(Action):
                     # into the module destdir, not the whole chroot
                     os.makedirs(destdir)
                     prefixes = ["{:08d}-".format(x) for x in data["builds"]]
-                    dirs = [d for d in os.listdir(srcdir) if d.startswith(tuple(prefixes))]
+                    dirs = [d.name for d in os.scandir(srcdir) if d.name.startswith(tuple(prefixes))]
                     for folder in dirs:
                         shutil.copytree(os.path.join(srcdir, folder), os.path.join(destdir, folder))
                         self.log.info("Copy directory: %s as %s",
                                       os.path.join(srcdir, folder), os.path.join(destdir, folder))
 
-                        for f in os.listdir(os.path.join(destdir, folder)):
+                        for folder_entry in os.scandir(os.path.join(destdir, folder)):
+                            f = folder_entry.name
                             if not f.endswith(".rpm") or f.endswith(".src.rpm"):
                                 continue
                             artifact = format_filename(zero_epoch=True, *splitFilename(f))

--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -187,7 +187,8 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         except FileExistsError:
             pass
 
-        if not os.listdir(job.results_dir):
+        results_dir_entries = list(os.scandir(job.results_dir))
+        if not results_dir_entries:
             return
 
         backup_dir_name = "prev_build_backup"
@@ -198,7 +199,7 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         if not os.path.exists(backup_dir):
             os.makedirs(backup_dir)
 
-        files = (x for x in os.listdir(job.results_dir) if x != backup_dir_name)
+        files = (x.name for x in results_dir_entries if x.name != backup_dir_name)
         for filename in files:
             file_path = os.path.join(job.results_dir, filename)
             if os.path.isfile(file_path):
@@ -975,7 +976,8 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         """
         if self.job.storage == StorageEnum.pulp:
             path = os.path.join(self.job.chroot_dir, self.job.target_dir_name)
-            for filename in os.listdir(path):
+            for filename_entry in os.scandir(path):
+                filename = filename_entry.name
                 if not filename.endswith(".rpm"):
                     continue
                 rpm = os.path.join(path, filename)

--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -155,9 +155,9 @@ def sign_rpms_in_dir(username, projectname, path, chroot, opts, log):
     """
 
     rpm_list = [
-        os.path.join(path, filename)
-        for filename in os.listdir(path)
-        if filename.endswith(".rpm")
+        os.path.join(path, filename.name)
+        for filename in os.scandir(path)
+        if filename.name.endswith(".rpm")
     ]
 
     if not rpm_list:
@@ -245,9 +245,9 @@ def unsign_rpms_in_dir(path, opts, log):
     :raises: :py:class:`backend.exceptions.CoprSignError` failed to sign at least one package
     """
     rpm_list = [
-        os.path.join(path, filename)
-        for filename in os.listdir(path)
-        if filename.endswith(".rpm")
+        os.path.join(path, filename.name)
+        for filename in os.scandir(path)
+        if filename.name.endswith(".rpm")
         ]
 
     if not rpm_list:

--- a/backend/run/copr-backend-generate-graphs
+++ b/backend/run/copr-backend-generate-graphs
@@ -272,7 +272,7 @@ def get_topmost_dataset(all_data, stats_type, keep_from_each_set=15,
 def _main(_args):
     download_js_files()
     sampledir = os.path.join(config.statsdir, "samples")
-    files = os.listdir(sampledir)
+    files = list(entry.name for entry in os.scandir(sampledir))
     json_files = sorted([sample for sample in files
                          if sample.endswith('json.zst')])
 

--- a/backend/run/copr-backend-resultdir-cleaner
+++ b/backend/run/copr-backend-resultdir-cleaner
@@ -156,7 +156,7 @@ def clean_in(resultdir, dry_run=True):
 
                     # detect a fedora-review failure dirs, like:
                     # https://download.copr.fedorainfracloud.org/results/throup/VisualVM/fedora-35-x86_64/04899225-VisualVM/VisualVM/
-                    items = os.listdir(subdir_path)
+                    items = list(entry.name for entry in os.scandir(subdir_path))
                     if "srpm-unpacked" in items and "upstream-unpacked" in items:
                         # Fedora review failure
                         todo_directory(subdir_path, "FEDORA_REVIEW_FAIL")

--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -100,28 +100,32 @@ def main():
     owner, project = args.project.split("/")
     ownerdir = os.path.join(config.destdir, owner)
 
-    for subproject in os.listdir(ownerdir):
+    for subproject_entry in os.scandir(ownerdir):
+        subproject = subproject_entry.name
         if not (subproject == project or subproject.startswith(project + ":")):
             continue
 
         coprdir = os.path.join(ownerdir, subproject)
-        for chroot in os.listdir(coprdir):
+        for chroot_entry in os.scandir(coprdir):
+            chroot = chroot_entry.name
             if chroot == "srpm-builds":
                 continue
 
-            chrootdir = os.path.join(coprdir, chroot)
-            if not os.path.isdir(chrootdir):
+            if not chroot_entry.is_dir():
                 continue
 
+            chrootdir = os.path.join(coprdir, chroot)
             appstream = None
             devel = None
             storage = PulpStorage(
                 owner, subproject, appstream, devel, config, log)
 
-            for builddir in os.listdir(chrootdir):
-                resultdir = os.path.join(chrootdir, builddir)
-                if not os.path.isdir(resultdir):
+            for builddir_entry in os.scandir(chrootdir):
+                if not builddir_entry.is_dir():
                     continue
+                builddir = builddir_entry.name
+                resultdir = os.path.join(chrootdir, builddir)
+
 
                 if not is_valid_build_directory(builddir):
                     log.info("Skipping: %s", resultdir)

--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -95,8 +95,7 @@ def main():
         log.error("Data removal is not supported yet")
         sys.exit(1)
 
-    config_file = "/etc/copr/copr-be.conf"
-    config = BackendConfigReader(config_file).read()
+    config = BackendConfigReader("/etc/copr/copr-be.conf").read()
     owner, project = args.project.split("/")
     ownerdir = os.path.join(config.destdir, owner)
 

--- a/backend/run/copr_find_wrong_chroot_artifacts.py
+++ b/backend/run/copr_find_wrong_chroot_artifacts.py
@@ -74,7 +74,8 @@ def check_rpm_results(path, known_dists):
     """
 
     releases = []
-    for artifact in os.listdir(path):
+    for artifact_entry in os.scandir(path):
+        artifact = artifact_entry.name
         if not artifact.endswith(".rpm"):
             continue
         (_, _, release, _, _) = splitFilename(artifact)
@@ -94,28 +95,30 @@ def main():
     """
     chroot_map = get_chroot_map()
     destdir_path = config["destdir"]
-    for owner in os.listdir(destdir_path):
-        owner_path = os.path.join(destdir_path, owner)
-        if not os.path.isdir(owner_path):
+    for owner_entry in os.scandir(destdir_path):
+        if not owner_entry.is_dir():
             continue
+        owner = owner_entry.name
+        owner_path = os.path.join(destdir_path, owner)
 
-        for project in os.listdir(owner_path):
-            project_path = os.path.join(owner_path, project)
-            if not os.path.isdir(project_path):
+        for project_entry in os.scandir(owner_path):
+            if not project_entry.is_dir():
                 continue
+            project_path = os.path.join(owner_path, project_entry.name)
 
-            for chroot in os.listdir(project_path):
-                chroot_path = os.path.join(project_path, chroot)
-                if not os.path.isdir(chroot_path):
+            for chroot_entry in os.scandir(project_path):
+                if not chroot_entry.is_dir():
                     continue
+                chroot = chroot_entry.name
+                chroot_path = os.path.join(project_path, chroot)
 
                 if chroot not in chroot_map:
                     continue
 
-                for build in os.listdir(chroot_path):
-                    build_path = os.path.join(chroot_path, build)
-                    if not os.path.isdir(build_path):
+                for build_entry in os.scandir(chroot_path):
+                    if not build_entry.is_dir():
                         continue
+                    build_path = os.path.join(chroot_path, build_entry.name)
 
                     check_rpm_results(build_path, chroot_map.values())
 

--- a/backend/run/copr_fix_gpg.py
+++ b/backend/run/copr_fix_gpg.py
@@ -81,9 +81,10 @@ def fix_copr(args, opts, copr_full_name):
 
     log.info("Re-sign rpms and call createrepo in copr's chroots")
 
-    for chroot in os.listdir(copr_path):
+    for chroot_entry in os.scandir(copr_path):
+        chroot = chroot_entry.name
         dir_path = os.path.join(copr_path, chroot)
-        if not os.path.isdir(dir_path):
+        if not chroot_entry.is_dir():
             log.debug("Ignoring %s, not a directory", dir_path)
             continue
 
@@ -101,9 +102,10 @@ def fix_copr(args, opts, copr_full_name):
                 continue
 
         log.info("Signing in %s chroot", chroot)
-        for builddir_name in os.listdir(dir_path):
+        for builddir_name_entry in os.scandir(dir_path):
+            builddir_name = builddir_name_entry.name
             builddir_path = os.path.join(dir_path, builddir_name)
-            if not os.path.isdir(builddir_path):
+            if not builddir_name_entry.is_dir():
                 continue
             if not builddir_matcher.match(builddir_name):
                 log.debug("Skipping %s, not a build dir", builddir_name)

--- a/backend/run/copr_print_results_to_delete.py
+++ b/backend/run/copr_print_results_to_delete.py
@@ -15,11 +15,13 @@ def main():
     config = BackendConfigReader(config_file).read()
     client = Client({"copr_url": config.frontend_base_url})
 
-    for ownername in os.listdir(config.destdir):
+    for ownername_entry in os.scandir(config.destdir):
+        ownername = ownername_entry.name
         ownerpath = os.path.join(config.destdir, ownername)
 
         try:
-            for projectname in os.listdir(ownerpath):
+            for projectname_entry in os.scandir(ownerpath):
+                projectname = projectname_entry.name
                 projectpath = os.path.join(ownerpath, projectname)
 
                 # I don't know how to determine whether a PR dir can be deleted or not
@@ -39,7 +41,8 @@ def main():
                     continue
 
                 # If a chroot is not enabled in the project, it should be removed
-                for chroot in os.listdir(projectpath):
+                for chroot_entry in os.scandir(projectpath):
+                    chroot = chroot_entry.name
                     if chroot in ["srpm-builds", "modules", "repodata", "pubkey.gpg"]:
                         continue
                     if not is_outdated_to_be_deleted(get_chroot_safe(client, ownername, projectname, chroot)):

--- a/backend/run/copr_sign_unsigned.py
+++ b/backend/run/copr_sign_unsigned.py
@@ -45,21 +45,23 @@ def check_signed_rpms(project_dir, user, project, opts, devel):
     Ensure that all rpm files are signed
     """
     success = True
-    for chroot in os.listdir(project_dir):
+    for chroot_entry in os.scandir(project_dir):
+        chroot = chroot_entry.name
         if not (chroot.startswith("fedora") or chroot.startswith("epel")):
             continue
 
         chroot_path = os.path.join(project_dir, chroot)
-        if not os.path.isdir(chroot_path):
+        if not chroot_entry.is_dir():
             continue
 
         log.debug("> Checking chroot `%s` in dir `%s`", chroot, project_dir)
 
-        for mb_pkg in os.listdir(chroot_path):
+        for mb_pkg_entry in os.scandir(chroot_path):
+            mb_pkg = mb_pkg_entry.name
             if mb_pkg in ["repodata", "devel"]:
                 continue
             mb_pkg_path = os.path.join(chroot_path, mb_pkg)
-            if not os.path.isdir(mb_pkg_path):
+            if not mb_pkg_entry.is_dir():
                 continue
 
             log.debug(">> Stepping into package: %s", mb_pkg_path)
@@ -102,8 +104,9 @@ def main():
     opts = BackendConfigReader().read()
     log.info("Starting pubkey fill, destdir: %s", opts.destdir)
 
-    log.debug("list dir: %s", os.listdir(opts.destdir))
-    for user_name in os.listdir(opts.destdir):
+    log.debug("list dir: %s", (d.name for d in os.scandir(opts.destdir)))
+    for user_name_entry in os.scandir(opts.destdir):
+        user_name = user_name_entry.name
         if user_name in users_done_old:
             log.info("skipping user: %s", user_name)
             continue
@@ -112,7 +115,8 @@ def main():
         log.info("Started processing user dir: %s", user_name)
         user_dir = os.path.join(opts.destdir, user_name)
 
-        for project_name in os.listdir(user_dir):
+        for project_name_entry in os.scandir(user_dir):
+            project_name = project_name_entry.name
             log.info("Checking project dir: %s", project_name)
 
             try:

--- a/backend/tests/test_action.py
+++ b/backend/tests/test_action.py
@@ -119,9 +119,9 @@ class TestAction(object):
             # this tarball, start distributing that tarball as separate
             # file/project and use it as Source1: in the spec file.
             testresults = os.path.join(self.test_project_dir, 'testresults')
-            for subdir in os.listdir(testresults):
-                shutil.move(os.path.join(testresults, subdir),
-                            os.path.join(self.tmp_dir_name, subdir))
+            for subdir in os.scandir(testresults):
+                shutil.move(os.path.join(testresults, subdir.name),
+                            os.path.join(self.tmp_dir_name, subdir.name))
             self.test_project_dir = os.path.join(self.tmp_dir_name, '@copr', 'prunerepo')
 
     def test_action_run_legal_flag(self, mc_time):


### PR DESCRIPTION
As recommended in https://peps.python.org/pep-0471/

scandir() has significantly better performance. On some places it does not have sense, but I was doing it everywhere, because it was super easy. I done it, because I recently done the same thing in scancode-toolkit where it matters a lot.

Related: #3601