### PR TITLE
backend: temporarily retain all repository packages

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -289,7 +289,9 @@ class PulpClient:
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_create
         """
         uri = "/api/v3/repositories/rpm/rpm/"
-        data = {"name": name, "retain_repo_versions": 1, "retain_package_versions": 5}
+        data = {"name": name, "retain_repo_versions": 1,
+                # Temporarily retain all packages, workaround for #4071
+                "retain_package_versions": 0}
         self.log.info("Pulp: create_repository: %s %s", uri, name)
         return self.send("POST", uri, data)
 


### PR DESCRIPTION
This is a temporary workaround for #4071.

<!-- issue-commentator = {"comment-id":"3715096943"} -->