### PR TITLE
frontend: drop no longer unused PULP_CONTENT_URL config

### DIFF
--- a/docker/frontend/files/etc/copr/copr.conf
+++ b/docker/frontend/files/etc/copr/copr.conf
@@ -162,5 +162,3 @@ USAGE_TREEMAP_TEAMS = {
 # OIDC_AUTH_URL=""
 # OIDC_TOKEN_URL=""
 # OIDC_USERINFO_URL=""
-
-PULP_CONTENT_URL = "http://localhost:5006/pulp/content/"

--- a/frontend/coprs_frontend/tests/test_repos.py
+++ b/frontend/coprs_frontend/tests/test_repos.py
@@ -93,7 +93,6 @@ class TestRepos(CoprsTestCase):
         easily test this but this but that it only an implementation detail.
         """
         app.config["BACKEND_BASE_URL"] = "http://backend"
-        app.config["PULP_CONTENT_URL"] = "http://pulp"
 
         self.c1.storage = StorageEnum.pulp
         self.db.session.add_all([self.c1, self.c4_dir])


### PR DESCRIPTION
This config option was just confusing in Fedora's ansible.git repo, and also here upstream.

<!-- issue-commentator = {"comment-id":"2768285850"} -->