### PR TITLE
Switch RPM upload to the synchronous API from pulp_rpm

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -181,7 +181,7 @@ class PulpClient:
         Create content for a given artifact
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Content:-Packages/operation/content_rpm_packages_create
         """
-        url = self.url("api/v3/content/rpm/rpmpackages/")
+        url = self.url("api/v3/content/rpm/packages/upload/")
         with open(path, "rb") as fp:
             data = {"pulp_labels": json.dumps(labels)}
             files = {"file": fp}


### PR DESCRIPTION
Prior to this commit, a synchronous upload API was only available in pulp_service plugin. This API has now been released as part of pulp_rpm. This change will ensure COPR continues to be able to upload RPM packages when this API is removed from pulp_service plugin.

<!-- issue-commentator = {"comment-id":"3050716938"} -->