### PR TITLE
rpmbuild: ignore unicode errors in the command output

### DIFF
--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -65,8 +65,8 @@ def run_cmd(cmd, cwd=".", preexec_fn=None, env=None):
 
     result = munch.Munch(
         cmd=cmd,
-        stdout=stdout.decode('utf-8').strip(),
-        stderr=stderr.decode('utf-8').strip(),
+        stdout=stdout.decode('utf-8', errors="ignore").strip(),
+        stderr=stderr.decode('utf-8', errors="ignore").strip(),
         returncode=process.returncode,
         cwd=cwd
     )


### PR DESCRIPTION
Fix #3645

This doesn't ignore the whole (lines of) output. Only the broken characters. In this particular example, there was a problem with the special "u" character in Tina Müller and the output resulted to Tina Mller and Tina M\xfcller. That is much better than failing completely.

<!-- issue-commentator = {"comment-id":"2681603955"} -->