### PR TITLE
frontend: use build.copr instead of copr context for batches builds

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/_builds_table.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/_builds_table.html
@@ -34,7 +34,7 @@
 
         <tr class="build-row" >
           <td data-order="{{ build.id }}">
-            <b><a href="{{ copr_url('coprs_ns.copr_build', copr, build_id=build.id) }}">
+            <b><a href="{{ copr_url('coprs_ns.copr_build', build.copr, build_id=build.id) }}">
               {{ build.id }}
             </a></b>
           </td>


### PR DESCRIPTION
Commit 0f656de83 changed build URL generation from build_href_from_sql() to copr_url(), but with the whole context variable `copr`. This fixes undefined error when viewing batch details page where no copr context available exists.

Fixes: #4030

<!-- issue-commentator = {"comment-id":"3743902709"} -->