### PR TITLE
common: send data only for POST and PUT requests

### DIFF
--- a/common/copr_common/request.py
+++ b/common/copr_common/request.py
@@ -78,7 +78,9 @@ class SafeRequest:
                 req_args["auth"] = self.auth
             req_args["headers"] = headers
             req_args["timeout"] = self.timeout / 5
-            req_args['data'] = data if files else json.dumps(data)
+            method = method.lower()
+            if method in ["post", "put"]:
+                req_args["data"] = data if files else json.dumps(data)
             response = requests.request(method, url, **req_args)
         except requests.RequestException as ex:
             raise RequestRetryError(


### PR DESCRIPTION
Otherwise the following tracebacks on distgit

    from copr_dist_git.helpers import download_file
    url = "https://download.copr-dev.fedorainfracloud.org/results/.../enum-1.1-1.src.rpm"
    download_file(url, "/tmp")

Sending data only for POST and PUT is what we have done before f40a284

<!-- issue-commentator = {"comment-id":"3285456103"} -->