### PR TITLE
backend: modify pulp label filter for content queries

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -627,15 +627,17 @@ class PulpClient:
         return PaginatedResponse(all_results, response)
 
     def _get_content(self, build_ids, chroot=None, fields=None):
-        query = "("
+        query = ""
         for i, build_id in enumerate(build_ids):
             if i:
                 query += " OR "
-            query += f"pulp_label_select=\"build_id={build_id}\""
-        query += ")"
-
-        if chroot:
-            query += f" AND pulp_label_select=\"chroot={chroot}\""
+            query += "("
+            query += f"pulp_label_select=\"build_id={build_id}"
+            if chroot:
+                query += f",chroot={chroot}\""
+            else:
+                query += "\""
+            query += ")"
 
         all_results = []
         offset = 0


### PR DESCRIPTION
Instead of filtering build_id and chroot with separate pulp_label_select clauses joined by AND, combine them into a single comma-separated label selector.