### PR TITLE
frontend: Fix AI button visibility

### DIFF
--- a/frontend/coprs_frontend/coprs/filters.py
+++ b/frontend/coprs_frontend/coprs/filters.py
@@ -286,3 +286,10 @@ def being_server_admin(user, copr):
     Is Copr maintainer using their special permissions to edit the project?
     """
     return helpers.being_server_admin(user, copr)
+
+
+@app.template_filter("is_older_than_days")
+def is_older_than_days(timestamp, days):
+    """Check if a timestamp is older than the specified number of days"""
+    now = time.time()
+    return (now - timestamp) > (days * 24 * 3600)

--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -138,22 +138,25 @@
   {% endif %}
 {% endmacro %}
 
-{% macro log_detective_ai_link(failed_log_url, build_id, chroot_name) %}
+{% macro log_detective_ai_link(failed_log_url, build_id, chroot_name, ended_on) %}
   {% if config.LOG_DETECTIVE_BUTTON %}
-    {% if failed_log_url %}
-      {% set url = "https://log-detective.com/explain?url=%s" %}
-      <a href="{{ url | format(failed_log_url | urlencode) }}"
+    {# hide the buttons after 13 days (logs are deleted after 14 days) #}
+    {% if not (ended_on|is_older_than_days(13)) %}
+      {% if failed_log_url %}
+        {% set url = "https://log-detective.com/explain?url=%s" %}
+        <a href="{{ url | format(failed_log_url | urlencode) }}"
+          class="pficon pficon-info"
+          title="See what AI can tell you about the build failure">
+          Ask AI
+        </a> &nbsp / &nbsp
+      {% endif %}
+      {% set url = "https://log-detective.com/contribute/copr/%s/%s" %}
+      <a href="{{ url | format(build_id, chroot_name) }}"
         class="pficon pficon-info"
-        title="See what AI can tell you about the build failure">
-        Ask AI
-      </a> &nbsp / &nbsp
+        title="Help us build a new AI tool to analyze build logs for you. We are creating new RPM build specific AI model, but we need more data to feed it with. Please, report and describe current logs in the redirected page.">
+        Teach AI
+      </a>
     {% endif %}
-    {% set url = "https://log-detective.com/contribute/copr/%s/%s" %}
-    <a href="{{ url | format(build_id, chroot_name) }}"
-      class="pficon pficon-info"
-      title="Help us build a new AI tool to analyze build logs for you. We are creating new RPM build specific AI model, but we need more data to feed it with. Please, report and describe current logs in the redirected page.">
-      Teach AI
-    </a>
   {% endif %}
 {% endmacro %}
 

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/build.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/build.html
@@ -208,7 +208,7 @@
             {% set link_shown = namespace(value=False) %}
               {% for url in build.get_source_log_urls %}
                 {% if not link_shown.value %}
-                  &nbsp&nbsp {{ log_detective_ai_link(url, build.id, "srpm-builds") }}
+                  &nbsp&nbsp {{ log_detective_ai_link(url, build.id, "srpm-builds", build.ended_on) }}
                   {% set link_shown.value = true %}
                 {% endif %}
               {% endfor %}
@@ -248,6 +248,12 @@
         </dl>
 
         {% if build.build_chroots %}
+        {% set has_failed_chroots = namespace(value=false) %}
+        {% for chroot in build.build_chroots %}
+          {% if chroot.state == "failed" %}
+            {% set has_failed_chroots.value = true %}
+          {% endif %}
+        {% endfor %}
         <table class="table table-striped table-bordered">
           <thead>
             <tr>
@@ -256,7 +262,7 @@
               <th>Build Time</th>
               <th>Logs</th>
               <th>State</th>
-              {% if config.LOG_DETECTIVE_BUTTON and build.state == "failed" and build.source_state == "succeeded" %}
+              {% if config.LOG_DETECTIVE_BUTTON and has_failed_chroots.value and build.source_state == "succeeded" %}
               <th>Log Detective AI</th>
               {% endif %}
             </tr>
@@ -300,10 +306,10 @@
               <td>
                 {{ build_state_text(chroot.state, chroot.status_reason, chroot.rpm_live_log_url) }}
               </td>
-              {% if config.LOG_DETECTIVE_BUTTON and build.state == "failed" and build.source_state == "succeeded" %}
+              {% if config.LOG_DETECTIVE_BUTTON and has_failed_chroots.value %}
               <td>
                 {% if chroot.state == "failed" %}
-                  {{ log_detective_ai_link(chroot.rpm_live_log_url, build.id, chroot.name) }}
+                  {{ log_detective_ai_link(chroot.rpm_live_log_url, build.id, chroot.name, chroot.ended_on) }}
                 {% else %}
                   -
                 {% endif %}


### PR DESCRIPTION
Ask/Teach AI buttons should be visible only to existing logs, while displaying then immediately when chroot fails.

<img width="1186" height="271" alt="ai-btn" src="https://github.com/user-attachments/assets/3dbbc43f-3cd6-4936-9988-a71367490291" />

Fix #3707
Fix #3760

<!-- issue-commentator = {"comment-id":"3070448969"} -->