### PR TITLE
frontend: models_committed has been moved in sqlalchemy

### DIFF
--- a/frontend/coprs_frontend/coprs/__init__.py
+++ b/frontend/coprs_frontend/coprs/__init__.py
@@ -6,6 +6,7 @@ import flask
 
 from werkzeug.routing import RequestRedirect
 from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.track_modifications import models_committed
 from contextlib import contextmanager
 try:
     from flask_caching import Cache
@@ -234,7 +235,6 @@ app.jinja_env.lstrip_blocks = True
 
 setup_profiler(app, profiler_enabled)
 
-from flask_sqlalchemy import models_committed
 models_committed.connect(coprs.whoosheers.CoprWhoosheer.on_commit, sender=app)
 
 # Serve static files from system-wide RPM files


### PR DESCRIPTION
Per this warning:
coprs/__init__.py:237: DeprecationWarning: 'models_committed' has been moved to 'track_modifications.models_committed'. The top-level import is deprecated and will be removed in Flask-SQLAlchemy 3.1.

<!-- issue-commentator = {"comment-id":"2792095727"} -->