### PR TITLE
frontend: 404 when build_chroot is not found in database from task_id

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -460,8 +460,8 @@ class BuildsLogic(object):
         except ValueError:
             raise MalformedArgumentException("Invalid task_id {}".format(task_id))
 
-        build_chroot = BuildChrootsLogic.get_by_build_id_and_name(build_id, chroot_name)
         try:
+            build_chroot = BuildChrootsLogic.get_by_build_id_and_name(build_id, chroot_name)
             return build_chroot.join(models.Build).one()
         except NoResultFound as ex:
             raise ObjectNotFound("Specified task ID not found") from ex

--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -365,10 +365,11 @@ def pending_jobs():
     return streamed_json(_stream())
 
 
-@backend_ns.route("/get-build-task/<task_id>/")
-@backend_ns.route("/get-build-task/<task_id>")
-def get_build_task(task_id):
+@backend_ns.route("/get-build-task/<int:build_id>-<chroot>/")
+@backend_ns.route("/get-build-task/<int:build_id>-<chroot>")
+def get_build_task(build_id, chroot):
     try:
+        task_id = f"{build_id}-{chroot}"
         task = BuildsLogic.get_build_task(task_id)
         build_record = get_build_record(task)
         return flask.jsonify(build_record)


### PR DESCRIPTION
Addresses concern raised in
https://github.com/fedora-copr/copr/issues/3457#issuecomment-2692289898

Providing nonexisting chroot will result in NoResultFound too.
This change returns 404 instead of 500.

Fix #3457

<!-- issue-commentator = {"comment-id":"2692300708"} -->