### PR TITLE
common: timeout is not precise because it can fail for other reasons

### DIFF
--- a/common/copr_common/request.py
+++ b/common/copr_common/request.py
@@ -126,7 +126,7 @@ class SafeRequest:
             i += 1
             if not self.try_indefinitely and i > self.attempts:
                 raise RequestError(
-                    "Attempt to talk to server timeouted "
+                    "The server didn't return a successful response "
                     "(we gave it {} attempts)".format(self.attempts))
 
             try:


### PR DESCRIPTION
See PR #4197