### PR TITLE
frontend: stop using deprecated Query.get method

### DIFF
--- a/frontend/coprs_frontend/coprs/forms.py
+++ b/frontend/coprs_frontend/coprs/forms.py
@@ -15,6 +15,7 @@ try: # get rid of deprecation warning with newer flask_wtf
 except ImportError:
     from flask_wtf import Form as FlaskForm
 
+from coprs import db
 from coprs import app
 from coprs import exceptions
 from coprs import helpers
@@ -1387,7 +1388,7 @@ def _get_build_form(active_chroots, form, package=None):
             return
 
         build_id = int(build_id)
-        build = models.Build.query.get(build_id)
+        build = db.session.get(models.Build, build_id)
         if not build:
             raise wtforms.ValidationError(
                 "Build {} not found".format(build_id))

--- a/frontend/coprs_frontend/coprs/logic/batches_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/batches_logic.py
@@ -63,7 +63,7 @@ class BatchesLogic:
         # We don't want to create a new batch if one already exists, but there's
         # the concurrency problem so we need to lock the build instance for
         # writing.
-        build = db.session.query(Build).get(build_id)
+        build = db.session.get(Build, build_id)
         if not build:
             raise BadRequest("Build {} doesn't exist".format(build_id))
 

--- a/frontend/coprs_frontend/tests/request_test_api.py
+++ b/frontend/coprs_frontend/tests/request_test_api.py
@@ -8,7 +8,7 @@ import json
 from bs4 import BeautifulSoup
 from werkzeug.datastructures import FileStorage
 
-from coprs import models
+from coprs import models, db
 
 
 # pylint: disable=consider-using-with
@@ -191,7 +191,7 @@ class WebUIRequests(_RequestsInterface):
 
     def rebuild_all_packages(self, project_id, package_names=None):
         """ There's a button "rebuild-all" in web-UI, hit that button """
-        copr = models.Copr.query.get(project_id)
+        copr = db.session.get(models.Copr, project_id)
         if not package_names:
             packages = copr.packages
             package_names = [p.name for p in packages]
@@ -207,7 +207,7 @@ class WebUIRequests(_RequestsInterface):
         return resp
 
     def resubmit_build_id(self, build_id):
