### PR TITLE
backend: fix rpmeta HW pools warning leaking to stderr

### DIFF
--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -25,7 +25,6 @@ import subprocess
 
 import munch
 from munch import Munch
-import yaml
 
 from copr_common.redis_helpers import get_redis_connection
 from copr.v3 import Client
@@ -249,25 +248,6 @@ def _get_limits_conf(parser):
     return limits
 
 
-def _load_rpmeta_hw_info(config_path):
-    """
-    Load rpmeta hardware pool definitions from a YAML file.
-    Returns an empty dict if the file is missing or unparseable.
-    """
-    log = logging.getLogger(__name__)
-    if not config_path or not os.path.exists(config_path):
-        log.warning("rpmeta: HW pools config not found at %s, "
-                     "predictions disabled", config_path)
-        return {}
-    try:
-        with open(config_path, "r", encoding="utf-8") as fh:
-            return yaml.safe_load(fh) or {}
-    except (yaml.YAMLError, OSError) as exc:
-        log.warning("rpmeta: failed to parse HW pools config %s: %s",
-                     config_path, exc)
-        return {}
-
-
 class BackendConfigReader(object):
     def __init__(self, config_file=None, ext_opts=None):
         self.config_file = config_file or "/etc/copr/copr-be.conf"
@@ -461,10 +441,9 @@ class BackendConfigReader(object):
             cp, "backend", "rpmeta_url", None)
         opts.rpmeta_timeout = _get_conf(
             cp, "backend", "rpmeta_timeout", 5, mode="int")
-        rpmeta_hw_pools_config = _get_conf(
+        opts.rpmeta_hw_pools_config = _get_conf(
             cp, "backend", "rpmeta_hw_pools_config",
             "/etc/copr/rpmeta-hw-pools.yaml")
-        opts.rpmeta_hw_info = _load_rpmeta_hw_info(rpmeta_hw_pools_config)
 
         # thoughts for later
         # ssh key for connecting to builders?

--- a/backend/copr_backend/rpmeta.py
+++ b/backend/copr_backend/rpmeta.py
@@ -7,6 +7,7 @@ import logging
 import os
 
 import requests
+import yaml
 
 from copr_backend.helpers import create_file_logger
 
@@ -22,6 +23,39 @@ def _get_predictions_logger(log_dir):
     logger.setLevel(logging.INFO)
     logger.propagate = False
     return logger
+
+
+def _load_rpmeta_hw_info(config_path, log):
+    """
+    Load rpmeta hardware pool definitions from a YAML file.
+    Returns an empty dict if the file is missing or unparseable.
+    """
+    if not config_path or not os.path.exists(config_path):
+        log.warning("rpmeta: HW pools config not found at %s, "
+                     "predictions disabled", config_path)
+        return {}
+    try:
+        with open(config_path, "r", encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+    except (yaml.YAMLError, OSError) as exc:
+        log.warning("rpmeta: failed to parse HW pools config %s: %s",
+                     config_path, exc)
+        return {}
+
+
+def _get_hw_info(opts, log):
+    """
+    Return the parsed HW pool info dict, loading from YAML on first call.
+    The result is cached on the opts object itself.
+    """
+    try:
+        return opts._rpmeta_hw_info_cached
+    except AttributeError:
+        pass
+    config_path = getattr(opts, "rpmeta_hw_pools_config", None)
+    hw_info = _load_rpmeta_hw_info(config_path, log)
+    opts._rpmeta_hw_info_cached = hw_info
+    return hw_info
 
 
 def parse_version(package_version):
@@ -77,7 +111,7 @@ def _rpmeta_predict_inner(job, opts, log):  # pylint: disable=too-many-return-st
     if job.chroot == "srpm-builds":
         return None
 
-    hw_info_map = getattr(opts, "rpmeta_hw_info", {})
+    hw_info_map = _get_hw_info(opts, log)
     if not hw_info_map:
         return None
 

--- a/backend/tests/test_rpmeta.py
+++ b/backend/tests/test_rpmeta.py
@@ -10,10 +10,10 @@ from unittest import mock
 
 import pytest
 import requests
-import yaml
+from munch import Munch
 
 from copr_backend import rpmeta
-from copr_backend.helpers import _load_rpmeta_hw_info
+from copr_backend.rpmeta import _load_rpmeta_hw_info
 
 
 SAMPLE_HW_CONFIG = """\
@@ -34,8 +34,6 @@ aarch64:
   swap: 0.0
 """
 
-SAMPLE_HW_INFO = yaml.safe_load(SAMPLE_HW_CONFIG)
-
 
 def _make_job(**kwargs):
     defaults = {
@@ -51,15 +49,19 @@ def _make_job(**kwargs):
 
 
 def _make_opts(tmpdir, **overrides):
+    hw_path = os.path.join(tmpdir, "hw-info.yaml")
+    if not os.path.exists(hw_path):
+        with open(hw_path, "w", encoding="utf-8") as fh:
+            fh.write(SAMPLE_HW_CONFIG)
     defaults = {
         "rpmeta_enabled": True,
         "rpmeta_url": "http://localhost:44882",
         "rpmeta_timeout": 5,
-        "rpmeta_hw_info": SAMPLE_HW_INFO,
+        "rpmeta_hw_pools_config": hw_path,
         "log_dir": tmpdir,
     }
     defaults.update(overrides)
-    return mock.MagicMock(**defaults)
+    return Munch(defaults)
 
 
 @pytest.fixture(autouse=True)
@@ -87,25 +89,33 @@ def config_file(tmpdir):
 
 class TestLoadRpmetaHwInfo:
     def test_loads_valid_config(self, config_file):
-        data = _load_rpmeta_hw_info(config_file)
+        log = mock.MagicMock()
+        data = _load_rpmeta_hw_info(config_file, log)
         assert "x86_64" in data
         assert data["x86_64"]["cpu_arch"] == "x86_64"
         assert data["aarch64"]["cpu_cores"] == 4
+        log.warning.assert_not_called()
 
     def test_missing_file_returns_empty(self, tmpdir):
-        data = _load_rpmeta_hw_info(os.path.join(tmpdir, "nonexistent.yaml"))
+        log = mock.MagicMock()
+        data = _load_rpmeta_hw_info(os.path.join(tmpdir, "nonexistent.yaml"), log)
         assert data == {}
+        log.warning.assert_called()
 
     def test_none_path_returns_empty(self):
-        data = _load_rpmeta_hw_info(None)
+        log = mock.MagicMock()
+        data = _load_rpmeta_hw_info(None, log)
         assert data == {}
+        log.warning.assert_called()
 
     def test_invalid_yaml_returns_empty(self, tmpdir):
+        log = mock.MagicMock()
         path = os.path.join(tmpdir, "bad.yaml")
         with open(path, "w", encoding="utf-8") as fh:
             fh.write("{{{{not valid yaml: [")
-        data = _load_rpmeta_hw_info(path)
+        data = _load_rpmeta_hw_info(path, log)
         assert data == {}
+        log.warning.assert_called()
 
 
 class TestParseVersion:


### PR DESCRIPTION
_load_rpmeta_hw_info() used a module-level logger that propagated to the root StreamHandler, which is the only handler available at BackendConfigReader.read() time. Remove the warning -- an empty dict already signals "predictions disabled" and the build path handles it silently.