### PR TITLE
backend: query Pulp content for only 7 builds at a time

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -9,6 +9,7 @@ import os
 import time
 import tomllib
 import hashlib
+from itertools import batched
 from urllib.parse import urlencode
 
 from copr_common.request import SafeRequest
@@ -612,6 +613,20 @@ class PulpClient:
         Get a list of PRNs for RPMs with provided build ids
         https://pulpproject.org/pulp_rpm/restapi/#tag/Content:-Packages/operation/content_rpm_packages_list
         """
+        if not build_ids:
+            raise ValueError("Content must be queried for specific builds")
+
+        all_results = []
+        # We need to chunk the `build_ids` into lists of only 7 items otherwise
+        # we are going to hit validation error from Pulp
+        # See https://github.com/fedora-copr/copr/issues/4187
+        # See https://github.com/pulp/pulpcore/issues/7435
+        for batch in batched(build_ids, 7):
+            results, response = self._get_content(batch, chroot, fields)
+            all_results.extend(results)
+        return PaginatedResponse(all_results, response)
+
+    def _get_content(self, build_ids, chroot=None, fields=None):
         query = "("
         for i, build_id in enumerate(build_ids):
             if i:
@@ -650,7 +665,7 @@ class PulpClient:
             offset += limit
 
         self.log.info("Pulp: get_content: fetched %d items", len(all_results))
-        return PaginatedResponse(all_results, response)
+        return all_results, response
 
     def delete_repository(self, repository):
         """

--- a/backend/tests/test_pulp.py
+++ b/backend/tests/test_pulp.py
@@ -5,6 +5,7 @@ Test Pulp client
 # pylint: disable=attribute-defined-outside-init
 
 from unittest.mock import Mock
+import pytest
 from copr_backend.pulp import PulpClient
 
 
@@ -113,3 +114,28 @@ class TestPulp:
 
         assert not response.ok
         assert client.send.call_count == 1
+
+    def test_get_content_build_ids_batched(self):
+        client = PulpClient(self.config)
+        results = [{"prn": f"rpm-{i}"} for i in range(50)]
+        mock_response = self.create_mock_response(results, 50, next_url=None)
+        client.send = Mock(return_value=mock_response)
+
+        build_ids = list(range(25))
+        response = client.get_content(build_ids, fields=["prn"])
+        assert client.send.call_count == 4
+        assert client.send.call_args_list[0].args[1].count("build_id") == 7
+        assert client.send.call_args_list[1].args[1].count("build_id") == 7
+        assert client.send.call_args_list[2].args[1].count("build_id") == 7
+        assert client.send.call_args_list[3].args[1].count("build_id") == 4
+
+        assert response.ok
+        assert response.json()["count"] == 200
+
+    def test_get_content_build_ids_empty(self):
+        client = PulpClient(self.config)
+        client.send = Mock()
+        with pytest.raises(ValueError) as ex:
+            client.get_content([], fields=["prn"])
+        assert "Content must be queried for specific builds" in str(ex)
+        assert not client.send.called


### PR DESCRIPTION
Fix #4187
See https://github.com/pulp/pulpcore/issues/7435

This is a workaround until the Pulp team can implement something like

    pulp_label_select=build_id=123|456|789|...