### PR TITLE
Switches PulpStorage to using the synchronous RPM upload API

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -2,7 +2,6 @@
 Pulp doesn't provide an API client, we are implementing it for ourselves
 """
 
-import json
 import logging
 import os
 import time
@@ -181,12 +180,16 @@ class PulpClient:
         Create content for a given artifact
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Content:-Packages/operation/content_rpm_packages_create
         """
-        url = self.url("api/v3/content/rpm/packages/")
+        url = self.url("api/v3/content/rpm/rpmpackages/")
         with open(path, "rb") as fp:
-            data = {"pulp_labels": json.dumps(labels)}
             files = {"file": fp}
-            return requests.post(
-                url, data=data, files=files, **self.request_params)
+            package =  requests.post(
+                url, files=files, **self.request_params)
+        if package.ok:
+            package_href = package.json()["pulp_href"]
+            for key, val in labels.items():
+                self.set_label(package_href, key, val)
+        return package
 
     def add_content(self, repository, artifacts):
         """

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -356,7 +356,10 @@ class PulpStorage(Storage):
             list_of_prns = [package["prn"] for package in content_response.json()["results"] ]
 
             response = self.client.delete_content(repository, list_of_prns)
-            if response.ok:
+            task = response.json()["task"]
+            response = self.client.wait_for_finished_task(task)
+            resources = response.json()["created_resources"]
+            if resources:
                 self.log.info("Successfully deleted Pulp content %s", list_of_prns)
             else:
                 result = False


### PR DESCRIPTION
Pulp Service added a synchronous RPM create API. The new API does not currently support creating labels at upload time. The build id is added to the RPMs in a separate API request.

<!-- issue-commentator = {"comment-id":"2984002504"} -->