### PR TITLE
frontend: the function was renamed to get_recorded_queries

### DIFF
--- a/frontend/coprs_frontend/tests/test_logic/test_batch_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_batch_logic.py
@@ -5,7 +5,7 @@ Tests for working with Batches
 import json
 import time
 import pytest
-from flask_sqlalchemy import get_debug_queries
+from flask_sqlalchemy.record_queries import get_recorded_queries
 from copr_common.enums import StatusEnum
 from coprs import app, models
 from coprs.exceptions import BadRequest
@@ -145,7 +145,7 @@ class TestBatchesLogic(CoprsTestCase):
         with app.app_context():
             r = self.tc.get("/backend/pending-jobs/")
             data = json.loads(r.data.decode("utf-8"))
-            dq = get_debug_queries()
+            dq = get_recorded_queries()
 
         # Be very careful if you have to bump the number here.  Any O(N)
         # slowdown means huge penalty on /bakcend/pending-jobs/ route.
@@ -280,7 +280,7 @@ class TestBatchesLogic(CoprsTestCase):
         with app.app_context():
             r = self.tc.get("/backend/pending-jobs/")
             data = json.loads(r.data.decode("utf-8"))
-            dq = get_debug_queries()
+            dq = get_recorded_queries()
 
         t3 = time.time()
 

--- a/frontend/coprs_frontend/tests/test_views/test_backend_ns/test_backend_general.py
+++ b/frontend/coprs_frontend/tests/test_views/test_backend_ns/test_backend_general.py
@@ -3,7 +3,7 @@ import json
 from unittest import mock, skip
 import pytest
 
-from flask_sqlalchemy import get_debug_queries
+from flask_sqlalchemy.record_queries import get_recorded_queries
 
 from copr_common.enums import BackendResultEnum, StatusEnum, DefaultActionPriorityEnum
 from tests.coprs_test_case import CoprsTestCase
@@ -116,7 +116,7 @@ class TestWaitingBuilds(CoprsTestCase):
         with app.app_context():
             r = self.tc.get("/backend/pending-jobs/")
             data = json.loads(r.data.decode("utf-8"))
-            dq = get_debug_queries()
+            dq = get_recorded_queries()
 
         # Only two queries should occur.  If you happen to see higher number
         # here, please check the get_pending_srpm_build_tasks and


### PR DESCRIPTION
Fix #3613

<!-- issue-commentator = {"comment-id":"2663999386"} -->