### PR TITLE
cli: colorize build statuses

### DIFF
--- a/cli/copr-cli.spec
+++ b/cli/copr-cli.spec
@@ -26,6 +26,8 @@ Requires:      python3-copr >= %min_python_copr_version
 Requires:      python3-jinja2
 Requires:      python3-humanize
 Requires:      python3-koji
+Requires:      python3-typing-extensions
+Requires:      python3-rich
 
 Recommends:    python3-progress
 Recommends:    python3-ConfigUpdater
@@ -39,6 +41,13 @@ BuildRequires: python3-pytest
 BuildRequires: python3-responses
 BuildRequires: python3-setuptools
 BuildRequires: python3-munch
+BuildRequires: python3-typing-extensions
+BuildRequires: python3-rich
+
+%if 0%{?rhel} && 0%{?rhel} <= 8
+Requires:      python3-dataclasses
+BuildRequires: python3-dataclasses
+%endif
 
 # We historically shipped empty doc package, uninstall it.
 Obsoletes:     copr-cli-doc < 1.72

--- a/cli/copr_cli/helpers.py
+++ b/cli/copr_cli/helpers.py
@@ -33,3 +33,23 @@ def print_project_info(project):
         additional_repos_str = " ".join(project.additional_repos)
         print("  Additional repo: {0}".format(additional_repos_str))
     print("")
+
+
+def colorize_status(status):
+    """
+    Return colorized status in the Rich Markup
+    https://rich.readthedocs.io/en/latest/markup.html
+    """
+    color = {
+        "importing": "blue",
+        "pending": "blue",
+        "starting": "yellow",
+        "running": "yellow",
+        "forked": "green",
+        "skipped": "green",
+        "failed": "red",
+        "succeeded": "green",
+        "canceled": "default",
+        "waiting": "default",
+    }.get(status, "default")
+    return "[{0}]{1}[/{0}]".format(color, status)


### PR DESCRIPTION
The `python-rich` package is available for EPEL9+ so for EPEL8 we would need to do some workaround.

<!-- issue-commentator = {"comment-id":"3649616560"} -->