### PR TITLE
backend: fix race condition in BatchedCreaterepo

### DIFF
--- a/backend/run/copr-repo
+++ b/backend/run/copr-repo
@@ -358,9 +358,6 @@ def main_locked(opts, batch, log):
     # possible we should move those two things before 'delete_builds' call.
     add_appdata(opts)
 
-    # while we still hold the lock, notify others we processed their task
-    batch.commit()
-
     log.info("%s run successful", sys.argv[0])
 
 
@@ -395,10 +392,13 @@ def main_try_lock(opts, batch):
                 "COPR_TESTSUITE_LOCKPATH", "/var/lock/copr-backend")
             with lock(opts.directory, lockdir=lockdir, timeout=5, log=opts.log):
                 main_locked(opts, batch, opts.log)
-                # skip commit if main_locked() raises exception
+
+                # While we still hold the lock, notify others we processed their
+                # task.  Note that we do not commit in case of random exceptions
+                # above.
                 batch.commit()
-                # Unless there's an exception, the bash.commit() is done and we are
-                # done.
+
+                # If no exception happened, we are done (break).
                 opts.log.debug("Metadata built by this process")
                 break
         except LockTimeout:


### PR DESCRIPTION
Previously we observed two race conditions.

For #3770, this used to happen:

1. process A adds the `task A` entry to DB
2. process B takes the `task A`, processes it, and commits() it
3. process C lists the task A (due to absence of fair locking!)
4. process A (without lock) detects the `task A` is committed by `process B`, and removes the task from DB to optimize waiting (see #1423 why we do this)
5. process C reads the `task A` content by hgetall(), but receives an empty dict.

Previously we continued, and failed the createrepo run:

6. process C tries to process task A, but fails with KeyError (if this happens, `task B` was already dropped from DB so nobody re-tried).

The problem of #3770 was that `task B` sometimes requested a build removal, but did not finish.  In such case, Frontend just blindly removes the build from it's own database (trusting backend to finish the removal), and never gives the user chance to remove the build again. Solution for #3770 is to ignore the empty `task A` in 6.

Also even weirder situation happened in #3777:

2. process B takes the `task A`, processes it, and commits() for the first time (and still exists)
3. process A (without lock) detects the task is committed, and removes itself from DB to speedup (see why we do this in #1423)
4. process B commits() the `task A` once more (double-commit()), but this key was never removed from DB.
5. since the `status=succeeded`, any other process later on ignores this entry as finished.

This situation isn't known to cause any damages though.  To fix this issue we simply never double-commit() now.  And we have to clean the (innocent) DB entries manually.

Folow-up-for: 7442ec4303f2e0ba2e31a6555c4da34b96de0ee1
Fixes: #3770
Fixes: #3777
Relates: #1423

<!-- issue-commentator = {"comment-id":"3062142515"} -->