### PR TITLE
Specify charset in lighttpd mimetypes

### DIFF
--- a/backend/conf/lighttpd/mime.conf
+++ b/backend/conf/lighttpd/mime.conf
@@ -52,7 +52,7 @@ mimetype.assign             = (
   ".conf"         =>      "text/plain",
   ".text"         =>      "text/plain",
   ".txt"          =>      "text/plain",
-  ".spec"         =>      "text/plain",
+  ".spec"         =>      "text/plain; charset=utf-8",
   ".dtd"          =>      "text/xml",
   ".xml"          =>      "text/xml",
   ".mpeg"         =>      "video/mpeg",


### PR DESCRIPTION
Specify charset in lighttpd mimetypes for build log files and .spec files.
Fixes #3077

<!-- issue-commentator = {"comment-id":"2921406389"} -->