### PR TITLE
releng: release clients into all EPEL chroots

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -5,7 +5,7 @@ branches = fedora-all
 
 [fedora-git-clients]
 releaser = tito.release.FedoraGitReleaser
-branches = fedora-all epel8 epel9
+branches = fedora-all epel-all
 
 [fedora-git-common]
 releaser = tito.release.FedoraGitReleaser


### PR DESCRIPTION
This includes EPEL 10.0 and EPEL 10.1 (next) at this point in time.

Resolves: #3685