### PR TITLE
backend: block all actions and builds for @copr/PyPI and @copr/PyPI3

### DIFF
--- a/backend/copr_backend/rpm_builds.py
+++ b/backend/copr_backend/rpm_builds.py
@@ -146,7 +146,8 @@ class BlockedOwnersLimit(PredicateWorkerLimit):
             # We don't have the `name` or `full_name` available, so the next
             # best thing is checking sandbox
             pypi = ("@copr/PyPI--", "@copr/PyPI3--")
-            if x.sandbox and x.sandbox.startswith(pypi):
+            sandbox = getattr(x, "sandbox", None)
+            if sandbox and sandbox.startswith(pypi):
                 return True
             return x.owner in blocked_owners
         super().__init__(predicate, limit=0, name="blocked_users")

--- a/backend/copr_backend/rpm_builds.py
+++ b/backend/copr_backend/rpm_builds.py
@@ -143,6 +143,11 @@ class BlockedOwnersLimit(PredicateWorkerLimit):
     """
     def __init__(self, blocked_owners):
         def predicate(x):
+            # We don't have the `name` or `full_name` available, so the next
+            # best thing is checking sandbox
+            pypi = ("@copr/PyPI--", "@copr/PyPI3--")
+            if x.sandbox and x.sandbox.startswith(pypi):
+                return True
             return x.owner in blocked_owners
         super().__init__(predicate, limit=0, name="blocked_users")
 


### PR DESCRIPTION
We already migrated `@rubygems/rubygems` to Pulp and it took 10 days. Assuming it will take roughly the same, it would mean blocked actions and builds for all `@copr` projects, including for example `@copr/copr-ping`. That is a no-go.

I am proposing this change, which I don't want to merge but only apply as a hotfix, so that we can specifically block only `@copr/PyPI` and `@copr/PyPI3`. It's not worth implementing a proper project-level blocking because these are the last two project where we will really need it.