### PR TITLE
backend: fix false-positive failures for build deletion

### DIFF
--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -358,12 +358,15 @@ class PulpStorage(Storage):
             response = self.client.delete_content(repository, list_of_prns)
             task = response.json()["task"]
             response = self.client.wait_for_finished_task(task)
-            resources = response.json()["created_resources"]
-            if resources:
+            data = response.json()
+            if response.ok and data["state"] == "completed":
                 self.log.info("Successfully deleted Pulp content %s", list_of_prns)
             else:
                 result = False
                 self.log.info("Failed to delete Pulp content %s", list_of_prns)
+
+            resources = data["created_resources"]
+            self.log.info("Deleted resources: %s", resources)
 
             published = self.publish_repository(chroot)
             if not published:


### PR DESCRIPTION
Fix #3689

The 45d1424 commit introduced a small bug. Consider this reproducer:

1. Submit a Copr build that succeeds in several chroots but fails in at least one
2. Click the Delete build button in Copr

For the failed `chroot`, the `resources` is just an empty list. Which IMHO makes sense because we didn't upload any RPMs for that chroot in the first place.

<!-- issue-commentator = {"comment-id":"3029416186"} -->