### PR TITLE
docker: use Pulp as default storage

### DIFF
--- a/docker/frontend/files/etc/copr/copr.conf
+++ b/docker/frontend/files/etc/copr/copr.conf
@@ -167,6 +167,7 @@ USAGE_TREEMAP_TEAMS = {
 # OIDC_TOKEN_URL=""
 # OIDC_USERINFO_URL=""
 
+DEFAULT_STORAGE = "pulp"
 PULP_CONTENT_URL = "http://pulp:80/pulp/content"
 
 # When running the website through apache,


### PR DESCRIPTION
At this point all new Copr projects use Pulp, so it's best to develop with that in mind.