### PR TITLE
doc: build html not dirhtml pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,9 +6,11 @@ on:
       - main
     paths:
       - 'doc/**'
+      - '.github/workflows/gh-pages.yml'
   pull_request:
     paths:
       - 'doc/**'
+      - '.github/workflows/gh-pages.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
It is unfortunate because `dirhtml` URLs are much nicer, for comparison:

    https://docs.copr.fedorainfracloud.org/maintenance/hypervisors/
    https://docs.copr.fedorainfracloud.org/maintenance/hypervisors.html

but on https://docs.pagure.org/copr.copr we used `html` so it will probably be safer to continue using it, so that redirects from the old URL has less of a chance to break.