### PR TITLE
Create one repository version and publication per chroot

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -679,12 +679,15 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         this method could upload the results and remove the temporary files
         at the same time.
         """
-        self.storage.upload_build_results(
+        result = self.storage.upload_build_results(
             self.job.chroot,
             self.job.results_dir,
             self.job.target_dir_name,
             build_id=self.job.build_id,
         )
+        if result:
+            # Only PulpStorage returns package HREFs
+            self.storage.create_repository_version(self.job.chroot, result)
 
     def _check_build_success(self):
         """

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -172,17 +172,27 @@ class PulpClient:
         }
         return requests.patch(url, json=data, **self.request_params)
 
-    def create_content(self, repository, path, labels):
+    def create_content(self, path, labels):
         """
         Create content for a given artifact
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Content:-Packages/operation/content_rpm_packages_create
         """
         url = self.url("api/v3/content/rpm/packages/")
         with open(path, "rb") as fp:
-            data = {"repository": repository, "pulp_labels": json.dumps(labels)}
+            data = {"pulp_labels": json.dumps(labels)}
             files = {"file": fp}
             return requests.post(
                 url, data=data, files=files, **self.request_params)
+
+    def add_content(self, repository, artifacts):
+        """
+        Add a list of artifacts to a repository
+        https://pulpproject.org/pulp_rpm/restapi/#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_modify
+        """
+        path = os.path.join(repository, "modify/")
+        url = self.config["base_url"] + path
+        data = {"add_content_units": artifacts}
+        return requests.post(url, json=data, **self.request_params)
 
     def delete_content(self, repository, artifacts):
         """

--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -146,6 +146,24 @@ def main():
             storage = PulpStorage(
                 owner, subproject, appstream, devel, config, log)
 
+            # TODO Fault-tolerance and data consistency
+            # Errors when creating things in Pulp will likely happen
+            # (networking issues, unforseen Pulp validation, etc). We
+            # should figure out how to ensure that all RPMs were
+            # successfully uploaded, and if not, we know about it.
+            #
+            # We also need to make sure that no builds, actions, or cron,
+            # are currently writing into the results directory. Otherwise
+            # we can end up with incosystent data in Pulp.
+
+            result = storage.init_project(subproject, chroot)
+            if not result:
+                log.error("Failed to initialize project: %s", chroot)
+                ok = False
+                break
+
+            all_package_hrefs = []
+
             for builddir_entry in os.scandir(chrootdir):
                 if not builddir_entry.is_dir():
                     continue
@@ -159,32 +177,24 @@ def main():
 
                 build_id = str(int(builddir.split("-")[0]))
 
-                # TODO Fault-tolerance and data consistency
-                # Errors when creating things in Pulp will likely happen
-                # (networking issues, unforseen Pulp validation, etc). We
-                # should figure out how to ensure that all RPMs were
-                # successfully uploaded, and if not, we know about it.
-                #
-                # We also need to make sure that no builds, actions, or cron,
-                # are currently writing into the results directory. Otherwise
-                # we can end up with incosystent data in Pulp.
-
-                result = storage.init_project(subproject, chroot)
-                if not result:
-                    log.error("Failed to initialize project: %s", resultdir)
-                    ok = False
-                    break
-
                 # We cannot check return code here
-                storage.upload_build_results(chroot, resultdir, None, max_workers=80, build_id=build_id)
+                package_hrefs = storage.upload_build_results(chroot, resultdir, None, max_workers=80, build_id=build_id)
+                all_package_hrefs.extend(package_hrefs)
 
-                result = storage.publish_repository(chroot)
-                if not result:
-                    log.error("Failed to publish a repository: %s", resultdir)
-                    ok = False
-                    break
+            # Add build results to the repository
+            result = storage.create_repository_version(chroot, all_package_hrefs)
+            if not result:
+                log.error("Failed to create a new repository version: %s", chroot)
+                ok = False
+                break
 
-                log.info("OK: %s", resultdir)
+            result = storage.publish_repository(chroot)
+            if not result:
+                log.error("Failed to publish a repository: %s", resultdir)
+                ok = False
+                break
+
+            log.info("OK: %s", chroot)
 
     # Not everything was migrated successfully. Play it safe and fail.
     if not ok:


### PR DESCRIPTION
This patch makes the following changes:

PulpClient.create_content() no longer accepts a repository parameter. As a result, the content is uploaded to Pulp without generating an additional task to create a repository version.

PulpClient.add_content() method provides ability to add multiple RPMs to a repository in a single task.

PulpStorage.upload_build_results() method now returns a list of HREFs corresponding to the uploaded RPMs.

PulpStorage.create_repository_version() method now handles creating a new repository version.

The copr-change-storage script now calls PulpStorage.create_repository_version() once for every chroot.

The copr-change-storage script now calls PulpStorage.publish_repository() once for every chroot.

<!-- issue-commentator = {"comment-id":"2963349301"} -->