### PR TITLE
frontend: change order of login menu, sign up should be the latest

### DIFF
--- a/frontend/coprs_frontend/coprs/context_processors.py
+++ b/frontend/coprs_frontend/coprs/context_processors.py
@@ -56,6 +56,12 @@ def login_menu():
                 'desc': 'log in',
             })
 
+        if oidc_enabled(config):
+            menu.append({
+                'link': flask.url_for("misc.oidc_login"),
+                'desc': '{} login'.format(app.config['OIDC_PROVIDER_NAME']),
+            })
+
         if config['KRB5_LOGIN']:
             menu.append({
                 # url_for takes the namespace + class method converted from camelCase to snake_case
@@ -67,12 +73,6 @@ def login_menu():
             menu.append({
                 'link': config["FAS_SIGNUP_URL"],
                 'desc': 'sign up',
-            })
-
-        if oidc_enabled(config):
-            menu.append({
-                'link': flask.url_for("misc.oidc_login"),
-                'desc': '{} login'.format(app.config['OIDC_PROVIDER_NAME']),
             })
 
     return dict(login_menu=menu)


### PR DESCRIPTION
changes the login menu from 

![menu1](https://github.com/user-attachments/assets/15350c37-fceb-48e9-a006-60e3d6df3865)

to

![menu2](https://github.com/user-attachments/assets/f3039189-7d9c-44ec-9321-d76b94f3d055)

to keep the logins together

Relates to #3483

<!-- issue-commentator = {"comment-id":"2677239716"} -->