### PR TITLE
Preload build.copr to fix the builds page for large projects

### DIFF
--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -490,6 +490,7 @@ class BuildsLogic(object):
             selectinload(models.Build.build_chroots),
             selectinload(models.Build.package),
             selectinload(models.Build.copr_dir),
+            selectinload(models.Build.copr),
         )
         return query
 


### PR DESCRIPTION
Fix #4144
See #4109
See PR #4112

The related issue is basically the same but it was about

    lazy load operation of attribute 'copr_dir'

and now the problem was with just `copr` attribute.