### PR TITLE
Improve timestamp printing in the frontend

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -398,7 +398,7 @@
           </p>
           <p class="list-group-item-text">
             <small>Finished:</small>
-            {{build.max_ended_on|time_ago()}} ago
+            <span title="{{build.max_ended_on | localized_time(g.user.timezone if g.user else 'UTC')}}">{{build.max_ended_on|time_ago()}} ago</span>
           </p>
         </a>
       {% endfor %}
@@ -764,7 +764,7 @@
         {% for task_type, time, task in tasks %}
           {% set build_chroot = task if type == 'importing' or task_type == 'srpm' else task.build %}
           <tr>
-            <td data-order="{{ time }}">{{ time | time_ago }}</td>
+            <td data-order="{{ time }}" title="{{time | localized_time(g.user.timezone if g.user else 'UTC')}}">{{ time | time_ago }}</td>
             <td data-order="{{ copr_name(build_chroot.copr) }}">
               <a href="{{ copr_details_href(build_chroot.copr) }}">
                 {{ copr_name(build_chroot.copr) }}

--- a/frontend/coprs_frontend/coprs/templates/admin/legal-flag.html
+++ b/frontend/coprs_frontend/coprs/templates/admin/legal-flag.html
@@ -20,7 +20,7 @@
       {% endif %}
 
       <small>
-        Submitted <b>{{ flag.raised_on | time_ago() }} ago </b> by <a href="{{ url_for('coprs_ns.coprs_by_user', username=flag.reporter.name) }}"> {{ flag.reporter.name }}</a>.
+        Submitted <b title="{{flag.raised_on | localized_time(g.user.timezone if g.user else 'UTC')}}">{{ flag.raised_on | time_ago() }} ago </b> by <a href="{{ url_for('coprs_ns.coprs_by_user', username=flag.reporter.name) }}"> {{ flag.reporter.name }}</a>.
       </small>
     </h3>
     <p>

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/_builds_table.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/_builds_table.html
@@ -61,7 +61,7 @@
               {% endif %}
           </td>
           {% endif %}
-          <td data-order="{{build.submitted_on}}"> {{ build.submitted_on|time_ago() }} ago </td>
+          <td data-order="{{build.submitted_on}}" title="{{build.submitted_on | localized_time(g.user.timezone if g.user else 'UTC')}}"> {{ build.submitted_on|time_ago() }} ago </td>
           <td data-order="{{build.started_on|timestamp_diff(build.ended_on)}}"> {{ build.started_on|time_ago(build.ended_on) }} </td>
           <td>
             {{ build_state(build) }}

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/_package_table.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/_package_table.html
@@ -42,7 +42,7 @@
             {% endif %}
         </td>
         {% endif %}
-        <td data-order="{{build.submitted_on}}"> {{ build.submitted_on|time_ago() }} ago </td>
+        <td data-order="{{build.submitted_on}}" title="{{build.submitted_on | localized_time(g.user.timezone if g.user else 'UTC')}}"> {{ build.submitted_on|time_ago() }} ago </td>
         <td data-order="{{build.started_on|timestamp_diff(build.ended_on)}}"> {{ build.started_on|time_ago(build.ended_on) }} </td>
         <td>
           {{ build_state(build) }}

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/_packages_table.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/_packages_table.html
@@ -38,7 +38,7 @@
 
         <td data-order="{{ submitted_on or 0 }}">
           {% if submitted_on %}
-            {{ submitted_on | time_ago() }} ago
+            <span title="{{submitted_on | localized_time(g.user.timezone if g.user else 'UTC')}}">{{ submitted_on | time_ago() }} ago</span>
           {% else %}
             -
           {% endif %}

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/overview.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/overview.html
@@ -179,7 +179,7 @@
           </p>
           <p class="list-group-item-text">
             <small> Finished: </small>
-            {{latest_build.max_ended_on|time_ago()}} ago
+            <span title="{{latest_build.max_ended_on | localized_time(g.user.timezone if g.user else 'UTC')}}">{{latest_build.max_ended_on|time_ago()}} ago</span>
           </p>
         </a>
       </div>

--- a/frontend/coprs_frontend/coprs/templates/recent/all.html
+++ b/frontend/coprs_frontend/coprs/templates/recent/all.html
@@ -36,7 +36,7 @@
         <td>
           {{ build.pkg_version}}
         </td>
-        <td>
+        <td title="{{build.max_ended_on | localized_time(g.user.timezone if g.user else 'UTC')}}">
           {{ build.max_ended_on|time_ago() }} ago
         </td>
         {% if build.canceled %}

--- a/frontend/coprs_frontend/coprs/templates/recent/my.html
+++ b/frontend/coprs_frontend/coprs/templates/recent/my.html
@@ -36,7 +36,7 @@
       <td>
         {{ build.pkg_version}}
       </td>
-      <td>
+      <td title="{{build.max_ended_on | localized_time(g.user.timezone if g.user else 'UTC')}}">
         {{ build.max_ended_on|time_ago() }} ago
       </td>
       {% if build.canceled %}


### PR DESCRIPTION
Wherever a relative time is shown (for example, "4 days ago"), add a `title` attribute containing the absolute time in the user's current time zone (or UTC for anonymous users). Browsers will display that title value as a native tooltip on hover.

Recently I needed to check the submission times for all project builds and discovered I had to open each build to see the time, since only relative times were displayed. This change should simplify the task.

<!-- issue-commentator = {"comment-id":"3660014718"} -->