### PR TITLE
frontend: print architecture statistics on status page

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/status_overview.html
+++ b/frontend/coprs_frontend/coprs/templates/status_overview.html
@@ -40,7 +40,7 @@ This page is cached for <strong>{{ cache_seconds }} seconds</strong>.
   </td>
   <td>{{ full_count }}</td>
 </tr>
-{% for stattype in ["chroots", "projects", "background"] %}
+{% for stattype in ["chroots", "projects", "background", "architecture"] %}
 <tr id="owner_name_{{ owner_name }}_{{ stattype }}"
   data-parent="#owner_name_{{ owner_name }}"
   class="collapsed"
@@ -63,8 +63,8 @@ This page is cached for <strong>{{ cache_seconds }} seconds</strong>.
 </table>
 
 
-{% for stattype in ["projects", "chroots", "background"] %}
-<h2>Queue by {{ stattype }}</h2>
+{% for stattype in ["projects", "chroots", "background", "architecture"] %}
+<h2> Queue by {{ stattype.capitalize() }}</h2>
 <table class="table table-bordered table-hover">
 <thead>
   <th></th>

--- a/frontend/coprs_frontend/coprs/views/status_ns/status_general.py
+++ b/frontend/coprs_frontend/coprs/views/status_ns/status_general.py
@@ -50,21 +50,25 @@ def pending_all():
         "projects": Counter(),
         "chroots": Counter(),
         "background": Counter(),
+        "architecture": Counter(),
     })
 
     project_stats = Counter()
     background_stats = Counter()
     chroot_stats = Counter()
+    architecture_stats = Counter()
 
-    def _calc_task(owner_name, project_name, chroot_name, background):
+    def _calc_task(owner_name, project_name, chroot_name, architecture, background):
         owner_stats[owner_name] += 1
         owner = owner_substats[owner_name]
         owner["projects"][project_name] += 1
         owner["chroots"][chroot_name] += 1
         owner["background"][background] += 1
+        owner["architecture"][architecture] += 1
         project_stats[project_name] += 1
         chroot_stats[chroot_name] += 1
         background_stats[background] += 1
+        architecture_stats[architecture] += 1
 
 
     for task in rpm_tasks:
@@ -72,6 +76,7 @@ def pending_all():
             task.build.copr.owner.name,
             task.build.copr.full_name,
             task.mock_chroot.name,
+            task.mock_chroot.arch,
             task.build.is_background,
         )
 
@@ -81,6 +86,7 @@ def pending_all():
             task.copr.owner.name,
             task.copr.full_name,
             "srpm-builds",
+            "noarch",
             task.is_background,
         )
 
@@ -90,6 +96,7 @@ def pending_all():
         "projects": project_stats,
         "chroots": chroot_stats,
         "background": background_stats,
+        "architecture": architecture_stats,
     }
 
     return flask.render_template(


### PR DESCRIPTION
Right now, it seems s390x is very overloaded, but it's not fully obvious.  This patch should help with queue-problem understanding.

<!-- issue-commentator = {"comment-id":"3282789900"} -->