### PR TITLE
frontend: preload fields for streamed responses

### DIFF
--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_builds.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_builds.py
@@ -64,7 +64,7 @@ def render_copr_build(build_id, copr):
 @req_with_copr
 @req_with_pagination
 def copr_builds(copr, page=1):
-
+    _preload = copr.group, copr.forked_from, copr.dirs
     flashes = flask.session.pop('_flashes', [])
     dirname = flask.request.args.get('dirname')
     builds_query = builds_logic.BuildsLogic.get_copr_builds_list(copr, dirname)

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_general.py
@@ -1000,6 +1000,7 @@ def copr_build_monitor(copr, detailed=False, page=1):
     The monitor page (overview of the build status in each chroot for all the
     packages built in given project).
     """
+    _preload = copr.group, copr.forked_from
     detailed = detailed == "detailed"
     pagination = builds_logic.BuildsMonitorLogic.get_monitor_data(
             copr, page=page)

--- a/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_packages.py
+++ b/frontend/coprs_frontend/coprs/views/coprs_ns/coprs_packages.py
@@ -33,6 +33,7 @@ from coprs.exceptions import (ActionInProgressException, ObjectNotFound, NoPacka
 @req_with_copr
 @req_with_pagination
 def copr_packages(copr, page=1):
+    _preload = copr.group, copr.forked_from
     flashes = flask.session.pop('_flashes', [])
 
     query_packages = PackagesLogic.get_all_ordered(copr.id)


### PR DESCRIPTION
Routes utilizing streamed responses appear to close the database session prematurely for reasons that are currently unclear to me (I haven't been able to reproduce this behavior in production, only on F42+ testing installations with otherwise almost empty databases).

The immediate workaround is to preload the necessary fields to prevent lazy loading attempts later in the request lifecycle, which would fail after the session is closed.

INFO:sqlalchemy.engine.Engine:ROLLBACK
Debugging middleware caught exception in streamed response at a point where response headers were already sent. Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/werkzeug/wsgi.py", line 256, in __next__
    return self._next()
           ~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/werkzeug/wrappers/response.py", line 32, in _iter_encoded
    for item in iterable:
                ^^^^^^^^
  File "/usr/lib/python3.14/site-packages/flask/helpers.py", line 132, in generator
    yield from gen
  File "/usr/lib/python3.14/site-packages/jinja2/environment.py", line 1667, in __next__
    return self._next()  # type: ignore
           ~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/jinja2/environment.py", line 1644, in _buffered_generator
    c = next(self._gen)
  File "/usr/lib/python3.14/site-packages/jinja2/environment.py", line 1348, in generate
    yield self.environment.handle_exception()
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/jinja2/environment.py", line 942, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/usr/share/copr/coprs_frontend/coprs/templates/coprs/detail/monitor/simple.html", line 7, in top-level template code
    {% set selected_monitor_tab = "simple" %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/copr/coprs_frontend/coprs/templates/coprs/detail/monitor.html", line 20, in top-level template code
    {{ tab_title }}
  File "/usr/share/copr/coprs_frontend/coprs/templates/coprs/detail.html", line 2, in top-level template code
    {% from "_helpers.html" import copr_title, copr_url, render_crumb, copr_name, render_project_voting %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/copr/coprs_frontend/coprs/templates/layout.html", line 6, in top-level template code
    <title>{% block title %}Coprs Build System{% endblock %}</title>
    ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/copr/coprs_frontend/coprs/templates/coprs/detail/monitor.html", line 4, in block 'title'
    {% block title %}Monitor {{ copr_name(copr) }}{% endblock %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/jinja2/runtime.py", line 784, in _invoke
    rv = self._func(*arguments)
  File "/usr/share/copr/coprs_frontend/coprs/templates/_helpers.html", line 272, in template
    {{ copr.full_name }}
  File "/usr/lib/python3.14/site-packages/jinja2/environment.py", line 490, in getattr
    return getattr(obj, attribute)
  File "/usr/share/copr/coprs_frontend/coprs/models.py", line 657, in full_name
    return "{}/{}".format(self.owner_name, self.name)
                          ^^^^^^^^^^^^^^^
  File "/usr/share/copr/coprs_frontend/coprs/models.py", line 495, in owner_name
    return self.group.at_name if self.is_a_group_project else self.user.name
                                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/share/copr/coprs_frontend/coprs/models.py", line 481, in is_a_group_project
    return self.group is not None
           ^^^^^^^^^^
  File "/usr/lib64/python3.14/site-packages/sqlalchemy/orm/attributes.py", line 569, in __get__
    return self.impl.get(state, dict_)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/site-packages/sqlalchemy/orm/attributes.py", line 1096, in get
    value = self._fire_loader_callables(state, key, passive)
  File "/usr/lib64/python3.14/site-packages/sqlalchemy/orm/attributes.py", line 1131, in _fire_loader_callables
    return self.callable_(state, passive)
           ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/site-packages/sqlalchemy/orm/strategies.py", line 922, in _load_for_state
    raise orm_exc.DetachedInstanceError(
    ^
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <Copr at 0x7f07aab42710> is not bound to a Session; lazy load operation of attribute 'group' cannot proceed (Background on this error at: https://sqlalche.me/e/20/bhk3)

<!-- issue-commentator = {"comment-id":"3478160653"} -->