### PR TITLE
backend: pulp in production and STG uses a bit different URLs

### DIFF
--- a/backend/run/copr-pulp-json-to-labels
+++ b/backend/run/copr-pulp-json-to-labels
@@ -69,7 +69,12 @@ def main():
 
                 ok = True
                 for resource in pulp_json["resources"]:
-                    if not resource.startswith("/pulp/api/v3/content/rpm"):
+                    resource_prefix = (
+                        "/pulp/api/v3/content/rpm",  # Docker
+                        "/api/pulp/copr/api/v3/content/rpm",  # Devel
+                        "/api/pulp/public-copr/api/v3/content/rpm",  # Production
+                    )
+                    if not resource.startswith(resource_prefix):
                         continue
 
                     build_id = str(int(os.path.basename(builddir).split("-")[0]))


### PR DESCRIPTION
Before, I only tested the script in my docker container with my local Pulp instance. On both production and STG, we use the Pulp hosted production instance, which has a bit different URLs.

<!-- issue-commentator = {"comment-id":"2932775289"} -->