### PR TITLE
unify bindir and sbindir

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -147,13 +147,12 @@ install -d %{buildroot}%{_unitdir}
 install -d %{buildroot}/%{_var}/log/copr-backend
 install -d %{buildroot}/%{_var}/run/copr-backend/
 install -d %{buildroot}/%{_tmpfilesdir}
-install -d %{buildroot}/%{_sbindir}
 install -d %{buildroot}%{_sysconfdir}/cron.daily
 install -d %{buildroot}%{_sysconfdir}/cron.weekly
 install -d %{buildroot}%{_sysconfdir}/sudoers.d
 install -d %{buildroot}%{_bindir}/
 
-cp -a copr-backend-service %{buildroot}/%{_sbindir}/
+cp -a copr-backend-service %{buildroot}/%{_bindir}/
 cp -a run/* %{buildroot}%{_bindir}/
 cp -a conf/copr-be.conf.example %{buildroot}%{_sysconfdir}/copr/copr-be.conf
 
@@ -228,7 +227,7 @@ useradd -r -g copr -G lighttpd -s /bin/bash -c "COPR user" copr
 %{_unitdir}/*.target
 %{_tmpfilesdir}/copr-backend.conf
 %{_bindir}/*
-%{_sbindir}/*
+
 
 %config(noreplace) %{_sysconfdir}/cron.daily/copr-backend
 %config(noreplace) %{_sysconfdir}/cron.weekly/copr-backend

--- a/selinux/copr-selinux.spec
+++ b/selinux/copr-selinux.spec
@@ -65,9 +65,9 @@ done
 install -d %{buildroot}%{_datadir}/selinux/devel/include/%{moduletype}
 install -p -m 644 %{modulename}.if \
   %{buildroot}%{_datadir}/selinux/devel/include/%{moduletype}/%{modulename}.if
-install -d %{buildroot}%{_sbindir}
-install -p -m 755 %{name}-enable %{buildroot}%{_sbindir}/%{name}-enable
-install -p -m 755 %{name}-relabel %{buildroot}%{_sbindir}/%{name}-relabel
+install -d %{buildroot}%{_bindir}
+install -p -m 755 %{name}-enable %{buildroot}%{_bindir}/%{name}-enable
+install -p -m 755 %{name}-relabel %{buildroot}%{_bindir}/%{name}-relabel
 install -d %{buildroot}%{_mandir}/man8
 install -p -m 644 man/%{name}-enable.8 %{buildroot}/%{_mandir}/man8/
 install -p -m 644 man/%{name}-relabel.8 %{buildroot}/%{_mandir}/man8/
@@ -104,8 +104,8 @@ done
 %{_datadir}/selinux/*/%{modulename}.pp.bz2
 # empty, do not distribute it for now
 %exclude %{_datadir}/selinux/devel/include/%{moduletype}/%{modulename}.if
-%{_sbindir}/%{name}-enable
-%{_sbindir}/%{name}-relabel
+%{_bindir}/%{name}-enable
+%{_bindir}/%{name}-relabel
 %{_mandir}/man8/%{name}-enable.8*
 %{_mandir}/man8/%{name}-relabel.8*
 


### PR DESCRIPTION
In Fedora 42 /usr/bin and /usr/sbin has been merged. We do not have real reason to insist on /usr/sbin and we can do this change for older distributions too.

Fixes: #3635

Addressing:
RPM build warnings:
    File listed twice: /usr/bin/copr-assure-permissions
    File listed twice: /usr/bin/copr-aws-s3-hitcounter
    File listed twice: /usr/bin/copr-backend-analyze-results
    File listed twice: /usr/bin/copr-backend-generate-graphs
    File listed twice: /usr/bin/copr-backend-process-action
    File listed twice: /usr/bin/copr-backend-process-build
    File listed twice: /usr/bin/copr-backend-resultdir-cleaner
    File listed twice: /usr/bin/copr-backend-service
    File listed twice: /usr/bin/copr-backend-unknown-resalloc-tickets.py
    File listed twice: /usr/bin/copr-change-storage
    File listed twice: /usr/bin/copr-compress-live-logs
    File listed twice: /usr/bin/copr-rename-chroot
    File listed twice: /usr/bin/copr-repo
    File listed twice: /usr/bin/copr-run-dispatcher-backend
    File listed twice: /usr/bin/copr_find_obsolete_builds.sh
    File listed twice: /usr/bin/copr_find_wrong_chroot_artifacts.py
    File listed twice: /usr/bin/copr_fix_gpg.py
    File listed twice: /usr/bin/copr_log_hitcounter.py
    File listed twice: /usr/bin/copr_print_results_to_delete.py
    File listed twice: /usr/bin/copr_prune_results.py
    File listed twice: /usr/bin/copr_prune_srpms.py
    File listed twice: /usr/bin/copr_run_logger.py
    File listed twice: /usr/bin/copr_sign_unsigned.py
    File listed twice: /usr/bin/print_queues.py

<!-- issue-commentator = {"comment-id":"2721410428"} -->