### PR TITLE
ci: grant permissions to upload sarif data

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   python-lint-job:
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+
     steps:
       - name: Repository checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This is needed, e.g., for the dependabot PRs like #3629, where non-privileged user opens PR from a temporary branch in our repository (not a PR from a remote fork).

<!-- issue-commentator = {"comment-id":"2662205017"} -->