### PR TITLE
backend: add prns to a repository, not pulp_hrefs

### DIFF
--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -461,11 +461,12 @@ class PulpStorage(Storage):
                 try:
                     response = future.result()
                     if response.ok:
-                        created = response.json().get("pulp_href")
+                        data = response.json()
                         uploaded[os.path.basename(filepath)] = {
                             "build_id": build_id,
                             "path": filepath,
-                            "pulp_href": created,
+                            "pulp_href": data.get("pulp_href"),
+                            "prn": data.get("prn"),
                         }
                         self.log.info(
                             "[%s/%s] Uploaded to Pulp: %s",
@@ -484,12 +485,12 @@ class PulpStorage(Storage):
 
             return uploaded
 
-    def create_repository_version(self, dirname, chroot, package_hrefs):
+    def create_repository_version(self, dirname, chroot, package_hrefs_or_prns):
         """
         Create a new repository version by adding a list of RPMs to the latest repository version.
         """
         repository = self._get_repository(chroot, dirname)
-        return self.client.add_content(repository, package_hrefs)
+        return self.client.add_content(repository, package_hrefs_or_prns)
 
     def publish_repository(self, chroot, **kwargs):
         # Publishing occurs after each repository version is created.

--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -207,8 +207,8 @@ def change_storage_for_project(fullname, dst, config):
                 uploaded.update(results)
 
             # Add build results to the repository
-            all_package_hrefs = [x["pulp_href"] for x in uploaded.values()]
-            if not storage.create_repository_version(subproject, chroot, all_package_hrefs):
+            all_package_prns = [x["prn"] for x in uploaded.values()]
+            if not storage.create_repository_version(subproject, chroot, all_package_prns):
                 log.error("Failed to create repository version for chroot: %s", chroot)
                 sys.exit(1)
 


### PR DESCRIPTION
See https://github.com/pulp/pulpcore/issues/7484

There is some performance problem with pulp_hrefs on the Pulp side, so they asked us to use prns instead. It should handle any large number of them.

For the record, prn means "Pulp resource name".