### PR TITLE
Use SafeRequest.timeout only as a timeout per request

### DIFF
--- a/common/copr_common/request.py
+++ b/common/copr_common/request.py
@@ -14,20 +14,28 @@ class SafeRequest:
     Build a HTTP request and _safely_ send it.
 
     If the server cannot be reached, the request is repeated either indefinitely
-    or until a timeout is reached.
+    or until a number of failed attempts is reached.
     """
 
     # Prolong the sleep time before asking frontend again
     SLEEP_INCREMENT_TIME = 5
 
     def __init__(self, auth=None, cert=None, log=None,
-                 try_indefinitely=False, timeout=2 * 60, user_agent=None):
+                 try_indefinitely=False, timeout=30, attempts=None,
+                 user_agent=None):
         # pylint: disable=too-many-positional-arguments
         self.auth = auth
         self.cert = cert
         self.log = log
-        self.try_indefinitely = try_indefinitely
         self.timeout = timeout
+
+        if attempts and try_indefinitely:
+            raise ValueError("Can't set both attempts and try_indefinitely")
+        if not attempts and not try_indefinitely:
+            attempts = 5
+
+        self.attempts = attempts
+        self.try_indefinitely = try_indefinitely
 
         # Use package name and version for the user agent
         self.package_name = 'copr-common'
@@ -76,7 +84,7 @@ class SafeRequest:
             elif self.auth:
                 req_args["auth"] = self.auth
             req_args["headers"] = headers
-            req_args["timeout"] = self.timeout / 5
+            req_args["timeout"] = self.timeout
             method = method.lower()
             if method in ["post", "put", "patch"]:
                 req_args["data"] = data if files else json.dumps(data)
@@ -110,19 +118,16 @@ class SafeRequest:
 
     def _send_request_repeatedly(self, url, method, data=None, **kwargs):
         """
-        Repeat the request until it succeeds, or timeout is reached.
+        Repeat the request until it succeeds, or number of attempts is reached.
         """
         sleep = self.SLEEP_INCREMENT_TIME
-        start = time.time()
-        stop = start + self.timeout
-
         i = 0
         while True:
             i += 1
-            if not self.try_indefinitely and time.time() > stop:
+            if not self.try_indefinitely and i > self.attempts:
                 raise RequestError(
                     "Attempt to talk to server timeouted "
-                    "(we gave it {} attempts)".format(i))
+                    "(we gave it {} attempts)".format(self.attempts))
 
             try:
                 return self._send_request(url, method=method, data=data,

--- a/common/python-copr-common.spec
+++ b/common/python-copr-common.spec
@@ -1,7 +1,7 @@
 %global srcname copr-common
 
 Name:       python-copr-common
-Version:    1.5
+Version:    1.5.1
 Release:    1%{?dist}
 Summary:    Python code used by Copr
 

--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -1,7 +1,7 @@
-%global copr_common_version 0.25.1~~dev0
+%global copr_common_version 1.5.1
 
 Name:       copr-dist-git
-Version:    1.3
+Version:    1.5
 Release:    1%{?dist}
 Summary:    Copr services for Dist Git server
 

--- a/dist-git/copr_dist_git/helpers.py
+++ b/dist-git/copr_dist_git/helpers.py
@@ -151,7 +151,7 @@ def download_file(url, destination):
     """
     log.debug("Downloading {0}".format(url))
     try:
-        request = SafeRequest(log=log, timeout=10 * 60)
+        request = SafeRequest(log=log, timeout=2 * 60)
         r = request.send(url, method='get', stream=True)
     except RequestError as e:
         raise FileDownloadException(str(e))


### PR DESCRIPTION
See #4186
See #4192

We are seeing unexpected timeouts from Pulp

    Read timed out. (read timeout=12.0)

and from copr-keygen

    Read timed out. (read timeout=24.0)

It took me a long time to notice that we abuse `SafeRequest.timeout` for both timeout per request and total timeout of how long should `SafeRequest` keep trying again and again. To make it make sense, we had divide the timeout by some constant to calculate the timeout per request.

The `PulpClient` basically does this:

    request = SafeRequest(
        timeout=60,
        try_indefinitely=True,
    )

you would read it as "timeout for every request is 60s and we are going to try indefinitely". Which is incorrect. The actual timeout per request was 60 / 5 = 12.

This PR untangles this logic, and uses `SafeRequest.timeout` only as a timeout per request. How long should we try is now controlled by `SafeRequest.attempts` and for backward compatibility also `SafeRequest.try_idefinitely`.