### PR TITLE
Initial Sentry integration

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -53,6 +53,7 @@ BuildRequires: python3-tabulate
 BuildRequires: python3-zstandard
 BuildRequires: python3-cachetools
 BuildRequires: python3-libdnf5
+BuildRequires: python3-sentry-sdk
 BuildRequires: prunerepo >= %prunerepo_version
 BuildRequires: resalloc-server
 BuildRequires: dnf
@@ -93,6 +94,7 @@ Requires:   redis
 Requires:   rpm-sign
 Requires:   rsync
 Requires:   python3-libdnf5
+Requires:   python3-sentry-sdk
 Recommends: util-linux-core
 Requires:   zstd
 

--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -314,6 +314,9 @@ class BackendConfigReader(object):
         opts.sign_domain = _get_conf(
             cp, "backend", "sign_domain", DOMAIN)
 
+        opts.sentry_dsn = _get_conf(
+            cp, "backend", "sentry_dsn", None)
+
         opts.build_groups = []
         for group_id in range(opts.build_groups_count):
             archs = _get_conf(cp, "backend",

--- a/backend/run/copr-backend-process-action
+++ b/backend/run/copr-backend-process-action
@@ -4,6 +4,7 @@
 Process one Action task provided by frontend (on backend).
 """
 
+import sentry_sdk
 from copr_common.enums import BackendResultEnum
 
 from copr_backend.background_worker import BackendBackgroundWorker
@@ -52,4 +53,6 @@ class ActionBackgroundWorker(BackendBackgroundWorker):
 
 if __name__ == "__main__":
     worker = ActionBackgroundWorker()
+    if worker.opts["sentry_dsn"]:
+        sentry_sdk.init(dsn=worker.opts["sentry_dsn"])
     worker.process()

--- a/backend/run/copr-backend-process-build
+++ b/backend/run/copr-backend-process-build
@@ -4,7 +4,11 @@
 Process one Build task provided by frontend (on backend).
 """
 
+import sentry_sdk
 from copr_backend.background_worker_build import BuildBackgroundWorker
 
 if __name__ == "__main__":
-    BuildBackgroundWorker().process()
+    worker = BuildBackgroundWorker()
+    if worker.opts["sentry_dsn"]:
+        sentry_sdk.init(dsn=worker.opts["sentry_dsn"])
+    worker.process()

--- a/backend/run/copr-run-dispatcher-backend
+++ b/backend/run/copr-run-dispatcher-backend
@@ -6,6 +6,7 @@ dispatchers from our systemd unit files.
 """
 
 import sys
+import sentry_sdk
 
 from copr_backend.daemons.action_dispatcher import ActionDispatcher
 from copr_backend.daemons.build_dispatcher import BuildDispatcher
@@ -23,7 +24,11 @@ def _main():
         raise NotImplementedError(
             "Not implemented '{}' dispatcher".format(request))
 
-    dispatcher(backend_opts=get_backend_opts()).run()
+    opts = get_backend_opts()
+    if opts["sentry_dsn"]:
+        sentry_sdk.init(dsn=opts["sentry_dsn"])
+
+    dispatcher(backend_opts=opts).run()
 
 
 if __name__ == "__main__":

--- a/backend/run/copr_run_logger.py
+++ b/backend/run/copr_run_logger.py
@@ -1,12 +1,16 @@
 #!/usr/bin/python3
 # coding: utf-8
 
+import sentry_sdk
 from copr_backend.helpers import get_backend_opts
 from copr_backend.daemons.log import RedisLogHandler
 
 
 def main():
     opts = get_backend_opts()
+    if opts["sentry_dsn"]:
+        sentry_sdk.init(dsn=opts["sentry_dsn"])
+
     handler = RedisLogHandler(opts)
     handler.run()
 

--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -24,6 +24,7 @@ BuildRequires: python3-pytest
 BuildRequires: python3-copr-common >= %copr_common_version
 BuildRequires: python3-redis
 BuildRequires: python3-setproctitle
+BuildRequires: python3-sentry-sdk
 
 Recommends: logrotate
 Requires: systemd
@@ -39,6 +40,7 @@ Requires: python3-munch
 Requires: python3-setproctitle
 Requires: python3-daemon
 Requires: python3-redis
+Requires: python3-sentry-sdk
 Requires: findutils
 Requires: (copr-selinux if selinux-policy-targeted)
 Requires: crontabs

--- a/dist-git/copr_dist_git/helpers.py
+++ b/dist-git/copr_dist_git/helpers.py
@@ -136,6 +136,8 @@ class ConfigReader(object):
         opts.redis_port = _get_conf(cp, "dist-git", "redis_port", "6379")
         opts.redis_password = _get_conf(cp, "dist-git", "redis_password", None)
 
+        opts.sentry_dsn = _get_conf(cp, "dist-git", "sentry_dsn", None)
+
         return opts
 
 

--- a/dist-git/run/copr-distgit-process-import
+++ b/dist-git/run/copr-distgit-process-import
@@ -7,6 +7,7 @@ Process one import task provided by frontend (on distgit).
 import os
 import sys
 import requests
+import sentry_sdk
 from copr_common.background_worker import BackgroundWorker
 from copr_dist_git.helpers import get_distgit_opts
 from copr_dist_git.importer import Importer
@@ -64,4 +65,6 @@ class ImportBackgroundWorker(BackgroundWorker):
 
 if __name__ == "__main__":
     worker = ImportBackgroundWorker()
+    if worker.opts["sentry_dsn"]:
+        sentry_sdk.init(dsn=worker.opts["sentry_dsn"])
     worker.process()

--- a/dist-git/run/copr-run-dispatcher-dist-git
+++ b/dist-git/run/copr-run-dispatcher-dist-git
@@ -6,6 +6,7 @@ dispatchers from our systemd unit files.
 """
 
 import sys
+import sentry_sdk
 from copr_dist_git.helpers import get_distgit_opts
 from copr_dist_git.import_dispatcher import ImportDispatcher
 
@@ -21,6 +22,10 @@ def _main():
 
     config = "/etc/copr/copr-dist-git.conf"
     opts = get_distgit_opts(config)
+
+    if opts["sentry_dsn"]:
+        sentry_sdk.init(dsn=opts["sentry_dsn"])
+
     dispatcher(opts).run()
 
 

--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -115,6 +115,7 @@ BuildRequires: python3dist(pygal)
 BuildRequires: redis
 BuildRequires: modulemd-tools >= 0.6
 BuildRequires: python3dist(authlib)
+BuildRequires: python3-sentry-sdk+flask
 %endif
 
 Requires: crontabs
@@ -171,6 +172,7 @@ Requires: js-jquery-ui
 Requires: python3dist(xstatic-patternfly)
 Requires: modulemd-tools >= 0.6
 Requires: python3dist(authlib)
+Requires: python3-sentry-sdk+flask
 
 Provides: bundled(bootstrap-combobox) = 1.1.6
 Provides: bundled(bootstrap-select) = 1.5.4

--- a/frontend/coprs_frontend/coprs/__init__.py
+++ b/frontend/coprs_frontend/coprs/__init__.py
@@ -17,6 +17,11 @@ from flask_whooshee import Whooshee
 
 from coprs.request import get_request_class
 from redis import StrictRedis
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
+
 
 app = flask.Flask(__name__)
 if "COPRS_ENVIRON_PRODUCTION" in os.environ:
@@ -38,6 +43,17 @@ app.config["SESSION_REDIS"] = StrictRedis(
     port=app.config["REDIS_PORT"],
     db=1,
 )
+
+if app.config["SENTRY_DSN"]:
+    sentry_sdk.init(
+        dsn=app.config["SENTRY_DSN"],
+        integrations=[
+            FlaskIntegration(),
+            SqlalchemyIntegration(),
+            RedisIntegration(),
+        ],
+    )
+
 
 session = Session(app)
 

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -214,6 +214,9 @@ class Config(object):
     # configured in Lighttpd
     PULP_CONTENT_URL = None
 
+    # Optionally enable Sentry integration by providing your project DSN
+    SENTRY_DSN = None
+
 
 class ProductionConfig(Config):
     DEBUG = False


### PR DESCRIPTION
See #3715

We currently trying to debug several Pulp related issues and we are missing helpful information in logs. For example the exact responses returned from Pulp. I believe they would be much easier to debug if we had Sentry already.

I tested this PR on my personal Sentry account but for production, we only need for somebody to create a new project under a Red Hat organization and gave us its DSN.