### PR TITLE
ci: detect the latest Fedora stable version

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/config
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/config
@@ -31,8 +31,8 @@ USER=`copr-cli whoami`
 # Some tests might want to install built packages
 # Therefore, these packages need to be built for the same fedora version
 # as this script is going to be run from
-FEDORA_VERSION=43
-PREV_FEDORA_VERSION=42
+FEDORA_VERSION=$(resolve-fedora-aliases fedora-latest-stable -o version)
+PREV_FEDORA_VERSION=$(( FEDORA_VERSION - 1 ))
 
 CHROOT="fedora-$FEDORA_VERSION-x86_64"
 PREV_CHROOT="fedora-$PREV_FEDORA_VERSION-x86_64"

--- a/testing-farm/prepare/roles/client/tasks/main.yaml
+++ b/testing-farm/prepare/roles/client/tasks/main.yaml
@@ -56,6 +56,7 @@
       - net-tools
       - procps-ng
       - python3-behave
+      - python3-fedora-distro-aliases
       - python3-hamcrest
       - rpm-build
       - sudo


### PR DESCRIPTION
Packit automatically selects the latest Fedora version (currently F44), and our testsuite needs to automatically move to that version, too.