### PR TITLE
frontend: add symlink to alma family logo from almalinux

### DIFF
--- a/frontend/coprs_frontend/coprs/static/chroot_logodir/alma.png
+++ b/frontend/coprs_frontend/coprs/static/chroot_logodir/alma.png
@@ -1,0 +1,1 @@
+almalinux.png


### PR DESCRIPTION
Fixes this:

<img width="244" height="171" alt="alma" src="https://github.com/user-attachments/assets/0d536d4b-ed92-43a9-ba68-3436e749cbcc" />
