### PR TITLE
frontend: don't fail pending-actions when copr is None

### DIFF
--- a/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
+++ b/frontend/coprs_frontend/coprs/views/backend_ns/backend_general.py
@@ -312,10 +312,14 @@ def pending_actions():
             # https://github.com/fedora-copr/copr/issues/2698
             continue
 
+        project_owner = None
+        if action.copr:
+            project_owner = action.copr.owner_name
+
         data.append({
             'id': action.id,
             'priority': action.priority or action.default_priority,
-            "project_owner": action.copr.owner_name,
+            "project_owner": project_owner,
         })
 
     return flask.json.dumps(data)


### PR DESCRIPTION
Fix #4322