### PR TITLE
backend: set longer timeout for Pulp file uploads

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -253,7 +253,7 @@ class PulpClient:
             relative += "/"
         return self.config["base_url"] + relative
 
-    def send(self, method, url, data=None, files=None, headers=None):
+    def send(self, method, url, data=None, files=None, headers=None, timeout=None):
         """
         Performs a "safe request", meaning that if a request fails, we wait
         and try again, and again, until it succeeds.
@@ -262,7 +262,7 @@ class PulpClient:
         request = SafeRequest(
             log=self.log,
             try_indefinitely=True,
-            timeout=self.timeout,
+            timeout=timeout or self.timeout,
         )
         if all(self.cert):
             request.cert = self.cert
@@ -385,7 +385,7 @@ class PulpClient:
         self.log.info("Pulp: get_publicatoin: %s", uri)
         return self.send("GET", uri)
 
-    def create_content(self, path, labels):
+    def create_content(self, path, labels, timeout=3600):
         """
         Create content for a given artifact
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Content:-Packages/operation/content_rpm_packages_create
@@ -395,7 +395,7 @@ class PulpClient:
             data = {"pulp_labels": json.dumps(labels)}
             files = {"file": fp}
             self.log.info("Pulp: create_content: %s %s", uri, path)
-            package = self.send("POST", uri, data=data, files=files)
+            package = self.send("POST", uri, data=data, files=files, timeout=timeout)
         return package
 
     def create_content_chunked(self, path, labels):


### PR DESCRIPTION
The Pulp team says that the timeout on their side is set to 30 minutes but I am intentionally using larger value, because I'd rather be cut off by them instead of timeouting prematurely.

This timeout should be enough to upload 4G files. Tested on `dotnet10.0-10.0.100~rc.1.25451.107-0.7.fc42~bootstrap.src.rpm`
It was the largest one I could find.

<!-- issue-commentator = {"comment-id":"3521911014"} -->