### PR TITLE
frontend: limit the maximum avatar width

### DIFF
--- a/frontend/coprs_frontend/coprs/static/copr.css
+++ b/frontend/coprs_frontend/coprs/static/copr.css
@@ -186,6 +186,9 @@ img.avatar {
   padding: 4px;
   border: 1px solid #ddd;
   border-radius: 4px;
+  box-sizing: content-box;
+  max-width: 80px;
+  max-height: 80px;
 }
 
 .alert ul {


### PR DESCRIPTION
This prevents the page layout from breaking if the libravatar server serves an image with the incorrect default size (80x80 pixels).

The bug can be reproduced by visiting my profile in the production environment: <https://copr.fedorainfracloud.org/coprs/bradan/> (I am fully aware that this is my fault for hosting a non-compliant libravatar server 😅)