### PR TITLE
backend: info about the task that is being processed

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -396,6 +396,7 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
                                                    self.args.chroot)
 
         try:
+            self.log.info("Getting Task info from frontend: %s", target)
             resp = self.frontend_client.get(target)
         except FrontendClientException as ex:
             self.log.error("Failed to download build info: %s", str(ex))


### PR DESCRIPTION
It was arguably hard to see where the problem is in #4034.

<!-- issue-commentator = {"comment-id":"3655205822"} -->