### PR TITLE
backend: drop the 'Z' suffix from timestamp

### DIFF
--- a/backend/run/copr-backend-generate-graphs
+++ b/backend/run/copr-backend-generate-graphs
@@ -33,7 +33,7 @@ def get_arg_parser():
 
 def stamp2js(stamp):
     """ JS works with miliseconds, and we know we work with UTC """
-    return dp.parse(stamp + "Z").timestamp()*1000
+    return dp.parse(stamp).timestamp()*1000
 
 
 def download_js_files():


### PR DESCRIPTION
ParserError: Unknown string format: 2024-10-08T03:07:02.693262+00:00Z

Fixes: #3743

<!-- issue-commentator = {"comment-id":"3056019208"} -->