### PR TITLE
Change the URL to work with the new API

### DIFF
--- a/frontend/coprs_frontend/coprs/templates/_helpers.html
+++ b/frontend/coprs_frontend/coprs/templates/_helpers.html
@@ -143,8 +143,8 @@
     {# hide the buttons after 13 days (logs are deleted after 14 days) #}
     {% if not (timestamp|is_older_than_days(13)) %}
       {% if failed_log_url %}
-        {% set url = "https://log-detective.com/explain?url=%s" %}
-        <a href="{{ url | format(failed_log_url | urlencode) }}"
+        {% set url = "https://log-detective.com/explain/copr/%s/%s" %}
+        <a href="{{ url | format(build_id, chroot_name) }}"
           class="pficon pficon-info"
           title="See what AI can tell you about the build failure">
           Ask AI


### PR DESCRIPTION
New API released with https://github.com/fedora-copr/logdetective-website/releases/tag/v0.32.0 allows submission of all logs from the build. Copr should use it instead of the legacy `url` endpoint, which allowed only a single log file.

Until this change is merged and released, the original endpoint will remain operational. 