### PR TITLE
beaker, cli, python: bypass anubis challenge by setting copr user agent

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/helpers
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/helpers
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+COPR_USER_AGENT="copr test/1.0"
+
+copr_curl()
+{
+    # Set User-Agent for Copr test tools - allows Anubis bot protection to identify us
+    # use only when really needed
+    curl -A "$COPR_USER_AGENT" "$@"
+}
+
 HELLO=https://github.com/fedora-copr/copr-test-sources/raw/main/hello-2.8-1.src.rpm
 EVIL_HELLO=https://github.com/fedora-copr/copr-test-sources/raw/main/evilhello-2.8-2.src.rpm
 SRPM_BUILDTAG=https://github.com/fedora-copr/copr-test-sources/raw/main/buildtag-0-0.src.rpm

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-webui.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-webui.sh
@@ -27,7 +27,7 @@ source "$HERE/helpers"
 
 curl()
 {
-    /usr/bin/curl -o /dev/null -s -f $1
+    /usr/bin/curl -A "$COPR_USER_AGENT" -o /dev/null -s -f "$@"
 }
 
 
@@ -57,7 +57,7 @@ rlJournalStart
         # the status code, nothing else. Also, some of the routes are hidden
         # behind an authentication, so we test the routes very superficially.
         # However, if some of them fails, there is likely a bug.
-        rlRun "curl $FRONTEND_URL"
+        rlRun "curl $FRONTEND_URL/coprs/"
         rlRun "curl $FRONTEND_URL/coprs/$owner_part/$PROJECTNAME"
         rlRun "curl $FRONTEND_URL/coprs/$owner_part/$PROJECTNAME/packages"
         rlRun "curl $FRONTEND_URL/coprs/$owner_part/$PROJECTNAME/builds"

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
@@ -315,9 +315,9 @@ rlJournalStart
 
         # test unlisted_on_hp project attribute
         rlRun "copr-cli create --unlisted-on-hp on --chroot $CHROOT ${NAME_PREFIX}Project7"
-        rlRun "curl $FRONTEND_URL --silent | grep ${NAME_PREFIX}Project7" 1 # project won't be present on hp
+        rlRun "copr_curl $FRONTEND_URL/coprs/ --silent | grep ${NAME_PREFIX}Project7" 1 # project won't be present on hp
         rlRun "copr-cli modify --unlisted-on-hp off ${NAME_PREFIX}Project7"
-        rlRun "curl $FRONTEND_URL --silent | grep ${NAME_PREFIX}Project7" 0 # project should be visible on hp now
+        rlRun "copr_curl $FRONTEND_URL/coprs/ --silent | grep ${NAME_PREFIX}Project7" 0 # project should be visible on hp now
 
         # FIXME It is now not possible to update whoosh index on demand
         # Instead, it is periodically recreated via cron
@@ -392,7 +392,7 @@ rlJournalStart
         # Bug 1365882 - on create group copr, gpg key is generated for user and not for group
         WAITING=`mktemp`
         rlRun "copr-cli create ${NAME_PREFIX}Project12 --chroot $CHROOT" 0
-        rlRun "curl --silent $FRONTEND_URL/backend/pending-action/ > $WAITING"
+        rlRun "copr_curl --silent $FRONTEND_URL/backend/pending-action/ > $WAITING"
         rlRun "cat $WAITING | grep action_type"
         cat $WAITING # debug
         rlRun "cat $WAITING | grep -E '.*data.*ownername.*' | grep $OWNER" 0

--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -40,6 +40,7 @@ from copr.v3 import (
     CoprConfigException, CoprNoResultException, CoprAuthException,
 )
 from copr.v3.pagination import next_page
+import copr.v3.requests as copr_requests
 from copr_cli.helpers import (
     cli_use_output_format,
     print_project_info,
@@ -2065,6 +2066,9 @@ def _handle_frontend_api_request_error(e, args):
 def main(argv=sys.argv[1:]):
     # pylint: disable=too-many-branches
     try:
+        # Set User-Agent for Copr CLI - allows Anubis bot protection to identify us
+        copr_requests.USER_AGENT = "copr copr-cli/{0}".format(__version__)
+
         # Set up parser for global args
         parser = setup_parser()
         # Parse the commandline


### PR DESCRIPTION
Allow our internal/external tools to completely bypass the anubis challenge by setting copr-related user agent. This agent is then completely ignored in anubis settings.

Fixes the rest of the failing tests alongside these:
  - https://pagure.io/fedora-infra/ansible/pull-request/3031
  - https://pagure.io/fedora-infra/ansible/pull-request/3029

Relates:
  - https://github.com/fedora-copr/copr/issues/3867
  - https://pagure.io/fedora-infra/ansible/pull-request/3031
  - https://pagure.io/fedora-infra/ansible/pull-request/3029

<!-- issue-commentator = {"comment-id":"3729127138"} -->