### PR TITLE
frontend: don't use future=True for sqlalchemy's create_engine

### DIFF
--- a/frontend/coprs_frontend/coprs/__init__.py
+++ b/frontend/coprs_frontend/coprs/__init__.py
@@ -41,8 +41,7 @@ app.config["SESSION_REDIS"] = StrictRedis(
 
 session = Session(app)
 
-# Set `future=True` to ensure compatibility between SQLAlchemy 1.x and 2.0
-db = SQLAlchemy(app, engine_options={"future": True})
+db = SQLAlchemy(app)
 
 @contextmanager
 def db_session_scope():


### PR DESCRIPTION
It was related to transition from v1->v2, now we are on v3: https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.future

<!-- issue-commentator = {"comment-id":"3642415864"} -->