### PR TITLE
rpmbuild: avoid ugly traceback for invalid --task-url and -r

### DIFF
--- a/rpmbuild/main.py
+++ b/rpmbuild/main.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import argparse
 import json
+
 import logging
 import shutil
 import pprint
@@ -14,6 +15,7 @@ import shlex
 from urllib.parse import urljoin, urlencode
 
 import daemon
+import requests.exceptions
 
 from copr_common.request import SafeRequest, RequestError
 from copr_common.helpers import nullcontext
@@ -97,6 +99,12 @@ def main_daemon(args, config):
     try:
         fcntl.lockf(lockfd, fcntl.LOCK_EX, 1)
         init(args, config)
+
+        if args.chroot and '/' in args.chroot:
+            raise RuntimeError(
+                "The -r/--chroot option expects a chroot name "
+                "(e.g. fedora-rawhide-x86_64), not a file path"
+            )
 
         if args.dump_configs:
             action = dump_configs
@@ -281,16 +289,20 @@ def dump_configs(args, config):
 
 
 def get_vanilla_build_config(url):
+    request = SafeRequest(log=log)
+    response = request.get(url)
     try:
-        request = SafeRequest(log=log)
-        response = request.get(url)
         build_config = response.json()
-        if not build_config:
-            raise RuntimeError("No valid build_config at {0}".format(url))
-        return build_config
-
-    except json.decoder.JSONDecodeError as ex:
-        raise RuntimeError("No valid build_config at {0}".format(url)) from ex
+    # simplejson.JSONDecodeError too, but to avoid hard dependency on simplejson
+    # I use its parent ValueError
+    except (json.JSONDecodeError, ValueError,
+            requests.exceptions.JSONDecodeError) as ex:
+        raise RuntimeError(
+            f"No valid build_config (JSON) at {url}"
+        ) from ex
+    if not build_config:
+        raise RuntimeError(f"No valid build_config at {url}")
+    return build_config
 
 
 def read_task_from_file(path):


### PR DESCRIPTION
The get_vanilla_build_config() function caught json.decoder.JSONDecodeError, but response.json() raises requests.exceptions.JSONDecodeError when simplejson is installed. That exception doesn't inherit from json.decoder.JSONDecodeError in all requests versions, so the traceback leaked to the user. Fix by catching ValueError, the common base class of all JSON decode error variants.

Also validate the -r/--chroot option early: reject values containing '/' since the option expects a chroot name (e.g. fedora-rawhide-x86_64), not a mock config file path.

More deeply on why change json.decoder.JSONDecodeError to ValueError:

● The bug itself was caused by this mismatch. response.json() from the
  requests library raises requests.exceptions.JSONDecodeError, not
  json.decoder.JSONDecodeError. When simplejson is installed (as it was in the
  bug report), the inheritance chain is:

  requests.exceptions.JSONDecodeError
    → InvalidJSONError → RequestException → OSError
    → simplejson.errors.JSONDecodeError → ValueError

  So except json.decoder.JSONDecodeError simply didn't catch it — that's what
  produced the ugly traceback.

  ValueError is the narrowest common ancestor that catches all three variants:
  - json.JSONDecodeError → ValueError
  - simplejson.JSONDecodeError → ValueError
  - requests.exceptions.JSONDecodeError → ValueError (via either of the above)

Fixes: #3486

Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>