### PR TITLE
doc: update URLs for Fedora Infra SOPs

### DIFF
--- a/doc/how_to_release_copr.rst
+++ b/doc/how_to_release_copr.rst
@@ -257,7 +257,7 @@ For each package do::
 Submit packages into stg infra tags
 ...................................
 
-Submit the pacakges into `Infra tags repo <https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/infra-repo/>`_.
+Submit the pacakges into `Infra tags repo <https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/infra-repo/>`_.
 If you don't have permissions to do this, try `@praiskup` or `@frostyx`, or someone on ``#fedora-admin`` libera.chat channel.
 
 .. warning::

--- a/doc/how_to_upgrade_persistent_instances.rst
+++ b/doc/how_to_upgrade_persistent_instances.rst
@@ -344,8 +344,8 @@ section.
 .. _`copr devel`: https://lists.fedoraproject.org/archives/list/copr-devel@lists.fedorahosted.org/
 .. _`Amazon AWS account`: https://id.fedoraproject.org/saml2/SSO/Redirect?SPIdentifier=urn:amazon:webservices&RelayState=https://console.aws.amazon.com
 .. _`Cloud Base Images`: https://fedoraproject.org/cloud/download/
-.. _`DNS SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/dns/
+.. _`DNS SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/dns/
 .. _`ec2instances.info`: https://ec2instances.info/
 .. _`helper playbook repository`: https://github.com/fedora-copr/ansible-fedora-copr
-.. _`playbook SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/ansible/
+.. _`playbook SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/ansible/
 .. _`private IP change`: https://pagure.io/fedora-infra/ansible/c/6c80a870ff2a62e73da98f7607574e534369fb37

--- a/doc/maintenance/announce_outage.rst
+++ b/doc/maintenance/announce_outage.rst
@@ -86,7 +86,7 @@ Resolved outage
 
 
 .. _`copr-devel`: https://lists.fedoraproject.org/archives/list/copr-devel@lists.fedorahosted.org/
-.. _`Fedora Outage SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/outage/
-.. _`Fedora Status SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/status-fedora/
+.. _`Fedora Outage SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/outage/
+.. _`Fedora Status SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/status-fedora/
 .. _`Fedora Copr Blog`: https://fedora-copr.github.io/
 .. _`Matrix channel`: https://matrix.to/#/#buildsys:fedoraproject.org

--- a/doc/maintenance/backup_check.rst
+++ b/doc/maintenance/backup_check.rst
@@ -74,7 +74,7 @@ For Frontend, we backup the PostgreSQL database (hourly).  Check
     -rw-r--r--. 1 postgres postgres 662M Nov  5 01:21 coprdb-2024-11-05.dump.xz
 
 If we provide such an updated tarball, `rdiff-backup
-<https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/rdiff-backup/>`_
+<https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/rdiff-backup/>`_
 periodically comes and pulls the backups "out"; as long as the box is in an
 appropriate `Ansible group
 <https://pagure.io/fedora-infra/ansible/blob/81f81668cc0ea3101cf74d56401aad3c1354f788/f/inventory/backups#_4>`_

--- a/doc/maintenance/credentials.rst
+++ b/doc/maintenance/credentials.rst
@@ -425,7 +425,7 @@ Rotation checklist
 4. Verify keygen firewall rules match current backend IPs.
 
 
-.. _`Ansible SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/ansible/
+.. _`Ansible SOP`: https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/ansible/
 .. _`sysadmin-main FAS group`: https://accounts.fedoraproject.org/group/sysadmin-main/
 .. _`root_auth_users`: https://pagure.io/fedora-infra/ansible/blob/main/f/inventory/group_vars/copr_aws
 .. _`FAS aws-copr`: https://accounts.fedoraproject.org/group/aws-copr/

--- a/doc/maintenance/hypervisors.rst
+++ b/doc/maintenance/hypervisors.rst
@@ -78,5 +78,5 @@ repository
 
 .. _`Nagios probes`: https://nagios.fedoraproject.org/nagios/cgi-bin//status.cgi?hostgroup=copr_hypervisor&style=detail
 .. _`how to install hypervisors`: https://pagure.io/fedora-infra/ansible/blob/main/f/roles/copr/hypervisor/README
-.. _`Batcave01`: https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/infra-git-repo/
+.. _`Batcave01`: https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/infra-git-repo/
 .. _`restart server in Fedora DC`: https://docs.fedoraproject.org/en-US/infra/howtos/restart_datacenter_server/

--- a/doc/maintenance/pulp.rst
+++ b/doc/maintenance/pulp.rst
@@ -4,7 +4,7 @@ Pulp maintenance
 ================
 
 In case of any suspected Pulp-related issues, follow the Fedora Infra SOP
-https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/copr/#_pulp_issues
+https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/copr/#_pulp_issues
 
 
 Migrate data to Pulp

--- a/doc/maintenance_documentation.rst
+++ b/doc/maintenance_documentation.rst
@@ -9,7 +9,7 @@ This section contains information about maintenance topics. You may also be inte
    :caption: Maintenance SOPs
    :maxdepth: 1
 
-   Fedora Infra Copr SOP <https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/copr/>
+   Fedora Infra Copr SOP <https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/copr/>
    How to release copr RPM packages <how_to_release_copr>
    How to build a hotfix <how_to_build_hotfix>
    how_to_upgrade_builders

--- a/doc/user_documentation.rst
+++ b/doc/user_documentation.rst
@@ -1096,7 +1096,7 @@ You should press Ctrl+Shift+R to invalidate your cache and reload page
 Groups membership is handled by `FAS <https://accounts.fedoraproject.org>`_. It can add/remove members to existing group. However it cannot create new group. You can create new group by `creating new fedora-infra ticket <https://pagure.io/fedora-infrastructure/new_issue>`_.
 You have to log out and then log in again to Copr so Copr can read your new
 settings.  Note also that you might need to wait a few minutes till the
-`group list gets synchronized <https://docs.fedoraproject.org/en-US/infra/sysadmin_guide/ipsilon/#_known_issues>`_.
+`group list gets synchronized <https://docs.fedoraproject.org/en-US/infra/sysadmin_sops/ipsilon/#_known_issues>`_.
 Users also reported that `logging-out first from Ipsilon <https://id.fedoraproject.org/logout>`_ might help with synchronization.
 
 Once copr knows the FAS groups you belong to, you still need to activate the


### PR DESCRIPTION
For some reason the old URLs stopped working and the new ones have `sysadmin_sops` instead of `sysadmin_guide`.