### PR TITLE
build_aux: fix container-based unit test workflow

### DIFF
--- a/build_aux/Containerfile.unittest
+++ b/build_aux/Containerfile.unittest
@@ -1,15 +1,36 @@
-FROM fedora:39
+FROM fedora:latest
 
-RUN dnf update -y && dnf install python-pytest-cov copr-dist-git rpmdevtools python3-copr copr-cli dnf-plugins-core -y
+RUN dnf install -y \
+    dnf-plugins-core \
+    python-pytest-cov \
+    redis \
+    rpmdevtools \
+    vcs-diff-lint \
+    && dnf clean all
 
-RUN useradd copr_user
+WORKDIR /tmp/specs
+COPY backend/copr-backend.spec backend/
+COPY frontend/copr-frontend.spec frontend/
+COPY cli/copr-cli.spec cli/
+COPY dist-git/copr-dist-git.spec dist-git/
+COPY rpmbuild/copr-rpmbuild.spec rpmbuild/
+COPY keygen/copr-keygen.spec keygen/
+COPY common/python-copr-common.spec common/
+COPY messaging/copr-messaging.spec messaging/
+COPY python/python-copr.spec python/
+
+RUN dnf builddep -y \
+    backend/copr-backend.spec \
+    frontend/copr-frontend.spec \
+    cli/copr-cli.spec \
+    dist-git/copr-dist-git.spec \
+    rpmbuild/copr-rpmbuild.spec \
+    keygen/copr-keygen.spec \
+    common/python-copr-common.spec \
+    messaging/copr-messaging.spec \
+    python/python-copr.spec \
+    && dnf clean all
+
+RUN groupadd -g 1000 copr_user && useradd -u 1000 -g 1000 copr_user
 USER copr_user
-WORKDIR /home/copr_user/copr
-COPY --chown=copr_user . /home/copr_user/copr
-
-USER root
-RUN dnf builddep *.spec -y
-USER copr_user
-
-# bind the code from local machine here
-WORKDIR /home/copr_user/copr_bind
+WORKDIR /copr

--- a/build_aux/per-subdir-makefile
+++ b/build_aux/per-subdir-makefile
@@ -1,5 +1,6 @@
 COPR_TEST_IMAGE ?= copr_test_image
 CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
+COMPONENT = $(notdir $(CURDIR))
 
 .PHONY: check test lint unittests
 
@@ -17,11 +18,15 @@ lint:
 	vcs-diff-lint
 
 build-test-image:
-	$(CONTAINER_ENGINE) build -f ../build_aux/Containerfile.unittest . -t $(COPR_TEST_IMAGE)
+	$(CONTAINER_ENGINE) build -f ../build_aux/Containerfile.unittest .. -t $(COPR_TEST_IMAGE)
 
 enter-test-image:
-	$(CONTAINER_ENGINE) run -v .:/home/copr_user/copr_bind:Z -ti $(COPR_TEST_IMAGE) /bin/bash
+	$(CONTAINER_ENGINE) run --userns=keep-id:uid=1000,gid=1000 -v ..:/copr:z -w /copr/$(COMPONENT) -ti $(COPR_TEST_IMAGE) /bin/bash
 
 unittest-in-container:
-	$(CONTAINER_ENGINE) run --rm -v .:/home/copr_user/copr_bind:Z \
-		-it $(COPR_TEST_IMAGE) /bin/sh -c "./run_tests.sh -vvv -s --no-coverage"
+	$(CONTAINER_ENGINE) run --rm --userns=keep-id:uid=1000,gid=1000 -v ..:/copr:z \
+		$(COPR_TEST_IMAGE) /bin/bash -c "cd $(COMPONENT) && ./run_tests.sh --no-cov -vv -s"
+
+lint-in-container:
+	$(CONTAINER_ENGINE) run --rm --userns=keep-id:uid=1000,gid=1000 -v ..:/copr:z \
+		$(COPR_TEST_IMAGE) /bin/bash -c "cd $(COMPONENT) && vcs-diff-lint"

--- a/cli/run_tests.sh
+++ b/cli/run_tests.sh
@@ -1,3 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
-PYTHONPATH=../python/:./copr_cli:$PYTHONPATH python3 -B -m pytest --cov-report term-missing --cov ./copr_cli/ $@
+COVPARAMS=(--cov-report term-missing --cov ./copr_cli/)
+
+KEEP_ARGS=()
+for arg; do
+    case $arg in
+    --nocov|--no-cov)
+        COVPARAMS=()
+        ;;
+    *)
+        KEEP_ARGS+=("$arg")
+        ;;
+    esac
+done
+
+PYTHONPATH="../python/:./copr_cli${PYTHONPATH:+:$PYTHONPATH}" python3 -B -m pytest "${COVPARAMS[@]}" "${KEEP_ARGS[@]}"

--- a/common/run_tests.sh
+++ b/common/run_tests.sh
@@ -1,3 +1,17 @@
-#! /bin/bash
+#!/bin/bash
 