-        build = models.Build.query.get(build_id)
+        build = db.session.get(models.Build, build_id)
         path = f"/coprs/{build.copr.full_name}/new_build_rebuild/{build_id}"
         response = self.client.post(
             path,
@@ -439,7 +439,7 @@ class BackendRequests:
         Given the build_id, finish the source build, import it, and move the
         corresponding BuildChroot instances to /pending-jobs/.
         """
-        build = models.Build.query.get(build_id)
+        build = db.session.get(models.Build, build_id)
         if not package_name:
             package_name = build.package.name
 
@@ -456,7 +456,7 @@ class BackendRequests:
         }).status_code == 200
 
         # import srpm to appropriate branches
-        build = models.Build.query.get(build_id)
+        build = db.session.get(models.Build, build_id)
         branch_commits = {}
         for bch in build.build_chroots:
             branch_commits[bch.mock_chroot.distgit_branch.name] = "4dc328232"

--- a/frontend/coprs_frontend/tests/test_anitya.py
+++ b/frontend/coprs_frontend/tests/test_anitya.py
@@ -54,7 +54,7 @@ class TestAnitya(CoprsTestCase):
         # Submit another build (not finished).  This one though has the
         # pypi_package_version field specified (could be submitted by anitya).
         resp = self.api3.rebuild_package("inprogress-match", "python-umap-pytorch")
-        build = models.Build.query.get(int(resp.json["id"]))
+        build = self.db.session.get(models.Build, int(resp.json["id"]))
         build.source_json = json.dumps({"pypi_package_version": "0.0.5"})
         db.session.commit()
 
@@ -62,7 +62,7 @@ class TestAnitya(CoprsTestCase):
         # pypi_package_version field specified, and is older so we want to
         # re-build).
         resp = self.api3.rebuild_package("inprogress-older", "python-umap-pytorch")
-        build = models.Build.query.get(int(resp.json["id"]))
+        build = self.db.session.get(models.Build, int(resp.json["id"]))
         build.source_json = json.dumps({"pypi_package_version": "0.0.4"})
         db.session.commit()
 

--- a/frontend/coprs_frontend/tests/test_apiv3/test_copr_chroot.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_copr_chroot.py
@@ -71,7 +71,7 @@ class TestCoprChroots(CoprsTestCase):
         )
 
         # Make sure all the chroot attributes are configured
-        chroot = self.models.CoprChroot.query.get(1)
+        chroot = self.db.session.get(self.models.CoprChroot, 1)
         assert chroot.isolation == "nspawn"
         assert chroot.buildroot_pkgs == "pkg1 pkg2 pkg3"
 
@@ -82,7 +82,7 @@ class TestCoprChroots(CoprsTestCase):
             reset_fields=["additional_packages"]
         )
         assert response.status_code == 200
-        chroot = self.models.CoprChroot.query.get(1)
+        chroot = self.db.session.get(self.models.CoprChroot, 1)
         assert chroot.isolation == "nspawn"
         assert chroot.buildroot_pkgs is None
 
@@ -92,7 +92,7 @@ class TestCoprChroots(CoprsTestCase):
             chrootname,
             reset_fields=["additional_packages", "isolation"]
         )
-        chroot = self.models.CoprChroot.query.get(1)
+        chroot = self.db.session.get(self.models.CoprChroot, 1)
         assert chroot.isolation == "unchanged"
         assert chroot.buildroot_pkgs is None
 

--- a/frontend/coprs_frontend/tests/test_apiv3/test_packages.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_packages.py
@@ -60,7 +60,7 @@ class TestAPIv3Packages(CoprsTestCase):
             "package_name": form_data["package_name"],
         }
         self.post_api3_with_auth(endpoint, rebuild_data, user)
-        build = self.models.Build.query.get(1)
+        build = self.db.session.get(self.models.Build, 1)
         assert json.loads(build.source_json) == expected_source_dict
         assert build.source_type == BuildSourceEnum(source_type_text)
 
@@ -75,7 +75,7 @@ class TestAPIv3Packages(CoprsTestCase):
         _assert_default_chroots(build)
         rebuild_data["chroots"] = chroots
         self.post_api3_with_auth(endpoint, rebuild_data, user)
-        build = self.models.Build.query.get(2)
+        build = self.db.session.get(self.models.Build, 2)
         assert json.loads(build.source_json) == expected_source_dict
         if "fedora-18-x86_64" in chroots or chroots == []:
             _assert_default_chroots(build)

--- a/frontend/coprs_frontend/tests/test_apiv3/test_project_chroots.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_project_chroots.py
@@ -49,7 +49,7 @@ class TestApiv3ProjectChroots(CoprsTestCase):
         response = self.api3.post(route, data)
         assert response.status_code == 200
 
-        chroot = models.CoprChroot.query.get(chroot.id)
+        chroot = self.db.session.get(models.CoprChroot, chroot.id)
         assert chroot.isolation == "nspawn"
         assert chroot.bootstrap == "off"
         assert chroot.buildroot_pkgs == "foo bar"

--- a/frontend/coprs_frontend/tests/test_apiv3/test_projects.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_projects.py
@@ -59,7 +59,8 @@ class TestApiv3Projects(CoprsTestCase):
         assert Copr.query.one().isolation == read
 
     def _get_copr_id_data(self, copr_id):
-        data = copy.deepcopy(self.models.Copr.query.get(copr_id).__dict__)
+        copr = self.db.session.get(self.models.Copr, copr_id)
+        data = copy.deepcopy(copr.__dict__)
         data.pop("_sa_instance_state")
         data.pop("latest_indexed_data_update")
         return data
@@ -186,16 +187,16 @@ class TestApiv3Projects(CoprsTestCase):
         project without specifying it.
         """
         self.db.session.add(self.c1)
-        copr = Copr.query.get(self.c1.id)
+        copr = self.db.session.get(Copr, self.c1.id)
         assert not copr.fedora_review
         assert not copr.delete_after_days
 
         route = "/api_3/project/edit/{}".format(self.c1.full_name)
         self.api3.post(route, {"fedora_review": True})
-        assert Copr.query.get(self.c1.id).fedora_review
+        assert self.db.session.get(Copr, self.c1.id).fedora_review
 
         self.api3.post(route, {"delete_after_days": 5})
-        copr = Copr.query.get(self.c1.id)
+        copr = self.db.session.get(Copr, self.c1.id)
         assert copr.fedora_review
         assert copr.delete_after_days == 5
 

--- a/frontend/coprs_frontend/tests/test_comps.py
+++ b/frontend/coprs_frontend/tests/test_comps.py
@@ -23,7 +23,7 @@ class TestComps(CoprsTestCase):
             bootstrap_image="image",
         )
 
-        chroot = models.CoprChroot.query.get(chroot_id)
+        chroot = self.db.session.get(models.CoprChroot, chroot_id)
         data = "<some><xml></xml></some>\n"
         assert chroot.comps == data
         assert chroot.bootstrap_image == "image"

