### PR TITLE
rpmbuild: AFAIK there is no python3-dnf5 only python3-libdnf5

### DIFF
--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -145,7 +145,7 @@ Requires: yum-utils
 %latest_requires dnf5-plugins
 %endif
 
-%latest_requires python3-dnf5
+%latest_requires python3-libdnf5
 %latest_requires dist-git-client
 %latest_requires libdnf5
 %latest_requires librepo


### PR DESCRIPTION
See PR #4215