### PR TITLE
frontend: use literal rawhide instead of $releasever in repo files

### DIFF
--- a/frontend/coprs_frontend/coprs/repos.py
+++ b/frontend/coprs_frontend/coprs/repos.py
@@ -19,7 +19,8 @@ def generate_repo_url(mock_chroot, url, arch=None):
     os_version = mock_chroot.os_version
 
     if mock_chroot.os_release == "fedora":
-        os_version = "$releasever"
+        if mock_chroot.os_version != "rawhide":
+            os_version = "$releasever"
 
     if mock_chroot.os_release == "centos-stream":
         os_version = "$releasever"

--- a/frontend/coprs_frontend/tests/test_repos.py
+++ b/frontend/coprs_frontend/tests/test_repos.py
@@ -34,9 +34,9 @@ class TestRepos(CoprsTestCase):
 
         test_sets.extend([
             dict(args=(m2, http_url),
-                 expected="http://example.com/path/fedora-$releasever-$basearch/"),
+                 expected="http://example.com/path/fedora-rawhide-$basearch/"),
             dict(args=(m2, https_url),
-                 expected="https://example.com/path/fedora-$releasever-$basearch/")])
+                 expected="https://example.com/path/fedora-rawhide-$basearch/")])
 
         m3 = deepcopy(mock_chroot)
         m3.os_release = "rhel7"


### PR DESCRIPTION
The downloaded repo file for rawhide used $releasever in the baseurl which can resolve to a numeric version (e.g. 45) in mock environment, where in fact in real fedora rawhide the releasever expands correctly to rawhide. Let's keep the literal rawhide there (same as mageia's cauldron is handled).

Fix #4206