### PR TITLE
memory optimalization in copr_log_hitcounter.py

### DIFF
--- a/backend/run/copr_log_hitcounter.py
+++ b/backend/run/copr_log_hitcounter.py
@@ -32,7 +32,8 @@ def parse_access_file(path):
     """
     with open(path, 'r') as logfile:
         firstline = logfile.readline()
-        assert firstline.startswith("=== start:")
+        if not firstline.startswith("=== start:"):
+            raise ValueError(f"Invalid header: expected '=== start:' at the beginning, got: {firstline!r}")
 
         for line in logfile:
             m = logline_regex.match(line)

--- a/backend/run/copr_log_hitcounter.py
+++ b/backend/run/copr_log_hitcounter.py
@@ -31,24 +31,24 @@ def parse_access_file(path):
     Take a raw access file and return its contents as a list of dicts.
     """
     with open(path, 'r') as logfile:
-        content = logfile.readlines()
-    assert content[0].startswith("=== start:")
+        firstline = logfile.readline()
+        assert firstline.startswith("=== start:")
 
-    accesses = []
-    for line in content[1:]:
-        m = logline_regex.match(line)
-        if not m:
-            continue
-        # Rename dict keys to match `copr-aws-s3-hitcounter`
-        access = m.groupdict()
-        access["cs-uri-stem"] = access.pop("url")
-        access["sc-status"] = access.pop("code")
-        access["cs(User-Agent)"] = access.pop("agent")
-        timestamp = datetime.strptime(access.pop("timestamp"),
-                                      "%d/%b/%Y:%H:%M:%S %z")
-        access["time"] = timestamp.strftime("%H:%M:%S")
-        access["date"] = timestamp.strftime("%Y-%m-%d")
-        accesses.append(access)
+        accesses = []
+        for line in logfile:
+            m = logline_regex.match(line)
+            if not m:
+                continue
+            # Rename dict keys to match `copr-aws-s3-hitcounter`
+            access = m.groupdict()
+            access["cs-uri-stem"] = access.pop("url")
+            access["sc-status"] = access.pop("code")
+            access["cs(User-Agent)"] = access.pop("agent")
+            timestamp = datetime.strptime(access.pop("timestamp"),
+                                          "%d/%b/%Y:%H:%M:%S %z")
+            access["time"] = timestamp.strftime("%H:%M:%S")
+            access["date"] = timestamp.strftime("%Y-%m-%d")
+            accesses.append(access)
     return accesses
 
 


### PR DESCRIPTION
This prevents loading 6GB in memory twice.
And replace one assert with a real condition.

Split into three separate commits to ease the review.

<!-- issue-commentator = {"comment-id":"2936937592"} -->