### PR TITLE
frontend: pagure-events fail for "dots" in copr.name

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/coprs_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/coprs_logic.py
@@ -1,7 +1,6 @@
 import locale
 import json
 import os
-import re
 import time
 import datetime
 from functools import cmp_to_key
@@ -696,9 +695,11 @@ class CoprDirsLogic(object):
                 f"Please use directory format {copr.name}:custom:<SUFFIX_OF_CHOICE> "
                 f"or {copr.name}:pr:<ID> (for automatically removed directories)"
             )
-        if not all(x.isalnum() for x in re.split(r"[:-]+", dirname)[1:]):
-            raise exceptions.BadRequest(
-                f"Wrong directory '{dirname}' specified.  Directory name can "
+
+        for dir_part in dirname.split(':')[1:]:
+            if not all(x.isalnum() for x in dir_part.split("-")):
+                raise exceptions.BadRequest(
+                    f"Wrong directory '{dirname}' specified.  Directory name can "
                 "consist of alpha-numeric strings separated by colons.")
 
     @classmethod

--- a/frontend/coprs_frontend/pagure_events.py
+++ b/frontend/coprs_frontend/pagure_events.py
@@ -266,7 +266,7 @@ class build_on_fedmsg_loop():
                     pkg.package.name,
                     pkg.package.id
             )
-            log.info('Considering pkg package: {}, source_json: {}'
+            log.info('Considering package: {}, source_json: {}'
                         .format(package, pkg.source_json_dict))
 
             if not pkg.copr.active_copr_chroots:

--- a/frontend/coprs_frontend/tests/test_logic/test_copr_dirs_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_copr_dirs_logic.py
@@ -143,3 +143,8 @@ class TestCoprDirsLogic(CoprsTestCase):
         for dirname in invalid:
             with pytest.raises(CoprHttpException):
                 CoprDirsLogic.validate(self.c1, dirname)
+
+        self.c1.name = "pytest-8.1.1"
+        for dirname in valid:
+            dirname = dirname.replace("foocopr", self.c1.name)
+            assert CoprDirsLogic.validate(self.c1, dirname) is None


### PR DESCRIPTION
This bug caused pagure-events traceback, so any subsequent package
"candidate" (even in project without dots in name) wasn't build either.

<!-- issue-commentator = {"comment-id":"2765471877"} -->