### PR TITLE
rpmbuild: fix make_srpm method on bootc builders

### DIFF
--- a/rpmbuild/mock-source-build.cfg.j2
+++ b/rpmbuild/mock-source-build.cfg.j2
@@ -5,7 +5,6 @@ config_opts['rpmbuild_networking'] = True
 config_opts['use_host_resolv'] = True
 config_opts['chroot_additional_packages'] = 'make dnf'
 config_opts['plugin_conf']['bind_mount_enable'] = True
-config_opts['use_bootstrap'] = False
 config_opts['nspawn_args'] = ['--drop-capability=CAP_SYS_ADMIN,CAP_IPC_OWNER,CAP_KILL,CAP_LEASE,CAP_LINUX_IMMUTABLE,CAP_NET_BIND_SERVICE,CAP_NET_BROADCAST,CAP_NET_RAW,CAP_SETGID,CAP_SETPCAP,CAP_SETUID,CAP_SYS_CHROOT,CAP_SYS_NICE,CAP_SYS_PTRACE,CAP_SYS_TTY_CONFIG,CAP_SYS_RESOURCE,CAP_SYS_BOOT,CAP_AUDIT_WRITE,CAP_AUDIT_CONTROL']
 
 {% for key, value in macros.items() %}


### PR DESCRIPTION
This was really hard for me to debug and took many hours. For some reason, nothing relevant appears in the logs. However, when digging manually, I found:

    >>> Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=updates
    >>> Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=updates
    >>> Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=updates
    >>> Librepo error: Cannot prepare internal mirrorlist: Status code: 404 for http
    Failed to download metadata (metalink: "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f$releasever&arch=x86_64") for repository "updates"

See the unevaluated `$releasever` variable. And yes, it should have been evaluated because the `$basearch` was evaluated into `arch=x86_64`. Also when you dump the DNF variables inside the Mock shell, the `$releasever` is missing.

    <mock-chroot> sh-5.2# dnf --dump-variables
    ======== Variables: ========
    arch = x86_64
    basearch = x86_64

I don't understand why this is happening and who is at fault (Copr, Mock, DNF, Bootc, ...).

Another issue was missing distribution-gpg-keys inside the Mock shell. Again, nothing interesting in the logs, but with some debugging, I encountered:

    Running transaction
    cannot open file: (2) - No such file or directory [/usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-42-primary]
    make: *** [/mnt/workdir-ijpnsm3g/copr-test-hello/.copr/Makefile:2: srpm] Error 1

This PR fixes both of these issues. I'd consider both of these to be workarounds but since these issues appear only in the `make_srpm` method, which is not used by many people, and we are planning to deprecate it, I don't think it is worth digging deeper, and personally, I would go with the workarounds

<!-- issue-commentator = {"comment-id":"2925781444"} -->