### PR TITLE
ci: temporarily use F43 testing environment

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -195,7 +195,7 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-latest-stable-x86_64
+      - fedora-43-x86_64
     packages:
       - copr-frontend
     skip_build: true


### PR DESCRIPTION
This is to work-around problems spotted by #4285 (Fedora 44 tests would need some fixes).