### PR TITLE
frontend/dist-git: remove redundant byte compile lines, these dirs are empty already

### DIFF
--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -97,9 +97,6 @@ cp -a conf/logrotate %{buildroot}%{_sysconfdir}/logrotate.d/copr-dist-git
 # for ghost files
 touch %{buildroot}%{_var}/log/copr-dist-git/main.log
 
-%py_byte_compile %{__python3} %{buildroot}%{_datadir}/copr/dist_git
-
-
 %check
 ./run_tests.sh -vv --no-cov
 

--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -295,7 +295,6 @@ EOF
 
 %py_byte_compile %{__python3} %{buildroot}%{_datadir}/copr/coprs_frontend/coprs
 %py_byte_compile %{__python3} %{buildroot}%{_datadir}/copr/coprs_frontend/alembic
-%py_byte_compile %{__python3} %{buildroot}%{_datadir}/copr/coprs_frontend/tests
 
 %check
 %if %{with check}


### PR DESCRIPTION
fix: https://github.com/fedora-copr/copr/issues/3637

<!-- issue-commentator = {"comment-id":"2682040189"} -->