### PR TITLE
Fix Pulp builds for CoprDirs

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -688,10 +688,21 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
             self.job.target_dir_name,
             build_id=self.job.build_id,
         )
-        if result:
-            # Only PulpStorage returns package HREFs
-            if not self.storage.create_repository_version(self.job.chroot, result):
-                raise BackendError("Pulp: Failed to create repository version.")
+
+        # Only PulpStorage returns package HREFs
+        if not result:
+            return
+
+        success = self.storage.create_repository_version(
+            self.job.project_dirname,
+            self.job.chroot,
+            result,
+        )
+        if not success:
+            raise BackendError(
+                "Pulp: Failed to create repository version for {0} and {1}"
+                .format(self.job.project_dirname, self.job.chroot)
+            )
 
     def _check_build_success(self):
         """

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -203,7 +203,7 @@ class PulpStorage(Storage):
 
         # When a repository is mentioned in other endpoints, it needs to be
         # mentioned by its href, not name
-        repository = self._get_repository(chroot)
+        repository = self._get_repository(chroot, dirname)
 
         distribution = self._distribution_name(chroot, dirname)
         response = self.client.create_distribution(distribution, repository)
@@ -271,11 +271,11 @@ class PulpStorage(Storage):
 
             return package_hrefs
 
-    def create_repository_version(self, chroot, package_hrefs):
+    def create_repository_version(self, dirname, chroot, package_hrefs):
         """
         Create a new repository version by adding a list of RPMs to the latest repository version.
         """
-        repository = self._get_repository(chroot)
+        repository = self._get_repository(chroot, dirname)
         return self.client.add_content(repository, package_hrefs)
 
     def publish_repository(self, chroot, **kwargs):
@@ -338,12 +338,12 @@ class PulpStorage(Storage):
             return "{0}-devel".format(repository)
         return repository
 
-    def _get_repository(self, chroot):
-        name = self._repository_name(chroot)
+    def _get_repository(self, chroot, dirname=None):
+        name = self._repository_name(chroot, dirname)
         response = self.client.get_repository(name)
         return response.json()["results"][0]["pulp_href"]
 
-    def _get_distribution(self, chroot):
-        name = self._distribution_name(chroot)
+    def _get_distribution(self, chroot, dirname=None):
+        name = self._distribution_name(chroot, dirname)
         response = self.client.get_distribution(name)
         return response.json()["results"][0]["pulp_href"]


### PR DESCRIPTION
I don't know when this stopped working, it was definitely broken before
PR #3807. The builds in CoprDirs was publishing the results into the main
repository instead of the CoprDir repository. This PR fixes that.

<!-- issue-commentator = {"comment-id":"3161257972"} -->