### PR TITLE
Stop using deprecated %py3_build/%py3_install macros 

### DIFF
--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -61,12 +61,16 @@ This package contains Copr services for Dist Git server.
 %setup -q
 
 
+%generate_buildrequires
+%pyproject_buildrequires
+
+
 %build
-%py3_build
+%pyproject_wheel
 
 
 %install
-%py3_install
+%pyproject_install
 
 install -d %{buildroot}%{_datadir}/copr/dist_git
 install -d %{buildroot}%{_sysconfdir}/copr
@@ -106,8 +110,8 @@ install -m0644 -D conf/copr-dist-git.sysusers.conf %{buildroot}%{_sysusersdir}/c
 
 %files
 %license LICENSE
-%python3_sitelib/copr_dist_git
-%python3_sitelib/copr_dist_git*egg-info
+%{python3_sitelib}/copr_dist_git
+%{python3_sitelib}/copr_dist_git-*.dist-info/
 
 %{_bindir}/*
 %dir %{_datadir}/copr

--- a/keygen/copr-keygen.spec
+++ b/keygen/copr-keygen.spec
@@ -20,7 +20,6 @@ BuildRequires: systemd
 
 BuildRequires: python3-devel
 BuildRequires: python3-copr-common >= %copr_common_version
-BuildRequires: python3-setuptools
 BuildRequires: python3-flask
 
 # doc
@@ -60,7 +59,6 @@ Summary:    Code documentation for copr-keygen component of Copr buildsystem
 Obsoletes:  copr-doc < 1.38
 
 BuildRequires: python3-devel
-BuildRequires: python3-setuptools
 BuildRequires: python3-requests
 BuildRequires: python3-flask
 BuildRequires: python3-sphinx
@@ -80,8 +78,12 @@ This package contains document for copr-keygen service.
 %setup -q
 
 
+%generate_buildrequires
+%pyproject_buildrequires
+
+
 %build
-%py3_build
+%pyproject_wheel
 
 # We currently have FTBFS errors for F37/Rawhide, related issues:
 # https://bugzilla.redhat.com/show_bug.cgi?id=2113156
@@ -92,7 +94,7 @@ make -C docs %{?_smp_mflags} html
 %endif
 
 %install
-%py3_install
+%pyproject_install
 find %{buildroot} -name '*.exe' -delete
 
 install -d %{buildroot}%{_sysconfdir}/copr-keygen

--- a/keygen/setup.py
+++ b/keygen/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-import shutil
 import sys
 
 requires = [
@@ -37,6 +36,3 @@ setup(
     include_package_data=True,
     zip_safe=False,
 )
-
-#TODO: fix dirty cleanup
-shutil.rmtree("src/copr_keygen.egg-info")


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"3240851848"} -->