### PR TITLE
Fix local builds in Pulp projects

### DIFF
--- a/docker/frontend/files/etc/copr/copr.conf
+++ b/docker/frontend/files/etc/copr/copr.conf
@@ -163,4 +163,4 @@ USAGE_TREEMAP_TEAMS = {
 # OIDC_TOKEN_URL=""
 # OIDC_USERINFO_URL=""
 
-PULP_CONTENT_URL = "http://localhost:5006/pulp/content/"
+PULP_CONTENT_URL = "http://pulp:80/pulp/content"

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -205,6 +205,11 @@ class Config(object):
     # Possible options are "backend" and "pulp"
     DEFAULT_STORAGE = "backend"
 
+    # Where Pulp results are served. When `None`, the standard Copr backend
+    # URLs are used, expecting the Copr instance to have some redirects
+    # configured in Lighttpd
+    PULP_CONTENT_URL = None
+
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -665,6 +665,11 @@ class Copr(db.Model, helpers.Serializer, CoprSearchRelatedData):
         """
         URL for a project repository
         """
+        if self.storage == StorageEnum.pulp and app.config["PULP_CONTENT_URL"]:
+            return "/".join([
+                app.config["PULP_CONTENT_URL"].rstrip("/"),
+                self.full_name,
+            ])
         return "/".join([app.config["BACKEND_BASE_URL"], "results",
                          self.full_name])
 
@@ -853,6 +858,12 @@ class CoprDir(db.Model):
         """
         URL for a CoprDir repository
         """
+        if self.copr.storage == StorageEnum.pulp and app.config["PULP_CONTENT_URL"]:
+            return "/".join([
+                app.config["PULP_CONTENT_URL"].rstrip("/"),
+                self.full_name,
+            ])
+
         return "/".join([app.config["BACKEND_BASE_URL"], "results",
                          self.full_name])
 

--- a/frontend/coprs_frontend/tests/test_repos.py
+++ b/frontend/coprs_frontend/tests/test_repos.py
@@ -93,7 +93,6 @@ class TestRepos(CoprsTestCase):
         easily test this but this but that it only an implementation detail.
         """
         app.config["BACKEND_BASE_URL"] = "http://backend"
-        app.config["PULP_CONTENT_URL"] = "http://pulp"
 
         self.c1.storage = StorageEnum.pulp
         self.db.session.add_all([self.c1, self.c4_dir])
@@ -104,6 +103,11 @@ class TestRepos(CoprsTestCase):
         # and let the HTTPD service redirect where needed
         url = "copr://user1/foocopr:PR"
         expected = "http://backend/results/user1/foocopr:PR/fedora-rawhide-x86_64/"
+        assert pre_process_repo_url("fedora-rawhide-x86_64", url) == expected
+
+        # Only when PULP_CONTENT_URL is set, we use that URL directly
+        app.config["PULP_CONTENT_URL"] = "http://pulp"
+        expected = "http://pulp/user1/foocopr:PR/fedora-rawhide-x86_64/"
         assert pre_process_repo_url("fedora-rawhide-x86_64", url) == expected
 
     def test_parse_repo_params(self):


### PR DESCRIPTION
Close #3632

In Fedora Copr production, we will leave this value as `None` because we want people to use our CDN URLs and basically not even notice, the results moved to Pulp. We already have Lighttpd redirects and everything.

However, in docker-compose, we need to use an URL that is accessible by other containers.

<!-- issue-commentator = {"comment-id":"2897406328"} -->