### PR TITLE
Adds batching to add_content() and delete_content() in Pulp client.

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -690,7 +690,8 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         )
         if result:
             # Only PulpStorage returns package HREFs
-            self.storage.create_repository_version(self.job.chroot, result)
+            if not self.storage.create_repository_version(self.job.chroot, result):
+                raise BackendError("Pulp: Failed to create repository version.")
 
     def _check_build_success(self):
         """

--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -182,17 +182,9 @@ def main():
                 all_package_hrefs.extend(package_hrefs)
 
             # Add build results to the repository
-            result = storage.create_repository_version(chroot, all_package_hrefs)
-            if not result:
-                log.error("Failed to create a new repository version: %s", chroot)
-                ok = False
-                break
-
-            result = storage.publish_repository(chroot)
-            if not result:
-                log.error("Failed to publish a repository: %s", resultdir)
-                ok = False
-                break
+            if not storage.create_repository_version(chroot, all_package_hrefs):
+                log.error("Failed to create repository version: %s", chroot)
+                sys.exit(1)
 
             log.info("OK: %s", chroot)
 


### PR DESCRIPTION
The locking logic is borrowed from the implementation in the BackendStorage.

Each call to PulpClient.add_content() and PulpClient.delete_content() now works like this:

1. Writes the request to Redis.
2. Check if another process processed the request. Return if so.
2. Try to acquire a lock.
3. If lock is acquired a. Collect all requests to add and remove content and make one request to Pulp. b. Create a publication If lock is not acquire, go back to step 2.
4. Notify other processes that their request was processed.

The PulpStorage.publish_repository() is now a no-op.

The distribution is no longer updated after a publication is created. The distribution always points to the latest publication for a particular repository.

This reduces the number of new repository versions and publications that are created for large repositories.

<!-- issue-commentator = {"comment-id":"3119127562"} -->