### PR TITLE
frontend: fix small typos in ‹.delete_after_humanized›

### DIFF
--- a/backend/run/copr_find_obsolete_builds.sh
+++ b/backend/run/copr_find_obsolete_builds.sh
@@ -19,7 +19,7 @@ then
     repoquery --repofrompath=query,$CHROOT_PATH --repoid=query -a --location 2>$ERR_LOG \
         | cut -c8- > $LATEST_PKGS
 
-    # Remove builds older then $DAYS days and which have newer builds available
+    # Remove builds older than $DAYS days and which have newer builds available
     for SUCCESS in $(find -name success -mtime +$DAYS); do
         DIR=$(basename $(dirname $SUCCESS))
         echo "# checking dir: " $DIR

--- a/frontend/coprs_frontend/coprs/models.py
+++ b/frontend/coprs_frontend/coprs/models.py
@@ -1929,13 +1929,13 @@ class CoprChroot(db.Model, helpers.Serializer):
         Return how soon the chroot is going to be deleted (expired).
         The largest unit we use is a day and the smallest is an hour. When the
         remaining time is just a couple of minutes or seconds, we just say that
-        it is "less then an hour".
+        it is "less than an hour".
         """
         if self.delete_after is None:
             return None
 
         if self.delete_after_expired:
-            return "To be removed in next cleanup"
+            return "to be removed in the next cleanup"
 
         delta = self.delete_after - datetime.datetime.now()
         if delta.days:
@@ -1944,7 +1944,7 @@ class CoprChroot(db.Model, helpers.Serializer):
         hours = int(round(delta.seconds / 3600))
         if hours:
             return "{0} hours".format(hours)
-        return "less then an hour"
+        return "less than an hour"
 
     @property
     def module_setup_commands(self):

--- a/frontend/coprs_frontend/tests/test_logic/test_outdated_chroots_logic.py
+++ b/frontend/coprs_frontend/tests/test_logic/test_outdated_chroots_logic.py
@@ -224,7 +224,7 @@ class TestOutdatedChrootsLogic(CoprsTestCase):
         assert chroot.delete_after_humanized == "12 hours"
 
         chroot.delete_after = datetime.now() + timedelta(minutes=30)
-        assert chroot.delete_after_humanized == "less then an hour"
+        assert chroot.delete_after_humanized == "less than an hour"
 
     @pytest.mark.usefixtures("f_users", "f_coprs", "f_mock_chroots", "f_db")
     def test_outdated_chroots_expired(self):


### PR DESCRIPTION
#grammarPolice

• “than” is used for comparing comparing numbers…
  “then” is an adverb

• “To be removed in next cleanup” -> “to be removed in the next cleanup”
  · lowercase “to” to keep consistent capitalization within the same property
  · add “the”, since it's a specific (the next one) deletion

Noticed this when going through the code related to #4163