### PR TITLE
releng: conform --test versions to PEP 440

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -4,4 +4,4 @@ tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s
 fetch_sources = True
-test_version_suffix = .test
+test_version_suffix = .post1


### PR DESCRIPTION
The canonical public version identifiers MUST comply with the following scheme:

[N!]N(.N)*[{a|b|rc}N][.postN][.devN]