### PR TITLE
rpmbuild: open spec file as read-only

### DIFF
--- a/.github/workflows/python-diff-lint.yml
+++ b/.github/workflows/python-diff-lint.yml
@@ -38,6 +38,8 @@ jobs:
           linter_tags: |
             pylint
             ruff
+          install_rpm_packages: |
+            python3-specfile
 
       - name: Upload artifact with detected defects in SARIF format
         uses: actions/upload-artifact@v7

--- a/rpmbuild/copr_rpmbuild/helpers.py
+++ b/rpmbuild/copr_rpmbuild/helpers.py
@@ -415,7 +415,8 @@ class Spec:
         try:
             # TODO We want to loop over all name-version chroots and parse the
             # spec values for each of them. For that, we will set dist macros.
-            self.spec = Specfile(path, macros=macros)
+            with open(path, "r", **Specfile.ENCODING_ARGS) as fd:
+                self.spec = Specfile(file=fd, macros=macros)
         except TypeError as ex:
             raise RuntimeError("No .spec file") from ex
         except OSError as ex:


### PR DESCRIPTION
We never modify the spec file; therefore, it is safer to provide python-specfile with a read-only file descriptor.  This prevents tracebacks that occur when python-specfile attempts to open a read-only file using default parameters (which defaults to 'r+' read-write).

Exception appeared during handling spec file: /var/lib/copr-rpmbuild/results/argparse-manpage.spec Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/copr_rpmbuild/helpers.py", line 418, in __init__
    self.spec = Specfile(path, macros=macros)
                ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/specfile/specfile.py", line 105, in __init__
    self._file = Path(path).open("r+", **self.ENCODING_ARGS)
                 ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/pathlib/__init__.py", line 771, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/var/lib/copr-rpmbuild/results/argparse-manpage.spec'

Fixes: #4266