### PR TITLE
Set retain_package_versions and retain_repo_versions on repositories

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -98,7 +98,7 @@ class PulpClient:
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_create
         """
         url = self.url("api/v3/repositories/rpm/rpm/")
-        data = {"name": name}
+        data = {"name": name, "retain_repo_versions": 1, "retain_package_versions": 5}
         return requests.post(url, json=data, **self.request_params)
 
     def get_repository(self, name):


### PR DESCRIPTION
retain_repo_versions of 1 will ensure that older repository versions are cleaned up.

retain_repo_versions of 5 will ensure that the latest repository version has only the latest 5 versions of a package.