### PR TITLE
backend, frontend: implement persistent projects in Pulp

### DIFF
--- a/backend/copr_backend/actions.py
+++ b/backend/copr_backend/actions.py
@@ -97,8 +97,9 @@ class Action(object):
             owner = self.ext_data.get("ownername")
             project = self.ext_data.get("projectname")
             devel = self.ext_data.get("devel")
+            persistent = self.ext_data.get("persistent")
             appstream = self.ext_data.get("appstream")
-            args = [owner, project, appstream, devel, self.opts, self.log]
+            args = [owner, project, appstream, devel, persistent, self.opts, self.log]
             self.storage = storage_for_enum(enum, *args)
 
             # Even though we already have `self.storage` which uses an

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -283,15 +283,18 @@ class PulpClient:
         )
         return response
 
-    def create_repository(self, name):
+    def create_repository(self, name, persistent=False):
         """
         Create an RPM repository
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_create
         """
         uri = "/api/v3/repositories/rpm/rpm/"
-        data = {"name": name, "retain_repo_versions": 1,
-                # Temporarily retain all packages, workaround for #4071
-                "retain_package_versions": 0}
+        data = {
+            "name": name,
+            "retain_repo_versions": 1,
+            # Temporarily retain all packages, workaround for #4071
+            "retain_package_versions": 0 if persistent else 0,
+        }
         self.log.info("Pulp: create_repository: %s %s", uri, name)
         return self.send("POST", uri, data)
 

--- a/frontend/coprs_frontend/coprs/logic/actions_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/actions_logic.py
@@ -116,6 +116,7 @@ class ActionsLogic(object):
             "appstream": copr.appstream,
             "storage": copr.storage,
             "reason": reason,
+            "persistent": copr.persistent,
         }
 
         run_in = set()

--- a/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
+++ b/frontend/coprs_frontend/tests/test_views/test_coprs_ns/test_coprs_general.py
@@ -511,6 +511,7 @@ class TestCoprUpdate(CoprsTestCase):
             "chroots": ["fedora-18-x86_64"],
             "appstream": True,
             "devel": True,
+            "persistent": False,
             "reason": CreaterepoReason.manual_createrepo_toggle,
             "storage": StorageEnum("backend"),
         }
@@ -1145,6 +1146,7 @@ class TestCoprActionsGeneration(CoprsTestCase):
             "project_dirnames": ["test"],
             "appstream": False,
             "devel": False,
+            "persistent": False,
             "reason": CreaterepoReason.new_chroot,
             "storage": StorageEnum("backend"),
         }


### PR DESCRIPTION
Fix #3501

Most of the persistent projects related code resides on the frontend and prevent users from removing builds or projects. This is storage agnostic and won't require any changes.

Next we have our `copr_prune_results.py` which already handles persistent projects on backend, and we don't have prunning for Pulp yet. See #4138 and

IMHO the only thing that needs to be done is to configure persistent projects to retain all package versions in Pulp. Notice the code is seemingly wrong:

    "retain_package_versions": 0 if persistent else 0,

That's because we are still workarounding #4071 but once that gets resolved, we will change the it to `0 if persistent else 5`.