--- a/frontend/coprs_frontend/tests/test_helpers.py
+++ b/frontend/coprs_frontend/tests/test_helpers.py
@@ -152,9 +152,9 @@ class TestHelpers(CoprsTestCase):
         in Copr database.
         """
         # "fedora-17-x86_64" from "user2/foocopr"
-        original = self.models.CoprChroot.query.get(2)
+        original = self.db.session.get(self.models.CoprChroot, 2)
         # "user1/foocopr"
-        target_copr = self.models.Copr.query.get(1)
+        target_copr = self.db.session.get(self.models.Copr, 1)
 
         assert "fedora-17-x86_64" not in \
                 [m.name for m in target_copr.mock_chroots]
@@ -175,7 +175,7 @@ class TestHelpers(CoprsTestCase):
         self.db.session.add(copy)
         self.db.session.commit()
 
-        target_copr = self.models.Copr.query.get(1)
+        target_copr = self.db.session.get(self.models.Copr, 1)
         assert "fedora-17-x86_64" in \
                 [m.name for m in target_copr.mock_chroots]
 

--- a/frontend/coprs_frontend/tests/test_logic/test_batch_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_batch_logic.py
@@ -101,7 +101,7 @@ class TestBatchesLogic(CoprsTestCase):
         assert "Not a valid integer" in error
 
         # drop the finished build from batch
-        build = models.Build.query.get(1)
+        build = self.db.session.get(models.Build, 1)
         build.batch = None
         self.db.session.commit()
         error = self._submit({"with_build_id": 1})
@@ -117,7 +117,8 @@ class TestBatchesLogic(CoprsTestCase):
         # existing build
         BatchesLogic.get_batch_or_create(2, self.transaction_user)
         # permission problem
-        user = models.User.query.get(2)
+        user = self.db.session.get(models.User, 2)
+
         with pytest.raises(BadRequest) as error:
             BatchesLogic.get_batch_or_create(2, user, modify=True)
         assert "The batch 2 belongs to project user1/test" in str(error)
@@ -126,11 +127,11 @@ class TestBatchesLogic(CoprsTestCase):
     def test_cant_group_others_build(self):
         self._prepare_project_with_batches()
         # de-assign the build from batch
-        build = models.Build.query.get(1)
+        build = self.db.session.get(models.Build, 1)
         build.batch = None
         self.db.session.commit()
 
-        user = models.User.query.get(2)
+        user = self.db.session.get(models.User, 2)
         with pytest.raises(BadRequest) as error:
             BatchesLogic.get_batch_or_create(1, user, modify=True)
         assert "Build 1 is not yet in any batch" in str(error)
@@ -217,7 +218,7 @@ class TestBatchesLogic(CoprsTestCase):
 
         self.db.session.commit()
 
-        build = models.Build.query.get(batch_build_id)
+        build = self.db.session.get(models.Build, batch_build_id)
         batch = build.batch
         mock_chroot = build.build_chroots[0].mock_chroot
 

--- a/frontend/coprs_frontend/tests/test_logic/test_complex_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_complex_logic.py
@@ -111,7 +111,7 @@ class TestComplexLogic(CoprsTestCase):
         # some builds are not finished, nothing deleted yet
         assert len([c for c in query.all() if c.deleted]) == 0
 
-        b = self.db.session.query(models.Build).get(3)
+        b = self.db.session.get(models.Build, 3)
         b.canceled = True
 
         ComplexLogic.delete_expired_projects()
@@ -120,7 +120,7 @@ class TestComplexLogic(CoprsTestCase):
         assert len([c for c in query.all() if c.deleted]) == 1
 
         # test that build is deleted as well
-        assert not self.db.session.query(models.Build).get(3)
+        assert not self.db.session.get(models.Build, 3)
 
 
 class TestProjectForking(CoprsTestCase):

--- a/frontend/coprs_frontend/tests/test_logic/test_copr_dirs_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_copr_dirs_logic.py
@@ -33,7 +33,7 @@ class TestCoprDirsLogic(CoprsTestCase):
     def test_coprdir_cleanup_no_build(self):
         self.api3.new_project("test-pr-dirs", ["fedora-17-i386"])
         self.pr_trigger.build_package("test-pr-dirs", "testpkg", 1)
-        build = models.Build.query.get(1)
+        build = db.session.get(models.Build, 1)
         db.session.delete(build)
         models.Action.query.delete()
         db.session.commit()

--- a/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
+++ b/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
@@ -336,7 +336,7 @@ class TestCoprDetail(CoprsTestCase):
 
         # And now cancel the build.
         self.web_ui.cancel_build(self.c2.name, build_id)
-        build = models.Build.query.get(build_id)
+        build = self.db.session.get(models.Build, build_id)
         assert build.state == "canceled"
 
 
@@ -1147,7 +1147,7 @@ class TestCoprActionsGeneration(CoprsTestCase):
             follow_redirects=False,
         )
         assert "user1/test-fedora-review/add_build" in resp.headers["Location"]
-        copr = self.models.Copr.query.get(1)
+        copr = self.db.session.get(self.models.Copr, 1)
         assert copr.full_name == "user1/test-fedora-review"
         assert len(copr.active_chroots) == 1
         assert copr.active_chroots[0].name == "fedora-rawhide-x86_64"


### PR DESCRIPTION
Fix #3612

<!-- issue-commentator = {"comment-id":"2651495974"} -->