### PR TITLE
backend: don't create "spawner", "terminator" and "vmm" logs

### DIFF
--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -37,7 +37,7 @@ from . import constants
 DOMAIN = "fedorahosted.org"
 
 LOG_COMPONENTS = [
-    "spawner", "terminator", "vmm", "build_dispatcher", "action_dispatcher",
+    "build_dispatcher", "action_dispatcher",
     "backend", "actions", "worker", "modifyrepo", "pruner", "analyze-results",
 ]
 


### PR DESCRIPTION


<!-- issue-commentator = {"comment-id":"3414954670"} -->