### PR TITLE
frontend: use beginning of the build as reference for timestamp

### DIFF
--- a/frontend/coprs_frontend/coprs/filters.py
+++ b/frontend/coprs_frontend/coprs/filters.py
@@ -291,5 +291,9 @@ def being_server_admin(user, copr):
 @app.template_filter("is_older_than_days")
 def is_older_than_days(timestamp, days):
     """Check if a timestamp is older than the specified number of days"""
+    if timestamp is None:
+        # For builds with no timestamp, we don't know their age
+        # so we assume they are not older than the specified days
+        return False
     now = time.time()
     return (now - timestamp) > (days * 24 * 3600)

--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -138,10 +138,10 @@
   {% endif %}
 {% endmacro %}
 
-{% macro log_detective_ai_link(failed_log_url, build_id, chroot_name, ended_on) %}
+{% macro log_detective_ai_link(failed_log_url, build_id, chroot_name, timestamp) %}
   {% if config.LOG_DETECTIVE_BUTTON %}
     {# hide the buttons after 13 days (logs are deleted after 14 days) #}
-    {% if not (ended_on|is_older_than_days(13)) %}
+    {% if not (timestamp|is_older_than_days(13)) %}
       {% if failed_log_url %}
         {% set url = "https://log-detective.com/explain?url=%s" %}
         <a href="{{ url | format(failed_log_url | urlencode) }}"

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/build.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/build.html
@@ -208,7 +208,7 @@
             {% set link_shown = namespace(value=False) %}
               {% for url in build.get_source_log_urls %}
                 {% if not link_shown.value %}
-                  &nbsp&nbsp {{ log_detective_ai_link(url, build.id, "srpm-builds", build.ended_on) }}
+                  &nbsp&nbsp {{ log_detective_ai_link(url, build.id, "srpm-builds", build.submitted_on) }}
                   {% set link_shown.value = true %}
                 {% endif %}
               {% endfor %}
@@ -309,7 +309,7 @@
               {% if config.LOG_DETECTIVE_BUTTON and has_failed_chroots.value %}
               <td>
                 {% if chroot.state == "failed" %}
-                  {{ log_detective_ai_link(chroot.rpm_live_log_url, build.id, chroot.name, chroot.ended_on) }}
+                  {{ log_detective_ai_link(chroot.rpm_live_log_url, build.id, chroot.name, build.submitted_on) }}
                 {% else %}
                   -
                 {% endif %}


### PR DESCRIPTION
Using the beginning of the build instead of the end of (chroot-)build.

Fix #3847

<!-- issue-commentator = {"comment-id":"3292584786"} -->