### PR TITLE
frontend: don't require admin permissions to show the rebuild button

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/package.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/package.html
@@ -21,6 +21,9 @@
 
 {% if g.user and g.user.can_edit(copr) %}
 {{ copr_package_delete_form(package, page, class="pull-right button-build-action") }}
+{% endif %}
+
+{% if g.user and g.user.can_build_in(copr) %}
 <a class="btn btn-default pull-right button-build-action" href="{{ copr_url('coprs_ns.copr_rebuild_package', copr, package_name=package.name) }}">
   <span class="pficon pficon-restart"></span> Rebuild
 </a>


### PR DESCRIPTION
Fix #4261