### PR TITLE
frontend: don't traceback for when copr.storage is None

### DIFF
--- a/frontend/coprs_frontend/alembic/versions/091ed798e555_set_storage_value_for_projects_that_.py
+++ b/frontend/coprs_frontend/alembic/versions/091ed798e555_set_storage_value_for_projects_that_.py
@@ -1,0 +1,28 @@
+"""
+Set storage value for projects that predate Pulp
+
+Revision ID: 091ed798e555
+Create Date: 2025-12-02 21:18:12.747970
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '091ed798e555'
+down_revision = 'bb52d9f878f5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    session = sa.orm.sessionmaker(bind=op.get_bind())()
+    sql = "UPDATE copr SET storage=0 WHERE storage IS NULL"
+    session.execute(sa.text(sql))
+
+
+def downgrade():
+    """
+    There is no way back
+    """


### PR DESCRIPTION
    Request: GET http://frontend:5000/api_3/project?ownername=jfilak&projectname=abrt
    User: None
    Traceback (most recent call last):
      File "/usr/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
        rv = self.dispatch_request()
      File "/usr/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
        return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
      File "/usr/lib/python3.14/site-packages/flask_restx/api.py", line 402, in wrapper
        resp = resource(*args, **kwargs)
      File "/usr/lib/python3.14/site-packages/flask/views.py", line 110, in view
        return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
      File "/usr/lib/python3.14/site-packages/flask_restx/resource.py", line 41, in dispatch_request
        resp = meth(*args, **kwargs)
      File "/opt/copr/frontend/coprs_frontend/coprs/views/apiv3_ns/__init__.py", line 364, in convert_query_parameters_of_endpoint_method
        return endpoint_method(self, *args, **kwargs)
      File "/usr/lib/python3.14/site-packages/flask_restx/marshalling.py", line 244, in wrapper
        resp = f(*args, **kwargs)
      File "/opt/copr/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_projects.py", line 138, in get
        return to_dict(copr)
      File "/opt/copr/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_projects.py", line 84, in to_dict
        "storage": StorageEnum(copr.storage),
                   ~~~~~~~~~~~^^^^^^^^^^^^^^
      File "/opt/copr/common/copr_common/enums.py", line 18, in __call__
        return cls._wrap(attr)
               ~~~~~~~~~^^^^^^
      File "/opt/copr/common/copr_common/enums.py", line 10, in _wrap
        raise NotImplementedError

<!-- issue-commentator = {"comment-id":"3591742432"} -->