### PR TITLE
frontend: fix packit_forge_projects_allowed to return list in API

### DIFF
--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/schema/schemas.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/schema/schemas.py
@@ -451,14 +451,15 @@ class _ProjectFields:
     appstream: Boolean = Boolean(
         description="Enable Appstream for this project",
     )
-    packit_forge_projects_allowed: String = String(
+    packit_forge_projects_allowed: List = List(
+        String,
         description=(
-            "Whitespace separated list of forge projects that will be "
+            "List of forge projects that will be "
             "allowed to build in the project via Packit. "
             "Supports wildcard patterns (e.g., github.com/theproject/* will allow "
             "all repositories in the theproject organization)."
         ),
-        example="github.com/fedora-copr/copr github.com/another/project github.com/theproject/*",
+        example=["github.com/fedora-copr/copr", "github.com/another/project", "github.com/theproject/*"],
     )
     follow_fedora_branching: Boolean = Boolean(
         description=(

--- a/frontend/coprs_frontend/tests/test_apiv3/test_projects.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_projects.py
@@ -31,6 +31,23 @@ class TestApiv3Projects(CoprsTestCase):
         assert [p["id"] for p in projects3] == [3, 1, 2]
         assert projects3 == list(reversed(projects2))
 
+    def test_get_project_packit_forge_projects_allowed(self, f_users, f_coprs,
+                                                        f_mock_chroots, f_db):
+        """
+        Test that packit_forge_projects_allowed is returned as a list in API response
+        """
+        # c3 (barcopr) has packit_forge_projects_allowed set in fixtures
+        url = "/api_3/project?ownername=user2&projectname=barcopr"
+        response = self.tc.get(url)
+        assert response.status_code == 200
+        data = response.json
+
+        assert isinstance(data["packit_forge_projects_allowed"], list)
+        assert data["packit_forge_projects_allowed"] == [
+            "github.com/packit/ogr",
+            "github.com/packit/requre"
+        ]
+
     @TransactionDecorator("u1")
     @pytest.mark.usefixtures("f_users", "f_users_api", "f_mock_chroots", "f_db")
     @pytest.mark.parametrize("store, read", [(True, "on"), (False, "off")])


### PR DESCRIPTION
Schema incorrectly defined field as String instead of List(String), causing Flask-RESTX to stringify the list in API responses. Context: https://github.com/packit/packit-service/pull/2907#discussion_r2626457707

Assisted-by: Cursor(Claude)

<!-- issue-commentator = {"comment-id":"3670060753"} -->