### PR TITLE
Add markup to copr-rpmbuild man page

### DIFF
--- a/rpmbuild/man/copr-rpmbuild.1.asciidoc
+++ b/rpmbuild/man/copr-rpmbuild.1.asciidoc
@@ -24,13 +24,13 @@ OPTIONS
 *--drop-resultdir*::
     Drops resultdir and its content at the beginning before continuing.
 
-*--config* _CONFIG_PATH_::
+*-c*, *--config* _CONFIG_PATH_::
     Path to an alternative config file. By default _/etc/copr-rpmbuild/main.ini_ is used.
 
-*--detached*::
-    Run build in background and output the process PID. Log into /var/lib/copr-rpmbuild/main.log.
+*-d*, *--detached*::
+    Run build in background and output the process PID. Log into _/var/lib/copr-rpmbuild/main.log_.
 
-*--chroot* _CHROOT_NAME_::
+*-r*, *--chroot* _CHROOT_NAME_::
     Name of the chroot to build for. This follows mock's convention for naming chroots (e.g. fedora-27-x86_64). See _/etc/mock_ for the full list.
 
 *--srpm*::
@@ -39,10 +39,10 @@ OPTIONS
 *--rpm*::
     Build RPM. This is the default action. Requires *--chroot* to be specified.
 
-*--verbose*::
+*-v*, *--verbose*::
     Print debugging information.
 
-*--help*::
+*-h*, *--help*::
     Display help.
 
 

--- a/rpmbuild/man/copr-rpmbuild.1.asciidoc
+++ b/rpmbuild/man/copr-rpmbuild.1.asciidoc
@@ -3,46 +3,46 @@ copr-rpmbuild(1)
 
 NAME
 ----
-copr-rpmbuild - run COPR builds.
+copr-rpmbuild - run COPR builds
 
 SYNOPSIS
 --------
-copr-rpmbuild [-c|--config CONFIG_PATH] [-d|--detached] [--drop-resultdir] [--rpm|--srpm] [-r|--chroot CHROOT_NAME] [-v|--verbose] [-h|--help] [--build-id COPR_BUILD_ID]
+*copr-rpmbuild* [*-c*|*--config* _CONFIG_PATH_] [*-d*|*--detached*] [*--drop-resultdir*] [*--rpm*|*--srpm*] [*-r*|*--chroot* _CHROOT_NAME_] [*-v*|*--verbose*] [*-h*|*--help*] [*--build-id* _COPR_BUILD_ID_]
 
 DESCRIPTION
 -----------
 Runs COPR build of the specified build ID and puts
-results into /var/lib/copr-rpmbuild/results/. The
+results into _/var/lib/copr-rpmbuild/results/_. The
 script generates target RPMs by default but it can
-also generate just an SRPM by using --srpm switch.
+also generate just an SRPM by using *--srpm* switch.
 
 OPTIONS
 -------
---build-id COPR_BUILD_ID::
+*--build-id* _COPR_BUILD_ID_::
     Run build of the specified ID.
 
---drop-resultdir::
+*--drop-resultdir*::
     Drops resultdir and its content at the beginning before continuing.
 
---config CONFIG_PATH::
-    Path to an alternative config file. By default /etc/copr-rpmbuild/main.ini is used.
+*--config* _CONFIG_PATH_::
+    Path to an alternative config file. By default _/etc/copr-rpmbuild/main.ini_ is used.
 
---detached::
+*--detached*::
     Run build in background and output the process PID. Log into /var/lib/copr-rpmbuild/main.log.
 
---chroot CHROOT_NAME::
-    Name of the chroot to build for. This follows mock's convention for naming chroots (e.g. fedora-27-x86_64). See /etc/mock for the full list.
+*--chroot* _CHROOT_NAME_::
+    Name of the chroot to build for. This follows mock's convention for naming chroots (e.g. fedora-27-x86_64). See _/etc/mock_ for the full list.
 
---srpm::
+*--srpm*::
     Build SRPM instead of building RPM.
 
---rpm::
-    Build RPM. This is the default action. Requires --chroot to be specified.
+*--rpm*::
+    Build RPM. This is the default action. Requires *--chroot* to be specified.
 
---verbose::
+*--verbose*::
     Print debugging information.
 
---help::
+*--help*::
     Display help.
 
 


### PR DESCRIPTION
This commit adds some minimal markup to the copr-rpmbuild man page, according to the rules in man-pages.7.