### PR TITLE
Handle docs build errors and warnings

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
+import importlib
 import sys
 
 # If extensions (or modules to document with autodoc) are in another
@@ -98,10 +98,7 @@ pygments_style = 'sphinx'
 # Otherwise fail, the production documentation is pushed from local _build
 # directory, therefore if something doesn't look as expected, it will be broken
 # also in production
-try:
-    import sphinx_rtd_theme
-    html_theme = "sphinx_rtd_theme"
-except ImportError:
+if not importlib.util.find_spec("sphinx_rtd_theme"):
     print("Please install the readthedocs theme with:")
     print("dnf install python*-sphinx_rtd_theme")
     sys.exit(1)

--- a/python/copr/v3/__init__.py
+++ b/python/copr/v3/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from .helpers import config_from_file
+from .helpers import config_from_file, wait
 from .client import Client
 from .proxies import BaseProxy
 from .proxies.project import ProjectProxy
@@ -20,6 +20,7 @@ from .exceptions import (CoprException,
 
 __all__ = [
     "config_from_file",
+    "wait",
     "Client",
 
     "BaseProxy",

--- a/python/copr/v3/proxies/project.py
+++ b/python/copr/v3/proxies/project.py
@@ -301,12 +301,12 @@ class ProjectProxy(BaseProxy):
 
     def can_build_in(self, who, ownername, projectname):
         """
-        Return `True` a user can submit builds for a ownername/projectname
+        Return ``True`` a user can submit builds for a ownername/projectname
 
         :param str who: name of the user checking their permissions
         :param str ownername: owner of the project
         :param str projectname: name of the project
-        :return Bool: `True` or raise
+        :return Bool: ``True`` or raise
         """
         endpoint = ("/project/permissions/can_build_in/"
                     "{who}/{ownername}/{projectname}/")

--- a/python/copr/v3/proxies/project_chroot.py
+++ b/python/copr/v3/proxies/project_chroot.py
@@ -72,7 +72,7 @@ class ProjectChrootProxy(BaseProxy):
             Possible values are 'default', 'simple', 'nspawn'.
         :param list reset_fields: list of chroot attributes, that should be
             reseted to their respective defaults. Possible values are
-            `additional_packages`, `additional_modules`, `isolation`, etc. See
+            ``additional_packages``, ``additional_modules``, ``isolation``, etc. See
             the output of `ProjectProxy.get` for all the possible field names.
         :return: Munch
         """

--- a/python/docs/ClientV1.rst
+++ b/python/docs/ClientV1.rst
@@ -1,6 +1,7 @@
+:orphan:
+
 .. warning::
     Legacy client is obsolete, please use Client version 3 instead. :ref:`This document <migration>` describes the migration process.
-
 
 Legacy client
 =============

--- a/python/docs/ClientV2.rst
+++ b/python/docs/ClientV2.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. warning::
     Client version 2 is obsolete, please use Client version 3 instead.
 

--- a/python/docs/ClientV3.rst
+++ b/python/docs/ClientV3.rst
@@ -38,6 +38,7 @@ Quick overview
     client_v3/data_structures.rst
     client_v3/error_handling.rst
     client_v3/pagination.rst
+    client_v3/utilities.rst
     client_v3/working_with_proxies_directly.rst
 
 

--- a/python/docs/client_v3/migration.rst
+++ b/python/docs/client_v3/migration.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _migration:
 
 Migration
@@ -96,4 +98,3 @@ so they split into multiple smaller functions.
 | ``build_module(...)``               | ``module_proxy.build_from_url``,                            |
 |                                     | ``module_proxy.build_from_file``                            |
 +-------------------------------------+-------------------------------------------------------------+
-

--- a/python/docs/client_v3/package_source_types.rst
+++ b/python/docs/client_v3/package_source_types.rst
@@ -2,14 +2,14 @@ Package Source Type
 ===================
 
 Read more about source types in the
-`User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#build-source-types>`_.
+`User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#build-source-types>`__.
 
 
 SCM
 ---
 
 Parameters when ``source_type=scm`` is used.
-See `User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#scm>`_ for more information.
+See `User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#scm>`__ for more information.
 
 =====================  ==================== ===============
 Field                  Type                 Description
@@ -19,7 +19,7 @@ committish             str
 subdirectory           str
 spec                   str
 scm_type               str                  "git", "svn"
-source_build_method    str                  See `User documentation <https://docs.pagure.org/copr.copr/user_documentation.html#scm>`_ for more info
+source_build_method    str                  See `User documentation <https://docs.pagure.org/copr.copr/user_documentation.html#scm>`__ for more info
 =====================  ==================== ===============
 
 
@@ -27,7 +27,7 @@ Rubygems
 --------
 
 Parameters when ``source_type=rubygems`` is used.
-See `User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#rubygems>`_ for more information.
+See `User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#rubygems>`__ for more information.
 
 ==================  ==================== ===============
 Field               Type                 Description
@@ -40,7 +40,7 @@ PyPI
 ----
 
 Parameters when ``source_type=pypi`` is used.
-See `User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#pypi>`_ for more information.
+See `User Documentation <https://docs.pagure.org/copr.copr/user_documentation.html#pypi>`__ for more information.
 
 =====================  ==================== ===============
 Field                  Type                 Description
@@ -56,7 +56,7 @@ Custom
 ------
 
 Parameters when ``source_type=custom`` is used.
-See `User Documentation <https://docs.pagure.org/copr.copr/custom_source_method.html#custom-source-method>`_ for more information.
+See `User Documentation <https://docs.pagure.org/copr.copr/custom_source_method.html#custom-source-method>`__ for more information.
 
 =====================  ==================== ===============
 Field                  Type                 Description

--- a/python/docs/client_v3/proxies.rst
+++ b/python/docs/client_v3/proxies.rst
@@ -40,13 +40,6 @@ Package
    :members:
 
 
-Module
-------
-
-.. autoclass:: copr.v3.proxies.module.ModuleProxy
-   :members:
-
-
 Monitor
 -------
 

--- a/python/docs/client_v3/utilities.rst
+++ b/python/docs/client_v3/utilities.rst
@@ -1,0 +1,53 @@
+.. _utilities:
+
+Helper Functions
+================
+
+The copr.v3 module provides several utility functions that make working with builds and other operations more convenient.
+
+wait function
+-------------
+
+The ``wait`` function allows you to wait for builds to complete before continuing execution.
+
+.. autofunction:: copr.v3.wait
+
+Usage Example
+~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from copr.v3 import Client, wait
+
+    # Create a client
+    client = Client.create_from_config_file()
+
+    # Submit builds
+    build1 = client.build_proxy.create_from_file("@user", "project", "/path/to/file.src.rpm")
+    build2 = client.build_proxy.create_from_url("@user", "project", "http://example.com/package.src.rpm")
+
+    # Wait for both builds to finish
+    finished_builds = wait([build1, build2])
+
+    # Check the results
+    for build in finished_builds:
+        print(f"Build {build.id} finished with state: {build.state}")
+
+With Callback
+~~~~~~~~~~~~~
+
+You can provide a callback function to monitor progress:
+
+.. code-block:: python
+
+    from copr.v3 import Client, wait
+
+    def progress_callback(builds):
+        for build in builds:
+            print(f"Build {build.id}: {build.state}")
+
+    client = Client.create_from_config_file()
+    build = client.build_proxy.create_from_file("@user", "project", "/path/to/file.src.rpm")
+    
+    # Wait with progress updates every 30 seconds
+    wait(build, callback=progress_callback)

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -11,9 +11,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
-
-
+import importlib
+import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -27,7 +27,13 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.todo'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -100,11 +106,7 @@ pygments_style = 'sphinx'
 # Use readthedocs theme if it is installed
 # Ideally, we want to develop the documentation in the same theme
 # that will be used in the production
-try:
-    import sphinx_rtd_theme
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-except ImportError:
+if not importlib.util.find_spec("sphinx_rtd_theme"):
     print("Please install the readthedocs theme with:")
     print("dnf install python*-sphinx_rtd_theme")
 


### PR DESCRIPTION
fixes here:
- add double underscore in package_source_types.rst - handle WARNING: Duplicate explicit target name
- add double backticks in copr/v3/proxies project.py and project_chroot.py - handle WARNING: 'any' reference target not found
- add :orphan: to rst files that are not in any doctree - handle WARNING: document isn't included in any toctree
- add sphinx.ext.todo in sphinx conf - handle ERROR: Unknown directive type 'todo'

Fix for #3955

<!-- issue-commentator = {"comment-id":"3402100375"} -->