### PR TITLE
Fix beaker tests before a release

### DIFF
--- a/beaker-tests/DockerTestEnv/Dockerfile
+++ b/beaker-tests/DockerTestEnv/Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y update \
     && if test "$COPR_PACKAGES" = devel; then dnf -y copr enable @copr/copr-dev; fi \
     && dnf -y install hostname htop net-tools iputils vim git sudo \
               openssh-server psmisc python-jedi procps-ng findutils tmux \
-              expect python3-behave python3-hamcrest \
+              expect python3-behave python3-hamcrest lftp \
     && dnf -y install python3-copr rpm-build copr-cli jq \
     && dnf -y install beakerlib util-linux-script \
     && dnf -y clean all

--- a/beaker-tests/Sanity/copr-cli-basic-operations/all-in-tmux-redhat.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/all-in-tmux-redhat.sh
@@ -9,6 +9,8 @@ BACKEND_URL=https://dev-coprbe.devel.redhat.com
 DISTGIT_URL=https://dev-copr-dist-git.devel.redhat.com
 VENDOR="Red Hat Internal Copr (devel) - "
 DISTGIT_BRANCH_FEDORA_PREFIX=fedora/
+PULP_CONTENT_URL=""
+STORAGE="backend"
 
 set -e
 
@@ -27,5 +29,6 @@ EOF
 
 fi
 
-export OWNER FRONTEND_URL BACKEND_URL DISTGIT_URL VENDOR DISTGIT_BRANCH_FEDORA_PREFIX
+export OWNER FRONTEND_URL BACKEND_URL DISTGIT_URL VENDOR \
+       DISTGIT_BRANCH_FEDORA_PREFIX PULP_CONTENT_URL STORAGE
 exec "$our_dir/all-in-tmux.sh" "$@"

--- a/beaker-tests/Sanity/copr-cli-basic-operations/auto-createrepo.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/auto-createrepo.sh
@@ -25,13 +25,22 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
+        if [[ $STORAGE == "pulp" ]]; then
+            urls=(
+                $PULP_CONTENT_URL/$PROJECT_T/$CHROOT-devel
+                $PULP_CONTENT_URL/$PROJECT_T/$CHROOT
+                $PULP_CONTENT_URL/$PROJECT_F/$CHROOT
+            )
+        else
+            urls=(
+                $BACKEND_URL/results/$PROJECT_T/$CHROOT/devel
+                $BACKEND_URL/results/$PROJECT_T/$CHROOT
+                $BACKEND_URL/results/$PROJECT_F/$CHROOT
+            )
+        fi
         while true; do
             success=:
-            for url in \
-                $BACKEND_URL/results/$PROJECT_T/$CHROOT/devel \
-                $BACKEND_URL/results/$PROJECT_T/$CHROOT \
-                $BACKEND_URL/results/$PROJECT_F/$CHROOT ;
-            do
+            for url in "${urls[@]}"; do
                 # all those must be created ^^^
                 check_repo "$url" && continue
                 success=false
@@ -47,7 +56,11 @@ rlJournalStart
         rlRun "copr-cli build $PROJECT_T $HELLO"
 
         rlLog "The devel repo must not exist in $PROJECT_F, till we flip the config"
-        rlRun "check_repo $BACKEND_URL/results/$PROJECT_F/$CHROOT/devel" 22
+        if [[ $STORAGE == "pulp" ]]; then
+            rlRun "check_repo $PULP_CONTENT_URL/$PROJECT_F/$CHROOT-devel" 22
+        else
+            rlRun "check_repo $BACKEND_URL/results/$PROJECT_F/$CHROOT/devel" 22
+        fi
 
 
         rlRun "copr-cli modify --disable_createrepo true $PROJECT_F"