-python3 -B -m pytest --cov-report term-missing --cov ./copr_common/ $@
+COVPARAMS=(--cov-report term-missing --cov ./copr_common/)
+
+KEEP_ARGS=()
+for arg; do
+    case $arg in
+    --nocov|--no-cov)
+        COVPARAMS=()
+        ;;
+    *)
+        KEEP_ARGS+=("$arg")
+        ;;
+    esac
+done
+
+python3 -B -m pytest "${COVPARAMS[@]}" "${KEEP_ARGS[@]}"

--- a/keygen/run_tests.sh
+++ b/keygen/run_tests.sh
@@ -14,4 +14,4 @@ for arg; do
     esac
 done
 
-PYTHONPATH=./src:$PYTHONPATH python3 -B -m pytest "${COVPARAMS[@]}" tests "${KEEP_ARGS[@]}"
+PYTHONPATH="./src${PYTHONPATH:+:$PYTHONPATH}" python3 -B -m pytest "${COVPARAMS[@]}" tests "${KEEP_ARGS[@]}"

--- a/messaging/run_tests.sh
+++ b/messaging/run_tests.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 set -e
 
@@ -6,4 +6,13 @@ dir=$(dirname "$(readlink -f "$0")")
 export PYTHONPATH=$dir:$dir/../common
 
 cd "$dir"
-python3 -m pytest -s copr_messaging/tests
+
+KEEP_ARGS=()
+for arg; do
+    case $arg in
+    --nocov|--no-cov) ;;
+    *) KEEP_ARGS+=("$arg") ;;
+    esac
+done
+
+python3 -m pytest -s copr_messaging/tests "${KEEP_ARGS[@]}"

--- a/python/run_tests.sh
+++ b/python/run_tests.sh
@@ -9,4 +9,17 @@ coverage=(
     --cov-report term-missing
     --cov copr/v3
 )
-python3 -B -m pytest "${coverage[@]}" copr/test "$@"
+
+KEEP_ARGS=()
+for arg; do
+    case $arg in
+    --nocov|--no-cov)
+        coverage=()
+        ;;
+    *)
+        KEEP_ARGS+=("$arg")
+        ;;
+    esac
+done
+
+python3 -B -m pytest "${coverage[@]}" copr/test "${KEEP_ARGS[@]}"

--- a/releng/detect-changed-packages
+++ b/releng/detect-changed-packages
@@ -31,8 +31,15 @@ cd "$(git rev-parse --show-toplevel)"
 git diff --name-status -C "$diff_against" --numstat | cut -f2 | sed 's|/.*||' \
 | sort | uniq | while read -r line; do
     case $line in
-        backend|frontend|cli|keygen|dist-git|messaging|rpmbuild|selinux)
+        backend|frontend|cli|keygen|dist-git|rpmbuild|selinux)
             echo "copr-$line"
+            ;;
+        messaging)
+            if test -z "$PYTHON_PKG_SUFFIX"; then
+                echo "copr-$line"
+            else
+                echo "python${PYTHON_PKG_SUFFIX}-copr-$line"
+            fi
             ;;
         python)
             echo "python$PYTHON_PKG_SUFFIX-copr"

--- a/rpmbuild/run_tests.sh
+++ b/rpmbuild/run_tests.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-args=()
-
 coverage=( --cov-report term-missing --cov bin --cov copr_rpmbuild --cov copr_distgit_client )
+
+KEEP_ARGS=()
 for arg; do
     case $arg in
-    --no-coverage) coverage=() ;;
-    *) args+=( "$arg" ) ;;
+    --nocov|--no-cov|--no-coverage) coverage=() ;;
+    *) KEEP_ARGS+=( "$arg" ) ;;
     esac
 done
 
@@ -16,4 +16,4 @@ abspath=$(readlink -f .)
 common_path=$(readlink -f "$abspath"/../common)
 export PYTHONPATH="${PYTHONPATH+$PYTHONPATH:}$common_path:$abspath"
 export PATH=$(readlink -f bin):$PATH
-"${PYTHON:-python3}" -m pytest -s tests "${coverage[@]}" "${args[@]}"
+"${PYTHON:-python3}" -m pytest -s tests "${coverage[@]}" "${KEEP_ARGS[@]}"


### PR DESCRIPTION
Fix Containerfile.unittest to install build deps from individual spec
files instead of globbing, use fedora:latest, and mount the full repo
tree. Update per-subdir-makefile to use --userns=keep-id for rootless
podman and add a lint-in-container target.

Unify --no-cov flag handling across all run_tests.sh scripts so
container-based runs can skip coverage consistently.

This does not affect old way of running unit tests and lints locally.
It fixes my old workflow for running it in containers also to allow it
for my AI agent to run it flawlesly.

Obviously I wasn't sure how to do this properly 3 years ago and after a while it become unusable to perform unit tests and lints in container (read as without copr dependencies on my machine)