### PR TITLE
Adding robots.txt endpoint

### DIFF
--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -33,7 +33,8 @@
 %templatedir/documentation_cards.html           \
 %templatedir/welcome.html                       \
 %templatedir/contact_us.html                    \
-%templatedir/sponsors.html
+%templatedir/sponsors.html                      \
+%templatedir/robots.txt
 
 %global devel_files \
 %flavor_generator

--- a/frontend/coprs_frontend/coprs/constants.py
+++ b/frontend/coprs_frontend/coprs/constants.py
@@ -6,3 +6,10 @@ File which contains only constants. Nothing else.
 BANNER_LOCATION = "/var/lib/copr/data/banner-include.html"
 
 DEFAULT_COPR_REPO_PRIORITY = 99
+
+DEFAULT_ROBOTS_TXT = """
+User-Agent: *
+Disallow: /
+DisallowAITraining: /
+Content-Usage: ai=n
+"""

--- a/frontend/coprs_frontend/coprs/static/robots.txt
+++ b/frontend/coprs_frontend/coprs/static/robots.txt
@@ -1,0 +1,97 @@
+# Well known AI agents and bots are allowed to access the website
+# with exception of the certain paths
+
+User-Agent: GPTBot
+User-Agent: ClaudeBot
+User-Agent: Claude-User
+User-Agent: Claude-SearchBot
+User-Agent: CCBot
+User-Agent: Google-Extended
+User-Agent: Applebot-Extended
+User-Agent: Facebookbot
+User-Agent: Meta-ExternalAgent
+User-Agent: Meta-ExternalFetcher
+User-Agent: diffbot
+User-Agent: PerplexityBot
+User-Agent: Perplexity‑User
+User-Agent: Omgili
+User-Agent: Omgilibot
+User-Agent: webzio-extended
+User-Agent: ImagesiftBot
+User-Agent: Bytespider
+User-Agent: TikTokSpider
+User-Agent: Amazonbot
+User-Agent: Youbot
+User-Agent: SemrushBot-OCOB
+User-Agent: Petalbot
+User-Agent: VelenPublicWebCrawler
+User-Agent: TurnitinBot
+User-Agent: Timpibot
+User-Agent: OAI-SearchBot
+User-Agent: ICC-Crawler
+User-Agent: AI2Bot
+User-Agent: AI2Bot-Dolma
+User-Agent: DataForSeoBot
+User-Agent: AwarioBot
+User-Agent: AwarioSmartBot
+User-Agent: AwarioRssBot
+User-Agent: Google-CloudVertexBot
+User-Agent: PanguBot
+User-Agent: Kangaroo Bot
+User-Agent: Sentibot
+User-Agent: img2dataset
+User-Agent: Meltwater
+User-Agent: Seekr
+User-Agent: peer39_crawler
+User-Agent: cohere-ai
+User-Agent: cohere-training-data-crawler
+User-Agent: DuckAssistBot
+User-Agent: Scrapy
+User-Agent: Cotoyogi
+User-Agent: aiHitBot
+User-Agent: Factset_spyderbot
+User-Agent: FirecrawlAgent
+
+Allow: /
+
+Disallow: /coprs
+Disallow: /api
+Disallow: /backend
+Disallow: /admin
+Disallow: /status
+Disallow: /recent
+Disallow: /explore
+Disallow: /batches
+Disallow: /groups
+Disallow: /user
+
+DisallowAITraining: /coprs
+DisallowAITraining: /api
+DisallowAITraining: /backend
+DisallowAITraining: /admin
+DisallowAITraining: /status
+DisallowAITraining: /recent
+DisallowAITraining: /explore
+DisallowAITraining: /batches
+DisallowAITraining: /groups
+DisallowAITraining: /user
+
+
+# All other bots are blocked from training on the website
+# but allowed to access it for general use
+User-Agent: *
+DisallowAITraining: /
+Content-Usage: ai=n
+
+Allow: /
+
+Disallow: /coprs
+Disallow: /api
+Disallow: /backend
+Disallow: /admin
+Disallow: /status
+Disallow: /recent
+Disallow: /explore
+Disallow: /batches
+Disallow: /groups
+Disallow: /user

--- a/frontend/coprs_frontend/coprs/views/misc.py
+++ b/frontend/coprs_frontend/coprs/views/misc.py
@@ -19,6 +19,8 @@ from coprs.measure import checkpoint_start
 from coprs.auth import UserAuth, OpenIDConnect
 from coprs.oidc import oidc_enabled, oidc_username_from_userinfo
 from coprs import oidc
+from coprs.constants import DEFAULT_ROBOTS_TXT
+
 
 @app.before_request
 def before_request():
@@ -313,3 +315,17 @@ def api_login_required(endpoint_method):
 
         return endpoint_method(self, *args, **kwargs)
     return check_if_api_login_is_required
+
+
+@misc.route("/robots.txt")
+def robots_txt():
+    """
+    Robots.txt for managing crawler and AI agent access, if no robots.txt is found
+    prohibit everything.
+    """
+    try:
+        with flask.current_app.open_resource("static/robots.txt") as f:
+            content = f.read().decode("utf-8")
+            return flask.Response(content, mimetype="text/plain")
+    except FileNotFoundError:
+        return flask.Response(DEFAULT_ROBOTS_TXT, mimetype="text/plain")

--- a/frontend/coprs_frontend/tests/test_robots_txt.py
+++ b/frontend/coprs_frontend/tests/test_robots_txt.py
@@ -1,0 +1,40 @@
+from unittest import mock
+from tests.coprs_test_case import CoprsTestCase
+
+class TestRobotsTxt(CoprsTestCase):
+    def test_robots_txt_success(self):
+        """
+        Test that /robots.txt is served correctly from the static directory.
+        """
+        response = self.tc.get("/robots.txt")
+
+        # Verify response metadata
+        assert response.status_code == 200
+        assert response.mimetype == "text/plain"
+
+        # Verify key contents from the actual robots.txt file
+        content = response.data.decode("utf-8")
+        assert "User-Agent: GPTBot" in content
+        assert "Disallow: /admin" in content
+        assert "DisallowAITraining: /api" in content
+        assert "Allow: /" in content
+
+    @mock.patch("flask.current_app.open_resource")
+    def test_robots_txt_file_error(self, mock_open):
+        """
+        Test the error handling when the robots.txt file cannot be opened.
+        """
+        # Simulate an exception when opening the file
+        error_message = "File not found"
+        mock_open.side_effect = Exception(error_message)
+
+        # We need to mock the logger to check if the error was logged
+        with mock.patch("coprs.app.logger.error") as mock_log:
+            response = self.tc.get("/robots.txt")
+
+            # Verify the function handled the exception and returned the error string
+            assert response.status_code == 200
+            assert error_message in response.data.decode("utf-8")
+
+            # Verify the error was logged
+            mock_log.assert_any_call(msg=error_message, exc_info=True)


### PR DESCRIPTION
The API will return robots.txt from static sources, unless it doesn't exist, for whatever reason. In that case it returns robots.txt blocking all crawlers and agents.