--- a/beaker-tests/Sanity/copr-cli-basic-operations/config
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/config
@@ -14,6 +14,13 @@ frontend_host_from_url=${FRONTEND_URL//*\/\//}
 : "${OWNER=@copr}"
 : "${VENDOR=Fedora Copr (devel) - group @copr}"
 : "${DISTGIT_BRANCH_FEDORA_PREFIX=f}"
+: "${PULP_CONTENT_URL=https://packages.redhat.com/api/pulp-content/public-copr-stage}"
+
+if [[ -n $PULP_CONTENT_URL ]]; then
+    : "${STORAGE=pulp}"
+else
+    : "${STORAGE=backend}"
+fi
 
 # Owner and project
 NAME_VAR="TEST$(date +%s%N)" # names should be unique

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-appstream.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-appstream.sh
@@ -32,6 +32,14 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
+        # Pulp doesn't support appstream metadata yet
+        # See https://github.com/fedora-copr/copr/issues/3499
+        # See https://github.com/pulp/pulp_rpm/issues/2432
+        if [[ $STORAGE == "pulp" ]]; then
+            rlLog "Skipping, Pulp doesn't support appstream metadata yet"
+            exit 0
+        fi
+
         # Create a project with appstream option turned on, and make sure
         # it is generated into the repodata
         rlRun "copr-cli create --chroot $CHROOT ${NAME_PREFIX}Appstream --appstream off"

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-regenerate-repos.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-regenerate-repos.sh
@@ -13,7 +13,12 @@ rlJournalStart
 
     rlPhaseStartTest
         PROJECT=${NAME_PREFIX}RegenerateRepos
-        URL="$BACKEND_URL/results/$PROJECT/$CHROOT/repodata/"
+
+        if [[ $STORAGE == "pulp" ]]; then
+            URL="$PULP_CONTENT_URL/$PROJECT/$CHROOT/repodata/"
+        else
+            URL="$BACKEND_URL/results/$PROJECT/$CHROOT/repodata/"
+        fi
 
         # Create a project that doesn't generate repositories automatically
         # and build some package in it
@@ -21,7 +26,8 @@ rlJournalStart
         rlRun "copr-cli build $PROJECT $HELLO"
 
         # The repository shouldn't provide any packages
-        rlRun "wget -r -np -P /tmp/$PROJECT/1 $URL"
+        rlRun "mkdir -p /tmp/$PROJECT/"
+        rlRun "lftp -c mirror $URL /tmp/$PROJECT/1"
         FILELISTS=`find /tmp/$PROJECT/1/ -name "*-filelists.xml.gz"`
         rlRun "gunzip -c $FILELISTS |grep 'packages=\"0\"'"
 
@@ -31,7 +37,7 @@ rlJournalStart
         sleep 60
 
         # Once the repository is regenerated, some packages should be available
-        rlRun "wget -r -np -P /tmp/$PROJECT/2 $URL"
+        rlRun "lftp -c mirror $URL /tmp/$PROJECT/2"
         FILELISTS=`find /tmp/$PROJECT/2/ -name "*-filelists.xml.gz"`
         rlRun "gunzip -c $FILELISTS |grep 'packages=\"4\"'"
     rlPhaseEnd

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-storage.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-storage.sh
@@ -34,6 +34,18 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
+        # The point of this file was to have a minimal set of tests that is
+        # run against all supported storages. However, some Copr instances
+        # don't use Pulp and therefore it doesn't make sense to run this
+        # test against them. This is all a temporary situation anyway,
+        # the proper way of doing things is going to be
+        # https://github.com/fedora-copr/copr/issues/4205
+        # and we are going to run the full beaker test suite there
+        if [[ $STORAGE == "backend" ]]; then
+            rlLog "Skipping, this Copr instance doesn't use Pulp"
+            exit 0
+        fi
+
         for storage in "backend" "pulp"; do
             project="$PROJECT-$storage"
             rlRun "copr-cli create --chroot $CHROOT $project --storage $storage"

--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest.sh
@@ -39,6 +39,8 @@ rlJournalStart
         setup_checks
         # and install... things
         yum -y install dnf dnf-plugins-core
+        # the info package is needed as a dependency of the hello
+        dnf -y install info
         TMP=`mktemp -d`
     rlPhaseEnd
 

--- a/testing-farm/all-on-single-host.sh
+++ b/testing-farm/all-on-single-host.sh
@@ -16,6 +16,9 @@ export FRONTEND_PUBLIC_HOST
 export FRONTEND_HOST=127.0.0.1
 export FRONTEND_URL=https://$FRONTEND_HOST
 export BACKEND_URL=$FRONTEND_URL
+export PULP_CONTENT_URL=""
+export STORAGE="backend"
+
 export VENDOR="Testing Copr - user single-host-testing"
 
 SCRIPT_DIR="."

--- a/testing-farm/prepare/roles/client/tasks/main.yaml
+++ b/testing-farm/prepare/roles/client/tasks/main.yaml
@@ -63,6 +63,7 @@
       - util-linux-script
       - vim
       - wget
+      - lftp
 
 - name: test environment hacks, inspired by DockerTestEnv/Dockerfile
   shell: |


### PR DESCRIPTION
See #4210

I started preparing for the release and found out several tests are broken, mainly because of the switch to Pulp as a default storage.