### PR TITLE
Small fixes for Pulp labels

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -683,6 +683,7 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
             self.job.chroot,
             self.job.results_dir,
             self.job.target_dir_name,
+            build_id=self.job.build_id,
         )
 
     def _check_build_success(self):

--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -149,14 +149,15 @@ def main():
             for builddir_entry in os.scandir(chrootdir):
                 if not builddir_entry.is_dir():
                     continue
-                builddir = builddir_entry.name
-                build_id = builddir.split('-')[0]
-                resultdir = os.path.join(chrootdir, builddir)
 
+                builddir = builddir_entry.name
+                resultdir = os.path.join(chrootdir, builddir)
 
                 if not is_valid_build_directory(builddir):
                     log.info("Skipping: %s", resultdir)
                     continue
+
+                build_id = str(int(builddir.split("-")[0]))
 
                 # TODO Fault-tolerance and data consistency
                 # Errors when creating things in Pulp will likely happen


### PR DESCRIPTION
This should fix our failing beaker tests and also make sure we won't have inconsistent labels because of leading zeros.

<!-- issue-commentator = {"comment-id":"2894725562"} -->