### PR TITLE
frontend: disable network when crearing a new fedora review project

### DIFF
--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
@@ -226,6 +226,7 @@ def copr_add_fedora_review(username):  # pylint: disable=unused-argument
                 delete_after_days=delete_after_days,
                 follow_fedora_branching=False,
                 fedora_review=True,
+                enable_net=False,
             )
             db.session.commit()
             flask.flash(


### PR DESCRIPTION
Fix #3622

This affects only new projects created by the "Create a Fedora Review Project" button. It is completely unrelated to the "Run fedora-review tool for packages in this project" checkbox when creating a new standard project.

<!-- issue-commentator = {"comment-id":"2987465071"} -->