### PR TITLE
frontend: fix SAWarnings about autoflush

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -958,13 +958,13 @@ class BuildsLogic(object):
             isolation=isolation,
             ssh_public_keys=ssh_public_keys,
         )
+        db.session.add(build)
 
         if timeout:
             build.timeout = timeout
         else:
             build.timeout = package.timeout if package else app.config["DEFAULT_BUILD_TIMEOUT"]
 
-        db.session.add(build)
         cls.assign_buildchroots(
             build,
             chroots,

--- a/frontend/coprs_frontend/coprs/logic/complex_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/complex_logic.py
@@ -520,6 +520,7 @@ class ProjectForking(object):
                                        exclude=["id", "group_id", "created_on",
                                                 "scm_repo_url", "scm_api_type", "scm_api_auth_json",
                                                 "persistent", "auto_prune", "contact", "webhook_secret"])
+            db.session.add(fcopr)
 
             fcopr.forked_from_id = copr.id
             fcopr.user = self.user
@@ -531,14 +532,12 @@ class ProjectForking(object):
                 fcopr.group_id = self.group.id
 
             fcopr_dir = models.CoprDir(name=fcopr.name, copr=fcopr, main=True)
+            db.session.add(fcopr_dir)
 
             for chroot in list(copr.active_copr_chroots):
                 CoprChrootsLogic.create_chroot_from(chroot,
                                                     mock_chroot=chroot.mock_chroot,
                                                     copr=fcopr)
-
-            db.session.add(fcopr)
-            db.session.add(fcopr_dir)
 
         return fcopr
 

--- a/frontend/coprs_frontend/coprs/logic/modules_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/modules_logic.py
@@ -213,14 +213,14 @@ class ModuleBuildFacade(object):
         blocked_by_id = None
         for group in self.get_build_batches(rpms):
             batch = models.Batch()
-            batch.blocked_by_id = blocked_by_id
             db.session.add(batch)
+            batch.blocked_by_id = blocked_by_id
             for pkgname, rpm in group.items():
                 build = self.get_build(rpm, pkgname)
+                db.session.add(build)
                 build.batch = batch
                 build.batch_id = batch.id
                 build.module_id = module.id
-                db.session.add(build)
 
             # Every batch needs to by blocked by the previous one
             blocked_by_id = batch.id

--- a/frontend/coprs_frontend/tests/coprs_test_case.py
+++ b/frontend/coprs_frontend/tests/coprs_test_case.py
@@ -24,6 +24,7 @@ from coprs.logic.dist_git_logic import DistGitLogic
 from tests.request_test_api import WebUIRequests, API3Requests, BackendRequests
 from tests.lib.pagure_pull_requests import PullRequestTrigger
 
+
 class CoprsTestCase(object):
 
     # These are made available by TransactionDecorator() decorator

--- a/frontend/coprs_frontend/tests/test_logging.py
+++ b/frontend/coprs_frontend/tests/test_logging.py
@@ -116,6 +116,8 @@ class TestLoggingCoprPermissionsLogic(CoprsTestCase):
             copr_builder=helpers.PermissionEnum("request"),
             copr_admin=helpers.PermissionEnum("request"))
 
+        self.db.session.add(perm)
+
         CoprPermissionsLogic.update_permissions(
             self.u2, self.c2, perm,
             new_builder=helpers.PermissionEnum("approved"),

--- a/frontend/coprs_frontend/tests/test_logic/test_builds_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_builds_logic.py
@@ -201,6 +201,7 @@ class TestBuildsLogic(CoprsTestCase):
             BuildsLogic.delete_build(self.u1, self.b1)
 
         self.copr_persistent = models.Copr(name=u"persistent_copr", user=self.u2, persistent=True)
+        self.db.session.add(self.copr_persistent)
         self.copr_dir = models.CoprDir(name="persistent_copr", main=True, copr=self.copr_persistent)
         self.build_persistent = models.Build(
             copr=self.copr_persistent, copr_dir=self.copr_dir,

--- a/frontend/coprs_frontend/tests/test_mail.py
+++ b/frontend/coprs_frontend/tests/test_mail.py
@@ -59,9 +59,12 @@ class TestMail(CoprsTestCase):
             mc = models.MockChroot(os_release="fedora", os_version=i,
                                    arch="x86_64", is_active=True)
             mc.distgit_branch = models.DistGitBranch.query.first()
+            self.db.session.add(mc)
+
             cc = models.CoprChroot()
             cc.mock_chroot = mc
             cc.copr = self.c2
+            self.db.session.add(cc)
             chroots.append(cc)
 
         now = datetime.datetime.now()

--- a/frontend/coprs_frontend/tests/test_pagure_events.py
+++ b/frontend/coprs_frontend/tests/test_pagure_events.py
@@ -38,6 +38,7 @@ class TestPagureEvents(CoprsTestCase):
             copr=self.c1, name="hello-world", source_type=8, webhook_rebuild=True,
             source_json='{"clone_url": "https://pagure.io/test"}'
         )
+        self.db.session.add(self.p2)
         candidates = ScmPackage.get_candidates_for_rebuild("https://pagure.io/test")
         dir_in_commit = [pkg for pkg in candidates if pkg.is_dir_in_commit({''})]
 
@@ -175,6 +176,7 @@ class TestPagureEvents(CoprsTestCase):
             copr=self.c1, name="hello-world", source_type=8, webhook_rebuild=True,
             source_json='{"clone_url": "https://pagure.io/test"}',
         )
+        self.db.session.add(self.p1)
         build = build_on_fedmsg_loop()
         message = Message(
             'io.pagure.prod.pagure.git.receive',


### PR DESCRIPTION
Since there was a lot of these warnings, there are 3 kind of fixes to these:

- 1st -> Just adds objects created and manipulated in tests to session to silence warnings
- 2nd -> Shifting `db.session.add`: These warnings occur because SQLAlchemy tries to manage relationships affecting an object (e.g. CoprDir) that has not yet been added to the session, and a flush is triggered by some automatic magic inside SQLalchemy, hence the warning. Moving `session.add` before tinkering/adding relationships to it silence the warning
- 3rd -> If for some reason 2nd fix can't be applied due to complicated relationships creations, `no_autoflush` can be applied to tell SQLAlchemy not to automatically flush (we do it anyway with `db.session.flush()`)

The second solution was inspired by https://github.com/sqlalchemy/sqlalchemy/issues/4491#issuecomment-462091501 since this is similar situation

<!-- issue-commentator = {"comment-id":"2781652423"} -->