### PR TITLE
backend, common: handle unsuccessful Pulp requests

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -2,7 +2,7 @@
 %global tests_version 5
 %global tests_tar test-data-copr-backend
 
-%global copr_common_version 0.25.1~~dev0
+%global copr_common_version 1.2.1
 
 Name:       copr-backend
 Version:    2.7

--- a/backend/copr_backend/frontend.py
+++ b/backend/copr_backend/frontend.py
@@ -66,7 +66,7 @@ class FrontendClient:
         # Repeat the request until it succeeds, or timeout is reached.
         # """
         url = "{}/{}/".format(self.frontend_url, url_path)
-        auth = self.frontend_auth if authenticate else None
+        auth = ("user", self.frontend_auth) if authenticate else None
         self.log.info("Sending %s request to frontend URL - %s",
                       method.upper(), url)
 

--- a/common/python-copr-common.spec
+++ b/common/python-copr-common.spec
@@ -1,7 +1,7 @@
 %global srcname copr-common
 
 Name:       python-copr-common
-Version:    1.2
+Version:    1.2.1
 Release:    1%{?dist}
 Summary:    Python code used by Copr
 

--- a/common/tests/test_request.py
+++ b/common/tests/test_request.py
@@ -15,7 +15,7 @@ class TestStringMethods(TestCase):
         }
         self.log = logging.getLogger("testlog")
 
-    @mock.patch("copr_common.request.post")
+    @mock.patch("copr_common.request.requests.request")
     def test_send_request_not_200(self, post_req):
         post_req.return_value.status_code = 501
         with self.assertRaises(RequestRetryError):
@@ -23,7 +23,7 @@ class TestStringMethods(TestCase):
             request._send_request(self.url, "post", self.data)
         self.assertTrue(post_req.called)
 
-    @mock.patch("copr_common.request.post")
+    @mock.patch("copr_common.request.requests.request")
     def test_send_request_post_error(self, post_req):
         post_req.side_effect = RequestException()
         with self.assertRaises(RequestRetryError):


### PR DESCRIPTION
Fix #3689

Reliance on copr-common and `SafeRequest` will complicate the effort to unify the `PulpClient` with other teams such as Konflux, but at this point there are already many differences, so I would rather focus on what's best for our use-case than a potential unification.

<!-- issue-commentator = {"comment-id":"3245312047"} -->