### PR TITLE
Allow resubmits for builds that fails during SRPM imports

### DIFF
--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -1393,7 +1393,13 @@ class Build(db.Model, helpers.Serializer):
 
         Build is repeatable only if sources has been imported.
         """
-        return self.source_status == StatusEnum("succeeded")
+        if self.source_status == StatusEnum("succeeded"):
+            return True
+        if (self.source_status == StatusEnum("failed") and
+                self.fail_type == FailTypeEnum("srpm_import_failed") and
+                not self.source_is_uploaded):
+            return True
+        return False
 
     @property
     def finished_early(self):

--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -1,5 +1,5 @@
 import flask
-from copr_common.enums import StatusEnum, ActionTypeEnum, StorageEnum
+from copr_common.enums import StatusEnum, ActionTypeEnum, StorageEnum, FailTypeEnum
 from coprs import db, app
 from coprs import models
 from coprs.logic import actions_logic
@@ -109,6 +109,8 @@ def dist_git_upload_completed():
 
     if final_source_status == StatusEnum("succeeded"):
         build.backend_enqueue_buildchroots()
+    else:
+        build.fail_type = FailTypeEnum("srpm_import_failed")
 
     build.source_status = final_source_status
     db.session.add(build)


### PR DESCRIPTION
Fixes #2844 

Make builds repeatable when SRPM build is successful but failed to import to dist-git.

<!-- issue-commentator = {"comment-id":"3694140009"} -->