### PR TITLE
rpmbuild: do not rely on working `/bin/su` in chroot

### DIFF
--- a/rpmbuild/bin/copr-sources-custom
+++ b/rpmbuild/bin/copr-sources-custom
@@ -110,6 +110,5 @@ if __name__ == "__main__":
         workdir=shlex.quote(workdir),
         env=" ".join(env)
     )
-    cmd = shlex.quote(cmd)
 
-    run_cmd(mock + ['--chroot', 'su - {0} -c {1}'.format(user, cmd)])
+    run_cmd(mock + ['--unpriv', '--chroot', cmd])


### PR DESCRIPTION
Relates: #3631

<!-- issue-commentator = {"comment-id":"2676369162"} -->