### PR TITLE
backend: log for what projects we are removing repositories in Pulp

### DIFF
--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -521,9 +521,14 @@ class PulpStorage(Storage):
         return True
 
     def delete_repository(self, chroot):
+        name = self._repository_name(chroot)
         repository = self._get_repository(chroot)
-        distribution = self._get_distribution(chroot)
+        self.log.info("Removing Pulp repository: %s", name)
         self.client.delete_repository(repository)
+
+        name = self._distribution_name(chroot)
+        distribution = self._get_distribution(chroot)
+        self.log.info("Removing Pulp distribution: %s", name)
         self.client.delete_distribution(distribution)
 
     def delete_project(self, dirname):
@@ -531,8 +536,11 @@ class PulpStorage(Storage):
         response = self.client.list_distributions(prefix)
         distributions = response.json()["results"]
         for distribution in distributions:
+            name = distribution["name"]
+            self.log.info("Removing Pulp distribution for %s", name)
             self.client.delete_distribution(distribution["pulp_href"])
             if distribution["repository"]:
+                self.log.info("Removing Pulp repository for %s", name)
                 self.client.delete_repository(distribution["repository"])
 
     def delete_builds(self, dirname, chroot_builddirs, build_ids):


### PR DESCRIPTION
Currently we are logging only the Pulp hrefs that we are deleting.

    Pulp: delete_repository: /api/pulp/public-copr/api/v3/repositories/rpm/rpm/019dd4a8-00cc-7ba1-b0ac-40239e6445a7/
    Pulp: delete_distribution: /api/pulp/public-copr/api/v3/distributions/rpm/rpm/019dd4a8-04d6-7182-82f7-98f146df8232/

Which is not enough information. We IMHO have no way to retroactively map these to their respective Copr projects.