### PR TITLE
Add sysusers.d config file to allow rpm to create users/groups automatically

### DIFF
--- a/keygen/configs/copr-keygen.sysusers.conf
+++ b/keygen/configs/copr-keygen.sysusers.conf
@@ -1,0 +1,2 @@
+#Type Name        ID       GECOS              Home directory            Shell
+u     copr-signer -        'Copr rpm signer'  /usr/share/copr-keygen    /bin/bash

--- a/keygen/copr-keygen.spec
+++ b/keygen/copr-keygen.spec
@@ -127,15 +127,10 @@ cp -a docs/_build/html %{buildroot}%{_pkgdocdir}/
 %{__install} -p -m 0644 configs/sign/sign.conf.example %{buildroot}%{_pkgdocdir}/sign/sign.conf.example
 %endif
 
+install -m0644 -D configs/copr-keygen.sysusers.conf %{buildroot}%{_sysusersdir}/copr-keygen.conf
+
 %check
 ./run_tests.sh -vv --no-cov
-
-
-%pre
-getent group copr-signer >/dev/null || groupadd -r copr-signer
-getent passwd copr-signer >/dev/null || \
-  useradd -r -g copr-signer -G copr-signer -d %{_datadir}/copr-keygen -s /bin/bash -c "Copr rpm signer" copr-signer
-/usr/bin/passwd -l copr-signer >/dev/null
 
 
 %post
@@ -166,6 +161,7 @@ systemctl condrestart httpd &>/dev/null || :
 %config(noreplace) %{_sysconfdir}/copr-keygen
 %dir %{_localstatedir}/log/copr-keygen
 %ghost %{_localstatedir}/log/copr-keygen/main.log
+%{_sysusersdir}/copr-keygen.conf
 
 %if 0%{?fedora}
 %files -n copr-keygen-doc


### PR DESCRIPTION
forwarded from downstream copr-keygen with added if-conditions 
Related: fedora-copr#2789

<!-- issue-commentator = {"comment-id":"2721326716"} -->