### PR TITLE
cleanup: remove gently_gpg_sha256 config option

### DIFF
--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -408,9 +408,6 @@ class BackendConfigReader(object):
 
         opts.prune_days = _get_conf(cp, "backend", "prune_days", None, mode="int")
 
-        opts.gently_gpg_sha256 = _get_conf(
-            cp, "backend", "gently_gpg_sha256", True, mode="bool")
-
         opts.aws_cloudfront_distribution = _get_conf(
             cp, "backend", "aws_cloudfront_distribution", None)
 

--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -97,6 +97,7 @@ def _sign_one(path, email, hashtype, log):
     return stdout, stderr
 
 
+# pylint: disable=unused-argument
 def gpg_hashtype_for_chroot(chroot, opts):
     """
     Given the chroot name (in "mock format", like "fedora-rawhide-x86_64")
@@ -109,18 +110,6 @@ def gpg_hashtype_for_chroot(chroot, opts):
     parts = chroot.split("-")
 
     version_part = parts[-2]
-
-    if opts.gently_gpg_sha256:
-        # For a few weeks we would use the sha256 hash type only for EL8+.
-        # This is a safety belt, in case of any failure we'll just re-sign
-        # epel-8+ and not _all_ the package data on backend.
-        if parts[0] in el_chroots:
-            el_version = version_part
-            if el_version in ["rawhide"]:
-                return "sha256"
-            if version.parse(el_version) > version.parse("7"):
-                return "sha256"
-        return "sha1"
 
     if parts[0] in el_chroots:
         chroot_version = version_part

--- a/backend/tests/test_background_worker_build.py
+++ b/backend/tests/test_background_worker_build.py
@@ -230,7 +230,6 @@ def f_build_rpm_sign_on(f_build_rpm_case):
     with open(config.be_config_file, "a+") as fdconfig:
         fdconfig.write("do_sign=true\n")
         fdconfig.write("keygen_host=keygen.example.com\n")
-        fdconfig.write("gently_gpg_sha256=false\n")
     config.bw = _reset_build_worker()
     return config
 

--- a/backend/tests/test_sign.py
+++ b/backend/tests/test_sign.py
@@ -31,7 +31,6 @@ class TestSign(object):
         self.tmp_dir_path = None
 
         self.opts = Munch(keygen_host="example.com")
-        self.opts.gently_gpg_sha256 = False
         self.opts.sign_domain = "fedorahosted.org"
 
     def teardown_method(self, method):
@@ -327,28 +326,6 @@ def test_chroot_gpg_hashes():
     ]
 
     opts = Munch()
-    opts.gently_gpg_sha256 = False
 
-    for chroot, exp_type in chroots:
-        assert (chroot, exp_type) == (chroot, gpg_hashtype_for_chroot(chroot, opts))
-
-    opts.gently_gpg_sha256 = True
-    chroots = [
-        ("fedora-26-x86_64", "sha1"),
-        ("fedora-27-s390x", "sha1"),
-        ("fedora-eln-x86_64", "sha1"),
-        ("fedora-rawhide-x86_64", "sha1"),
-        ("mageia-8-x86_64", "sha1"),
-        ("opensuse-tumbleweed-aarch64", "sha1"),
-        ("epel-7-ppc64", "sha1"),
-        ("centos-7.dev-aarch64", "sha1"),
-        ("epel-8-aarch64", "sha256"),
-        ("rhel-8.dev-ppc64le", "sha256"),
-        ("oraclelinux-9-s390x", "sha256"),
-        ("centos-stream-8-s390x", "sha256"),
-        ("centos-stream-9-s390x", "sha256"),
-        ("rhel-rawhide-s390x", "sha256"),
-        ("srpm-builds", "sha1"),
-    ]
     for chroot, exp_type in chroots:
         assert (chroot, exp_type) == (chroot, gpg_hashtype_for_chroot(chroot, opts))


### PR DESCRIPTION
This reverts db73448bda5e164e726f533a4c62f72675381c0d that is no longer needed

<!-- issue-commentator = {"comment-id":"3240851835"} -->