### PR TITLE
Fix duplicate NEVRA error when migrating projects to Pulp

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -679,10 +679,10 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         this method could upload the results and remove the temporary files
         at the same time.
         """
+        rpms = self.storage.find_build_results(self.job.results_dir)
         result = self.storage.upload_build_results(
+            rpms,
             self.job.chroot,
-            self.job.results_dir,
-            self.job.target_dir_name,
             build_id=self.job.build_id,
         )
 
@@ -690,10 +690,11 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         if not result:
             return
 
+        hrefs = [x["pulp_href"] for x in result.values()]
         success = self.storage.create_repository_version(
             self.job.project_dirname,
             self.job.chroot,
-            result,
+            hrefs,
         )
         if not success:
             raise BackendError(

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -388,7 +388,8 @@ class PulpClient:
         if response.ok and data["state"] == "completed":
             self.log.info("Successfully modified Pulp repository content %s", repository)
         else:
-            self.log.info("Failed to modify Pulp repository content %s", repository)
+            self.log.error("Failed to modify Pulp repository content %s", repository)
+            self.log.error("Response %s: %s", response, response.json())
             return False
 
         # Make a request to create a new publication

--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -19,7 +19,6 @@ from copr_backend.exceptions import FrontendClientException
 STORAGES = ["backend", "pulp"]
 
 log = logging.getLogger(__name__)
-setup_script_logger(log, "/var/log/copr-backend/change-storage.log")
 
 
 def get_arg_parser():
@@ -106,6 +105,9 @@ def main():
     """
     # pylint: disable=too-many-locals
     # pylint: disable=too-many-statements
+    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-nested-blocks
+    setup_script_logger(log, "/var/log/copr-backend/change-storage.log")
     parser = get_arg_parser()
     args = parser.parse_args()
 
@@ -162,8 +164,7 @@ def main():
                 ok = False
                 break
 
-            all_package_hrefs = []
-
+            uploaded = {}
             for builddir_entry in os.scandir(chrootdir):
                 if not builddir_entry.is_dir():
                     continue
@@ -175,13 +176,40 @@ def main():
                     log.info("Skipping: %s", resultdir)
                     continue
 
-                build_id = str(int(builddir.split("-")[0]))
+                build_id = int(builddir.split("-")[0])
+
+                to_upload = []
+                rpms = storage.find_build_results(resultdir)
+                for rpm in rpms:
+                    # Was a package with this NEVRA already uploaded?
+                    # We cannot simply uploaded.get(rpm) because the keys are
+                    # full paths and we need to compare only basenames
+                    # uploaded_rpm = None
+                    basename = os.path.basename(rpm)
+                    if basename in uploaded:
+                        # If the already uploaded package comes from a newer
+                        # build we don't need to bother with uploading this
+                        # package
+                        if build_id < uploaded[basename]["build_id"]:
+                            continue
+                    to_upload.append(rpm)
 
                 # We cannot check return code here
-                package_hrefs = storage.upload_build_results(chroot, resultdir, None, max_workers=1, build_id=build_id)
-                all_package_hrefs.extend(package_hrefs)
+                results = storage.upload_build_results(
+                    to_upload,
+                    chroot,
+                    build_id=build_id,
+                )
+
+                # It is possible that we already uploaded a package with the
+                # same NEVRA. In such case we will replace it here, and the
+                # previously uploaded package won't get into the repository.
+                # That doesn't bother us because Pulp will garbage collect and
+                # remove it.
+                uploaded.update(results)
 
             # Add build results to the repository
+            all_package_hrefs = [x["pulp_href"] for x in uploaded.values()]
             if not storage.create_repository_version(subproject, chroot, all_package_hrefs):
                 log.error("Failed to create repository version for chroot: %s", chroot)
                 sys.exit(1)


### PR DESCRIPTION
While trying to migrate the `@copr/copr-pull-requests` project to Pulp, we
encountered the following error:

    Cannot create repository version. More than one rpm.package content with the
    duplicate values for name, epoch, version, release, arch, location_href.

This is a common Copr use-case, building a package with the same NEVRA but
different content again and again, so why the error started happening only now?

Everything works perfectly when submitting consequent builds with same NEVRA and
different content because createrepo happens after every build and therefore
Pulp knows it is supposed to remove the old package from the repository and add
the new one.

However, when migrating data using the `copr-change-storage` scrpit, we upload
all the RPM packages and then do createrepo only once for all of them. But when
we want to add multiple packages at the same time, Pulp doesn't know which of
them is the old one.

In this PR I am implementing a mechanism that prevents migrating duplicate
NEVRAs into a Pulp repository.

<!-- issue-commentator = {"comment-id":"3315199385"} -->