### PR TITLE
frontend: handle chroots not found in the build for build task yet

### DIFF
--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -175,7 +175,7 @@ def get_build_record(task, for_backend=False):
         "storage": task.build.copr.storage,
     })
 
-    copr_chroot = CoprChrootsLogic.get_by_name_or_none(task.build.copr, task.mock_chroot.name)
+    copr_chroot = ComplexLogic.get_copr_chroot(task.build.copr, task.mock_chroot.name)
 
     # When the chroot is temporarily disabled or EOL
     if not copr_chroot:


### PR DESCRIPTION
When backend gets the build task for a pending build, the get_by_name_or_none correctly returns None, since the chroot does not yet exists for the specific build yet, thus the get_build_task returns correctly None, since we can;t fill the data yet. However this should be somehow nicely given to the backend, instead of plain null -> traceback to backend with the state instead.

Fix #3735

<!-- issue-commentator = {"comment-id":"3095976295"} -->