### PR TITLE
Revert "convert eror message to binary text before emitting" 

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/complex_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/complex_logic.py
@@ -204,7 +204,7 @@ class ComplexLogic(object):
             raise ObjectNotFound(
                 message="Project @{}/{} does not exist.".format(
                     group_name, copr_name
-                ).encode()
+                )
             ) from exc
 
     @staticmethod
@@ -219,7 +219,7 @@ class ComplexLogic(object):
             raise ObjectNotFound(
                 message="Project {}/{} does not exist.".format(
                     user_name, copr_name
-                ).encode()
+                )
             ) from exc
 
     @staticmethod


### PR DESCRIPTION
This reverts commit https://github.com/fedora-copr/copr/commit/57fcaf089b1a3e6f5f6aa25ebc67f856f996f631.

https://github.com/fedora-copr/copr/pull/3651#issuecomment-2710932004
explains why probably this issue was resolved and we no longer need this
fix. Also this commit caused bad formatting - b' prefix and 'suffix.
If similar issue like https://github.com/fedora-copr/copr/issues/3072 appears, we should probably parse the string
and leave the unparsable characters as their byte value.
See https://github.com/fedora-copr/copr/commit/4c8b3ec5bdc9965def756c95879a451510154cc3

Fix https://github.com/fedora-copr/copr/issues/3644

<!-- issue-commentator = {"comment-id":"2730283491"} -->