### PR TITLE
packit: add stable status name for testing-farm job

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -200,6 +200,7 @@ jobs:
       - copr-frontend
     skip_build: true
     manual_trigger: true
+    status_name_template: "packit/testing-farm/gating/{package}"
 
   # Main commit builds:
   #


### PR DESCRIPTION
This allows using GitHub required status checks to block merging PRs that haven't run /packit test, without needing to update the check name every time the target changes.

See https://packit.dev/docs/configuration#status_name_template

Fix #4287