### PR TITLE
frontend: use after/with-build-id fields when "rebuilding all"

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/packages_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/packages_logic.py
@@ -342,12 +342,13 @@ class PackagesLogic(object):
 
     @classmethod
     def batch_build(cls, user, copr, packages, chroot_names=None,
-                    only_package_chroots=None, **build_options):
+                    only_package_chroots=None, with_build_id=None,
+                    after_build_id=None, **build_options):
+
         new_builds = []
-
-        batch = models.Batch()
-        db.session.add(batch)
-
+        batch = builds_logic.BuildsLogic.setup_batch(after_build_id,
+                                                     with_build_id, user,
+                                                     always_create=True)
         for package in packages:
             git_hashes = {}
             skip_import = False

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_packages.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_packages.py
@@ -107,6 +107,8 @@ def copr_rebuild_all_packages(copr):
                 form.selected_chroots,
                 enable_net=form.enable_net.data,
                 only_package_chroots=form.only_package_chroots.data,
+                with_build_id=form.with_build_id.data,
+                after_build_id=form.after_build_id.data,
             )
 
         except (ObjectNotFound, ActionInProgressException, NoPackageSourceException, \


### PR DESCRIPTION
Fixes: #3328

<!-- issue-commentator = {"comment-id":"2666447515"} -->