### PR TITLE
backend: fix logging typo

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -151,7 +151,7 @@ class PulpClient:
             "repository": repository,
             "base_path": basepath or name,
         }
-        self.log.info("Pulp: create_distribution: %s %s %s", uri, data)
+        self.log.info("Pulp: create_distribution: %s %s", uri, data)
         return requests.post(self.url(uri), json=data, **self.request_params)
 
     def create_publication(self, repository):


### PR DESCRIPTION
    TypeError: not enough arguments for format string