### PR TITLE
backend: fix prefix so it can't accidentally match multiple projects

### DIFF
--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -527,7 +527,7 @@ class PulpStorage(Storage):
         self.client.delete_distribution(distribution)
 
     def delete_project(self, dirname):
-        prefix = "{0}/{1}".format(self.owner, dirname)
+        prefix = "{0}/{1}/".format(self.owner, dirname)
         response = self.client.list_distributions(prefix)
         distributions = response.json()["results"]
         for distribution in distributions:


### PR DESCRIPTION
Fix #4290

What happened in this instance:

1. The project `@fedora-llvm-team/llvm-snapshots-big-merge-20260428` was successfully created with all of its Pulp repositories and distributions
2. Somebody removed a different project `@fedora-llvm-team/llvm-snapshots`. See the action `2624884` for more details.
3. The `name__startswith` accidentally matched both these projects and removed their repositories, distributions, everything

What an embarrassing bug, sorry about that. The reason why we did `startswith` instead of an exact match was to match all chroots within a project. The repository and distribution names look like this:

    @fedora-llvm-team/llvm-snapshots/fedora-rawhide-x86_64
    @fedora-llvm-team/llvm-snapshots/fedora-44-x86_64
    @fedora-llvm-team/llvm-snapshots/rhel-8-x86_64

Changing the searched prefix to end with `/` should fix this problem.