### PR TITLE
frontend, cli: Add wildcard support for 'Packit allowed forge projects'

### DIFF
--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -1028,6 +1028,8 @@ def create_and_modify_common_opts(parser):
         metavar="FORGE_PROJECT", action="append", help=(
             "Forge project that will be allowed to build in this project "
             "via Packit in format github.com/packit/ogr. "
+            "Supports wildcard patterns (e.g., github.com/theproject/* will allow "
+            "all repositories in the theproject organization). "
             "Can be specified multiple times."
     ))
 

--- a/frontend/coprs_frontend/coprs/logic/coprs_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/coprs_logic.py
@@ -1,3 +1,4 @@
+import fnmatch
 import locale
 import json
 import os
@@ -479,10 +480,22 @@ class CoprsLogic(object):
         """
         Raise InsufficientRightsException if given forge project can't build
         in given copr via Packit. Return None otherwise.
+        
+        Supports wildcard patterns for allowed forge projects:
+        - github.com/theproject/* would match all repositories in the theproject organization
+        - github.com/* would match all GitHub repositories
         """
-        if packit_forge_project and packit_forge_project not in copr.packit_forge_projects_allowed_list:
-            raise exceptions.InsufficientRightsException(
-                f"Forge project {packit_forge_project} can't build in this Copr via Packit.")
+
+        if not packit_forge_project:
+            return
+
+        for pattern in copr.packit_forge_projects_allowed_list:
+            if fnmatch.fnmatch(packit_forge_project, pattern):
+                return
+
+        raise exceptions.InsufficientRightsException(
+            f"Forge project {packit_forge_project} can't build in this Copr via Packit."
+        )
 
 
 class CoprPermissionsLogic(object):

--- a/frontend/coprs_frontend/coprs/templates/coprs/_coprs_forms.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/_coprs_forms.html
@@ -167,7 +167,7 @@ render_bootstrap_options %}
 
     {{ render_field(form.runtime_dependencies, rows=5, cols=50, placeholder='Optional - URL to additional yum repos, which can be used as runtime dependencies. Space separated. This should be baseurl from .repo file. E.g.: http://copr-be.cloud.fedoraproject.org/results/rhughes/f20-gnome-3-12/fedora-$releasever-$basearch/') }}
 
-    {{ render_field(form.packit_forge_projects_allowed, rows=5, cols=50, placeholder='Optional - forge projects, which can build in this project via Packit. Space separated. E.g.: github.com/packit/ogr', info='These projects will be allowed to build in this project via Packit.') }}
+    {{ render_field(form.packit_forge_projects_allowed, rows=5, cols=50, placeholder='Optional - forge projects, which can build in this project via Packit. Space separated. E.g.: github.com/packit/ogr github.com/theproject/*', info='These projects will be allowed to build in this project via Packit. Supports wildcard patterns (e.g., github.com/theproject/* will allow all repositories in the theproject organization).') }}
     </div>
   </div>
 

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/schema/schemas.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/schema/schemas.py
@@ -454,9 +454,11 @@ class _ProjectFields:
     packit_forge_projects_allowed: String = String(
         description=(
             "Whitespace separated list of forge projects that will be "
-            "allowed to build in the project via Packit"
+            "allowed to build in the project via Packit. "
+            "Supports wildcard patterns (e.g., github.com/theproject/* will allow "
+            "all repositories in the theproject organization)."
         ),
-        example="github.com/fedora-copr/copr github.com/another/project",
+        example="github.com/fedora-copr/copr github.com/another/project github.com/theproject/*",
     )
     follow_fedora_branching: Boolean = Boolean(
         description=(


### PR DESCRIPTION
Fix https://github.com/fedora-copr/copr/issues/3804

~~not yet tested in stg~~

deployed on stg, the UI seems to be correct. However there is probably no way how to test packit directly against stg instance :/ (but the tests I created passed, so it should behave as expected)

<!-- issue-commentator = {"comment-id":"3347577188"} -->