### PR TITLE
backend: drop the novaclient dependency

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -87,7 +87,6 @@ Requires:   python3-humanize
 Requires:   python3-jinja2
 Requires:   python3-munch
 Requires:   python3-netaddr
-Requires:   python3-novaclient
 Requires:   python3-packaging
 Requires:   python3-pytz
 Requires:   python3-requests


### PR DESCRIPTION
I received "Orphaned packages looking for new maintainers" e-mail today, with this:

    copr-backend (maintained by: @copr-sig, frostyx, msuchy, praiskup)
        copr-backend-2.3-1.fc43.noarch requires python3-novaclient = 1:18.7.0-2.fc42

This dep has been added by 75405aa39791eadd44c81d, but the script cleanup_vm_nova.py is no longer in our code, since d81e71ce5e8c704b3e.