### PR TITLE
python: Use correctly PUT and DELETE HTTP methods as required by APIv3 docs

### DIFF
--- a/python/copr/v3/proxies/build.py
+++ b/python/copr/v3/proxies/build.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import os
 from . import BaseProxy
-from ..requests import FileRequest, munchify, POST
+from ..requests import FileRequest, munchify, DELETE, POST, PUT
 from ..exceptions import CoprValidationException
 from ..helpers import for_all_methods, bind_proxy
 
@@ -85,7 +85,7 @@ class BuildProxy(BaseProxy):
         """
         endpoint = "/build/cancel/{0}".format(build_id)
         response = self.request.send(
-            endpoint=endpoint, method=POST, auth=self.auth)
+            endpoint=endpoint, method=PUT, auth=self.auth)
         return munchify(response)
 
     def create_from_urls(self, ownername, projectname, urls, buildopts=None, project_dirname=None):
@@ -356,7 +356,7 @@ class BuildProxy(BaseProxy):
         """
         endpoint = "/build/delete/{0}".format(build_id)
         response = self.request.send(
-            endpoint=endpoint, method=POST, auth=self.auth)
+            endpoint=endpoint, method=DELETE, auth=self.auth)
         return munchify(response)
 
     def delete_list(self, build_ids):
@@ -370,5 +370,5 @@ class BuildProxy(BaseProxy):
         endpoint = "/build/delete/list"
         data = {"builds": build_ids}
         response = self.request.send(
-            endpoint=endpoint, data=data, method=POST, auth=self.auth)
+            endpoint=endpoint, data=data, method=DELETE, auth=self.auth)
         return munchify(response)

--- a/python/copr/v3/proxies/package.py
+++ b/python/copr/v3/proxies/package.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from . import BaseProxy
 from .build import BuildProxy
-from ..requests import munchify, POST
+from ..requests import munchify, DELETE, POST, PUT
 from ..helpers import for_all_methods, bind_proxy
 
 
@@ -141,7 +141,7 @@ class PackageProxy(BaseProxy):
             "package_name": packagename,
         }
         response = self.request.send(
-            endpoint=endpoint, data=data, method=POST, auth=self.auth)
+            endpoint=endpoint, data=data, method=PUT, auth=self.auth)
         return munchify(response)
 
     def build(self, ownername, projectname, packagename, buildopts=None, project_dirname=None):
@@ -181,5 +181,5 @@ class PackageProxy(BaseProxy):
             "package_name": packagename,
         }
         response = self.request.send(
-            endpoint=endpoint, data=data, method=POST, auth=self.auth)
+            endpoint=endpoint, data=data, method=DELETE, auth=self.auth)
         return munchify(response)

--- a/python/copr/v3/proxies/project.py
+++ b/python/copr/v3/proxies/project.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import warnings
 
 from . import BaseProxy
-from ..requests import munchify, POST, GET, PUT
+from ..requests import munchify, DELETE, POST, PUT
 from ..helpers import for_all_methods, bind_proxy
 
 
@@ -236,7 +236,7 @@ class ProjectProxy(BaseProxy):
 
         response = self.request.send(
             endpoint=endpoint,
-            method=POST,
+            method=PUT,
             params=params,
             data=data,
             auth=self.auth,
@@ -261,7 +261,7 @@ class ProjectProxy(BaseProxy):
         }
         response = self.request.send(
             endpoint=endpoint,
-            method=POST,
+            method=DELETE,
             params=params,
             data=data,
             auth=self.auth,

--- a/python/copr/v3/proxies/project_chroot.py
+++ b/python/copr/v3/proxies/project_chroot.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import os
 from . import BaseProxy
-from ..requests import FileRequest, munchify, POST
+from ..requests import FileRequest, munchify, PUT
 from ..helpers import for_all_methods, bind_proxy
 
 
@@ -110,7 +110,7 @@ class ProjectChrootProxy(BaseProxy):
         )
         response = request.send(
             endpoint=endpoint,
-            method=POST,
+            method=PUT,
             params=params,
             data=data,
             auth=self.auth,

--- a/python/copr/v3/requests.py
+++ b/python/copr/v3/requests.py
@@ -13,6 +13,7 @@ from .exceptions import CoprRequestException, CoprNoResultException, CoprTimeout
 GET = "GET"
 POST = "POST"
 PUT = "PUT"
+DELETE = "DELETE"
 
 
 class Request(object):


### PR DESCRIPTION
Originally various requests made in v3.proxies.* modules used just GET and POST HTTP methods. However, for some operations these are nowadays deprecated or even already removed based on the APIv3 documentation.

Use PUT and DELETE HTTP requests as required by APIv3 docs instead. Following methods in v3.proxies module have been updated:

      * Use DELETE HTTP method:
        * BuildProxy.delete: DELETE
        * BuildProxy.delete_list: DELETE
        * PackageProxy.delete: DELETE
        * ProjectProxy.delete: DELETE
    
      * Use PUT HTTP method:
        * BuildProxy.cancel: PUT
        * PackageProxy.reset: PUT
        * ProjectChrootProxy.edit: PUT
        * ProjectProxy.edit: PUT

Also define the `DELETE` HTTP method in the `v3.requests` module. 

Doc: https://copr.fedorainfracloud.org/api_3/docs/


Disclaimer: I haven't tested changes manually. In this case I hope there for CI to cover that nothing gets broken. I followed blindly just the APIv3 documentation in this case.

Relates to: #3883 #3884

<!-- issue-commentator = {"comment-id":"3285456252"} -->