### PR TITLE
Set user agent for Pulp requests to crc-pulp-client

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -263,6 +263,7 @@ class PulpClient:
             log=self.log,
             try_indefinitely=True,
             timeout=timeout or self.timeout,
+            user_agent="crc-pulp-client",
         )
         if all(self.cert):
             request.cert = self.cert

--- a/common/copr_common/request.py
+++ b/common/copr_common/request.py
@@ -19,21 +19,21 @@ class SafeRequest:
     # Prolong the sleep time before asking frontend again
     SLEEP_INCREMENT_TIME = 5
 
-    # Use package name and version for the user agent
-    package_name = 'copr-common'
-    user_agent = {
-        'name': package_name,
-        'version': package_version(package_name),
-    }
-
     def __init__(self, auth=None, cert=None, log=None,
-                 try_indefinitely=False, timeout=2 * 60):
+                 try_indefinitely=False, timeout=2 * 60, user_agent=None):
         # pylint: disable=too-many-positional-arguments
         self.auth = auth
         self.cert = cert
         self.log = log
         self.try_indefinitely = try_indefinitely
         self.timeout = timeout
+
+        # Use package name and version for the user agent
+        self.package_name = 'copr-common'
+        self.user_agent = user_agent or "{name}/{version}".format(
+            name=self.package_name,
+            version=package_version(self.package_name),
+        )
 
     def get(self, url, **kwargs):
         """
@@ -64,7 +64,7 @@ class SafeRequest:
         files = kwargs.get("files", None)
 
         headers = kwargs.get("headers", None) or {}
-        headers["User-Agent"] = "{name}/{version}".format(**SafeRequest.user_agent)
+        headers["User-Agent"] = self.user_agent
         if not files:
             headers["content-type"] = "application/json"
 


### PR DESCRIPTION
Fix #4010

This was recommended to us by the Pulp team. This user agent is required by prodsec for some reason. By setting this, we will prevent errors like:

    [2025-11-18 15:05:44,051][ ERROR][PID:2858721] Failed to create Pulp content for: /var/lib/copr/public_html/results/xsnrg/indi-3rdparty-bleeding/fedora-42-x86_64/09807248-libsvbony/libsvbony-2.1.3.git-20251118150333.fc42.x86_64.rpm, Forbidden <HTML><HEAD>
    <TITLE>Access Denied</TITLE>
    </HEAD><BODY>
    <H1>Access Denied</H1>

    You don't have permission to access "http&#58;&#47;&#47;mtls&#46;internal&#46;console&#46;redhat&#46;com&#47;api&#47;pulp&#47;public&#45;copr&#47;api&#47;v3&#47;content&#47;rpm&#47;packages&#47;upload&#47;" on this server.<P>
    Reference&#32;&#35;18&#46;c868dc17&#46;1763478343&#46;15486b16
    <P>https&#58;&#47;&#47;errors&#46;edgesuite&#46;net&#47;18&#46;c868dc17&#46;1763478343&#46;15486b16</P>
    </BODY>
    </HTML>
     (attempt #32)
    [2025-11-18 15:05:44,351][  INFO][PID:2858721] Pulp: create_content: /api/v3/content/rpm/packages/upload/ /var/lib/copr/public_html/results/xsnrg/indi-3rdparty-bleeding/fedora-42-x86_64/09807248-libsvbony/libsvbony-2.1.3.git-20251118150333.fc42.x86_64.rpm

<!-- issue-commentator = {"comment-id":"3550111351"} -->