### PR TITLE
Handle permission errors

### DIFF
--- a/backend/run/copr_prune_results.py
+++ b/backend/run/copr_prune_results.py
@@ -321,10 +321,6 @@ def clean_copr(path, days=DEF_DAYS, verbose=True):
             # Handle Permission Denied error explicitly
             LOG.error("No permission to delete path %s", dir_path)
             continue
-        except Exception as exception:  # pylint: disable=broad-exception-caught
-            # Catch and log any other exception
-            LOG.error("Exception when deleting path %s, %s", dir_path, str(exception))
-            continue
 
         # also remove the associated log in the main dir
         build_id = os.path.basename(dir_path).split('-')[0]

--- a/backend/run/copr_prune_srpms.py
+++ b/backend/run/copr_prune_srpms.py
@@ -110,11 +110,6 @@ def prune(path, days, dry_run=False, stdout=False):
                     error_message = "No permission to delete path {}".format(subdir)
                     print_remove_error(error_message, stdout)
                     continue
-                except Exception as exception:  # pylint: disable=broad-exception-caught
-                    # Catch and log any other exception
-                    error_message = "Exception when deleting path {}, {}".format(subdir, str(exception))
-                    print_remove_error(error_message, stdout)
-                    continue
 
         # We don't create such files anymore but it doesn't hurt to check
         for srpm_log_file in files:


### PR DESCRIPTION
in this PR:
- created a new helper function for error messages
- added handling of permission errors
- continue with script execution if such errors occur 

fix for #3875 and #3874

<!-- issue-commentator = {"comment-id":"3387024948"} -->