### PR TITLE
frontend: fix code formatting test causing FTBFS

### DIFF
--- a/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
+++ b/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
@@ -343,14 +343,19 @@ class TestCoprDetail(CoprsTestCase):
     def test_codeblock_html_in_project_description(self, f_users, f_coprs):
         r = self.tc.get("/coprs/{0}/{1}/".format(self.u1.name, self.c1.name))
         lines = ['<pre><code class="language-python"><div class="highlight"><span></span><span class="c1"># code snippet</span>',
-                 '<span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>',
                  '    <span class="n">bar</span><span class="p">()</span>',
                  '    <span class="k">return</span> <span class="mi">1</span>',
                  '</div>',
                  '</code></pre>']
         removed_code = ['<blink>']
 
+        alternatives = [
+            '<span class="k">def</span> <span class="nf">foo</span><span class="p">():</span>',
+            '<span class="k">def</span><span class="w"> </span><span class="nf">foo</span><span class="p">():</span>',
+        ]
+
         generated_html = r.data.decode("utf-8")
+        assert any(exp in generated_html for exp in alternatives)
         for line in lines:
             assert line in generated_html
         for line in removed_code:


### PR DESCRIPTION
Fedora 43 has a new python3-pygments v2.19 providing slightly different generated code output.

Fixes: #3656

<!-- issue-commentator = {"comment-id":"2750306286"} -->