### PR TITLE
openshift: convert Jinja2 templates to plain OpenShift templates

### DIFF
--- a/openshift/.gitignore
+++ b/openshift/.gitignore
@@ -1,1 +1,3 @@
 secret*
+params.env
+*.b64

--- a/openshift/MIGRATION.md
+++ b/openshift/MIGRATION.md
@@ -1,0 +1,135 @@
+# Migration from Jinja2 Templates to Plain OpenShift Templates
+
+## What Changed
+
+The OpenShift deployment has been converted from Ansible + Jinja2 templates to plain OpenShift YAML templates with parameter substitution.
+
+### Old Approach (Jinja2/Ansible)
+- Used `deploy.yml` Ansible playbook
+- Jinja2 templates in `services/*.yml.j2` and `config/*.j2`
+- Variables defined in `secret-vars.yml`
+- Ansible handled image detection and secret generation
+
+### New Approach (Plain OpenShift)
+- Direct deployment with `oc` or `envsubst`
+- Plain YAML templates in `services/*.yml`
+- Parameters in environment variables or `params.env`
+- Manual configuration preparation required
+
+## File Mapping
+
+### Templates Converted
+
+| Old File (Jinja2) | New File (Plain YAML) |
+|-------------------|----------------------|
+| `project.yaml.j2` | `project.yaml` |
+| `services/backend.yml.j2` | `services/backend.yml` |
+| `services/frontend.yml.j2` | `services/frontend.yml` |
+| `services/postgres.yml.j2` | `services/postgres.yml` |
+| `services/redis.yml.j2` | `services/redis.yml` |
+| `services/distgit.yml.j2` | `services/distgit.yml` |
+| `services/resalloc.yml.j2` | `services/resalloc.yml` |
+| `services/keygen.yml.j2` | `services/keygen.yml` |
+
+### Config Files
+
+| Old File (Jinja2) | New File (Example) |
+|-------------------|-------------------|
+| `config/distgit-copr.conf.j2` | `config/distgit-copr.conf.example` |
+| `config/resalloc-aws-credentials.j2` | `config/resalloc-aws-credentials.example` |
+| `config/resalloc-pool.yaml.j2` | `config/resalloc-pool.yaml.example` |
+| `config/resalloc-spinup-playbook.yml.j2` | `config/resalloc-spinup-playbook.yml.example` |
+
+Files without variables (like `distgit-distgit.conf.j2` and `resalloc-server.yaml.j2`) were renamed to remove the `.j2` extension.
+
+## Variable Substitution Changes
+
+### Jinja2 Format
+```yaml
+image: "{{ copr_backend_image }}"
+data:
+  config: "{{ backend_config | b64encode }}"
+```
+
+### OpenShift Parameter Format
+```yaml
+image: ${COPR_BACKEND_IMAGE}
+data:
+  config: ${BACKEND_CONFIG_B64}
+```
+
+**Important:** Base64 encoding is no longer automatic - you must encode configuration files before deployment.
+
+## Migration Steps
+
+If you have an existing deployment using the Ansible approach:
+
+1. **Export your current configuration:**
+   - Save your `secret-vars.yml` file
+   - Note all configuration values
+
+2. **Prepare new config files:**
+   ```bash
+   cd openshift/config/
+   cp distgit-copr.conf.example distgit-copr.conf
+   cp resalloc-pool.yaml.example resalloc-pool.yaml
+   cp resalloc-aws-credentials.example resalloc-aws-credentials
+   cp resalloc-spinup-playbook.yml.example resalloc-spinup-playbook.yml
+   # Edit each file with your values from secret-vars.yml
+   ```
+
+3. **Use the preparation script:**
+   ```bash
+   ./prepare-deployment.sh
+   ```
+
+4. **Deploy with new templates:**
+   ```bash
+   source params.env
+   envsubst < project.yaml | oc apply -f -
+   for svc in postgres redis frontend backend distgit resalloc keygen; do
+     envsubst < services/${svc}.yml | oc apply -f -
+   done
+   ```
+
+## Mapping secret-vars.yml to Parameters
+
+| secret-vars.yml | New Parameter | Notes |
+|----------------|---------------|-------|
+| `project` | `PROJECT_NAME` | Project/namespace name |
+| `postgres_user` | `POSTGRES_USER_B64` | Base64-encoded |
+| `postgres_password` | `POSTGRES_PASSWORD_B64` | Base64-encoded |
+| `postgres_database_name` | `POSTGRES_DATABASE_NAME_B64` | Base64-encoded |
+| `deployment` (prod/dev) | `POSTGRES_STORAGE_SIZE` | "12Gi" for prod, "1Gi" for dev |
+| `frontend_backend_password` | In `FRONTEND_CONFIG_B64` | Part of config file content |
+| `frontend_base_url` | In config files | Multiple places |
+| `distgit_fqdn` | In config files | Multiple places |
+| `backend_fqdn` | In config files | Multiple places |
+| `aws_config.access_key_id` | In `AWS_CREDENTIALS_B64` | Part of credentials file |
+| `aws_config.secret_access_key` | In `AWS_CREDENTIALS_B64` | Part of credentials file |
+| `aws_config.ssh_key.private` | `AWS_SSH_PRIVATE_KEY_B64` | Base64-encoded |
+| `aws_config.ssh_key.public` | In config files | In spinup playbook |
+| `aws_config.ssh_key.name` | In config files | In pool config |
+
+## Benefits of the New Approach
+
+1. **No Ansible dependency** - Deploy from any system with `oc` or `kubectl`
+2. **Simpler automation** - Easier to integrate with CI/CD pipelines
+3. **More portable** - Works with any Kubernetes/OpenShift tooling
+4. **GitOps friendly** - Plain YAML is easier to version control and review
+
+## Drawbacks to Consider
+
+1. **Manual preparation** - No automatic base64 encoding or image detection
+2. **More verbose** - Need to manage parameters file
+3. **Less validation** - Ansible provided some configuration validation
+
+## Backwards Compatibility
+
+The old `deploy.yml` playbook and `.j2` templates are still present but deprecated. They will be removed in a future release. Please migrate to the new plain templates.
+
+## Getting Help
+
+- See `README-NEW.md` for deployment instructions
+- See `PARAMETERS.md` for complete parameter reference
+- Use `prepare-deployment.sh` to simplify configuration preparation

--- a/openshift/PARAMETERS.md
+++ b/openshift/PARAMETERS.md
@@ -1,0 +1,117 @@
+# OpenShift Template Parameters
+
+This document lists all the parameters you need to provide when deploying Copr to OpenShift using the plain templates.
+
+## Overview
+
+The templates have been converted from Jinja2 to plain OpenShift manifests. Configuration files and secrets need to be base64-encoded before applying them.
+
+## Required Parameters
+
+### Project Configuration
+
+- `PROJECT_NAME` - Name of the OpenShift project (namespace)
+
+### PostgreSQL
+
+- `POSTGRES_USER_B64` - PostgreSQL username (base64-encoded)
+- `POSTGRES_PASSWORD_B64` - PostgreSQL password (base64-encoded)
+- `POSTGRES_DATABASE_NAME_B64` - PostgreSQL database name (base64-encoded)
+- `POSTGRES_STORAGE_SIZE` - Storage size for PostgreSQL (e.g., "1Gi" for dev, "12Gi" for prod)
+- `POSTGRESQL_IMAGE` - PostgreSQL container image (can be left empty to use ImageStream)
+
+### Redis
+
+- `REDIS_IMAGE` - Redis container image (can be left empty to use ImageStream)
+
+### Frontend
+
+- `FRONTEND_CONFIG_B64` - Frontend configuration file content (base64-encoded)
+  - Source: `config/frontend-copr.conf` (fill in your values)
+- `COPR_FRONTEND_IMAGE` - Frontend container image (can be left empty to use ImageStream)
+
+### Backend
+
+- `BACKEND_CONFIG_B64` - Backend configuration file content (base64-encoded)
+  - Source: `config/backend-copr-be.conf` (fill in your values)
+- `BACKEND_HTTPD_CONFIG_B64` - Backend nginx configuration (base64-encoded)
+  - Source: `config/backend-nginx.conf`
+- `COPR_BACKEND_IMAGE` - Backend container image (can be left empty to use ImageStream)
+- `NGINX_IMAGE` - Nginx container image (can be left empty to use ImageStream)
+- `AWS_SSH_PRIVATE_KEY_B64` - AWS SSH private key for builders (base64-encoded)
+
+### DistGit
+
+- `DISTGIT_CONFIG_B64` - DistGit configuration (base64-encoded)
+  - Source: `config/distgit-distgit.conf`
+- `DISTGIT_COPR_CONFIG_B64` - DistGit Copr configuration (base64-encoded)
+  - Source: `config/distgit-copr.conf.example` (fill in your values)
+- `COPR_DISTGIT_IMAGE` - DistGit container image (can be left empty to use ImageStream)
+
+### Resalloc
+
+- `RESALLOC_POOL_YAML_B64` - Resalloc pool configuration (base64-encoded)
+  - Source: `config/resalloc-pool.yaml.example` (fill in your values)
+- `RESALLOC_SERVER_YAML_B64` - Resalloc server configuration (base64-encoded)
+  - Source: `config/resalloc-server.yaml`
+- `RESALLOC_SPINUP_PLAYBOOK_B64` - Resalloc spinup playbook (base64-encoded)
+  - Source: `config/resalloc-spinup-playbook.yml.example` (fill in your values)
+- `AWS_CREDENTIALS_B64` - AWS credentials file (base64-encoded)
+  - Source: `config/resalloc-aws-credentials.example` (fill in your values)
+- `RESALLOC_IMAGE` - Resalloc container image (can be left empty to use ImageStream)
+
+### Keygen
+
+- `COPR_KEYGEN_IMAGE` - Keygen container image (can be left empty to use ImageStream)
+
+## How to Base64 Encode Files
+
+To encode a configuration file to base64:
+
+```bash
+# Linux/Mac
+cat config/your-file.conf | base64 -w 0
+
+# Or to save to a file
+base64 -w 0 < config/your-file.conf > config/your-file.conf.b64
+```
+
+## Deployment Methods
+
+### Method 1: Using `oc process` with a parameter file
+
+Create a `params.env` file:
+```
+PROJECT_NAME=my-copr
+POSTGRES_USER_B64=$(echo -n "copr-fe" | base64)
+POSTGRES_PASSWORD_B64=$(echo -n "your-password" | base64)
+...
+```
+
+Then apply:
+```bash
+oc process -f services/postgres.yml --param-file=params.env | oc apply -f -
+```
+
+### Method 2: Using `envsubst`
+
+Export environment variables and use `envsubst`:
+```bash
+export PROJECT_NAME=my-copr
+export POSTGRES_USER_B64=$(echo -n "copr-fe" | base64)
+...
+envsubst < services/postgres.yml | oc apply -f -
+```
+
+### Method 3: Manual substitution
+
+For simple deployments, you can manually edit the YAML files and replace `${PARAMETER}` with actual values before applying.
+
+## Image Parameters
+
+For most image parameters (e.g., `COPR_FRONTEND_IMAGE`, `POSTGRESQL_IMAGE`), you can:
+
+1. Leave them empty (`""` or `" "`) to let OpenShift use the image from the ImageStream triggers
+2. Or provide a specific image reference if you want to override the ImageStream
+
+The original Ansible playbook detected current images to avoid unnecessary redeployments. With plain templates, it's simpler to let ImageStream triggers handle updates automatically.

--- a/openshift/README-NEW.md
+++ b/openshift/README-NEW.md
@@ -1,0 +1,177 @@
+# Deploy Copr build system in OpenShift
+
+This directory contains OpenShift templates for deploying a fully-working Copr build system infrastructure into an OpenShift cluster, with builders (virtual machines) being automatically started/stopped in external clouds (currently just pre-configured AWS).
+
+**Note:** At the time of writing this document, it is not common to be able to start privileged containers in OpenShift, nor rootless containers (user namespaces). Therefore, builders need to stay as virtual machines only.
+
+## Quick Start
+
+The templates have been converted from Jinja2/Ansible to plain OpenShift manifests with parameters. This simplifies deployment but requires more manual configuration preparation.
+
+### Prerequisites
+
+1. An OpenShift cluster and `oc` CLI access
+2. AWS credentials for EC2 builder instances
+3. Configuration files prepared (see below)
+
+### Deployment Steps
+
+#### 1. Prepare Configuration Files
+
+Copy the example config files and fill in your values:
+
+```bash
+cd openshift/config/
+
+# Copy and edit these files with your actual values:
+cp distgit-copr.conf.example distgit-copr.conf
+cp resalloc-pool.yaml.example resalloc-pool.yaml
+cp resalloc-aws-credentials.example resalloc-aws-credentials
+cp resalloc-spinup-playbook.yml.example resalloc-spinup-playbook.yml
+
+# Edit the existing config files:
+# - backend-copr-be.conf
+# - frontend-copr.conf
+```
+
+See `PARAMETERS.md` for a complete list of required configuration values.
+
+#### 2. Base64 Encode Configuration Files
+
+```bash
+# Encode all config files
+base64 -w 0 < config/frontend-copr.conf > config/frontend-copr.conf.b64
+base64 -w 0 < config/backend-copr-be.conf > config/backend-copr-be.conf.b64
+base64 -w 0 < config/backend-nginx.conf > config/backend-nginx.conf.b64
+base64 -w 0 < config/distgit-distgit.conf > config/distgit-distgit.conf.b64
+base64 -w 0 < config/distgit-copr.conf > config/distgit-copr.conf.b64
+base64 -w 0 < config/resalloc-pool.yaml > config/resalloc-pool.yaml.b64
+base64 -w 0 < config/resalloc-server.yaml > config/resalloc-server.yaml.b64
+base64 -w 0 < config/resalloc-spinup-playbook.yml > config/resalloc-spinup-playbook.yml.b64
+base64 -w 0 < config/resalloc-aws-credentials > config/resalloc-aws-credentials.b64
+
+# Encode PostgreSQL credentials
+echo -n "copr-fe" | base64 > /tmp/postgres-user.b64
+echo -n "your-postgres-password" | base64 > /tmp/postgres-password.b64
+echo -n "copr-db" | base64 > /tmp/postgres-db.b64
+
+# Encode AWS SSH key (use your actual private key file)
+base64 -w 0 < ~/.ssh/your-aws-key.pem > /tmp/aws-ssh-key.b64
+```
+
+#### 3. Create Parameters File
+
+Create a `params.env` file with all your parameters:
+
+```bash
+PROJECT_NAME=my-copr-project
+POSTGRES_USER_B64=$(cat /tmp/postgres-user.b64)
+POSTGRES_PASSWORD_B64=$(cat /tmp/postgres-password.b64)
+POSTGRES_DATABASE_NAME_B64=$(cat /tmp/postgres-db.b64)
+POSTGRES_STORAGE_SIZE=1Gi
+POSTGRESQL_IMAGE=
+REDIS_IMAGE=
+FRONTEND_CONFIG_B64=$(cat config/frontend-copr.conf.b64)
+COPR_FRONTEND_IMAGE=
+BACKEND_CONFIG_B64=$(cat config/backend-copr-be.conf.b64)
+BACKEND_HTTPD_CONFIG_B64=$(cat config/backend-nginx.conf.b64)
+COPR_BACKEND_IMAGE=
+NGINX_IMAGE=
+AWS_SSH_PRIVATE_KEY_B64=$(cat /tmp/aws-ssh-key.b64)
+DISTGIT_CONFIG_B64=$(cat config/distgit-distgit.conf.b64)
+DISTGIT_COPR_CONFIG_B64=$(cat config/distgit-copr.conf.b64)
+COPR_DISTGIT_IMAGE=
+RESALLOC_POOL_YAML_B64=$(cat config/resalloc-pool.yaml.b64)
+RESALLOC_SERVER_YAML_B64=$(cat config/resalloc-server.yaml.b64)
+RESALLOC_SPINUP_PLAYBOOK_B64=$(cat config/resalloc-spinup-playbook.yml.b64)
+AWS_CREDENTIALS_B64=$(cat config/resalloc-aws-credentials.b64)
+RESALLOC_IMAGE=
+COPR_KEYGEN_IMAGE=
+```
+
+#### 4. Deploy to OpenShift
+
+```bash
+# Create the project
+envsubst < project.yaml | oc apply -f -
+
+# Deploy each service
+for service in postgres redis frontend backend distgit resalloc keygen; do
+    envsubst < services/${service}.yml | oc apply -f -
+done
+```
+
+Alternative using `oc process` (if templates are converted to OpenShift Template objects):
+
+```bash
+oc process -f services/postgres.yml --param-file=params.env | oc apply -f -
+```
+
+## Differences from Ansible Deployment
+
+The previous deployment used Ansible with Jinja2 templates (`deploy.yml`). Key changes:
+
+1. **No Ansible playbook** - Deploy directly with `oc` commands
+2. **Manual parameter preparation** - You must prepare and base64-encode all config files yourself
+3. **Simpler but less automated** - No automatic image detection or secret generation
+4. **More portable** - Works in any OpenShift environment without Ansible dependencies
+
+## Configuration Files
+
+All configuration files are in the `config/` directory:
+
+- **Backend**: `backend-copr-be.conf`, `backend-nginx.conf`
+- **Frontend**: `frontend-copr.conf`
+- **DistGit**: `distgit-distgit.conf`, `distgit-copr.conf`
+- **Resalloc**: `resalloc-server.yaml`, `resalloc-pool.yaml`, `resalloc-spinup-playbook.yml`, `resalloc-aws-credentials`
+
+Files with `.example` extension are templates - copy them and fill in your values.
+
+## Images
+
+Currently maintained images are at: https://quay.io/organization/copr
+
+The templates reference these images:
+- `quay.io/copr/frontend:test`
+- `quay.io/copr/backend:test`
+- `quay.io/copr/distgit:test`
+- `quay.io/copr/keygen:test`
+- `quay.io/copr/resalloc:test`
+
+## WARNING
+
+This deployment is in a pre-production state!
+
+## TODO list
+
+- copr-keygen pod signing process needs to be secured, currently the pod accepts sign requests from any other pod in the project because we "allow 0.0.0.0/0"
+
+- start logging to stdout/stderr, so we can just do 'oc logs <podname> -c <container>', according to https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html. Alternatively at least implement log-rotation.
+
+- we should merge https://github.com/openSUSE/obs-sign/pull/36 - currently patched Fedora-only
+
+- zombie reaping - use tini
+
+- Let's Encrypt automation
+
+- starting the containers against a locally maintained code (from git root), currently we just use 'docker-compose'
+
+- automate PostgreSQL initialization from a SQL dump file, for easier debugging of complicated scenarios
+
+- setup cron jobs (automatic build removals, etc.)
+
+- better container image tagging (currently everything in :test)
+
+- automatic image builds (quay.io builds are broken for F35 https://bugzilla.redhat.com/show_bug.cgi?id=2025899)
+
+- automatize the AWS SSH key creation/removal (this is the hardest part in the secret-vars.yml config file)
+
+- separate the normal and secret vars (now everything needs to be in params.env)
+
+## Research
+
+- write an operator for starting builders hosted in OpenShift? But we need to wait for the state when "user namespaces" are "commonly" available
+
+- automatic termination of orphaned resalloc instances - this happens easily when project is deleted (oc delete project <your project>)
+
+- experiment with Terraform

--- a/openshift/config/distgit-copr.conf.example
+++ b/openshift/config/distgit-copr.conf.example
@@ -1,0 +1,4 @@
+[dist-git]
+frontend_base_url=http://copr-frontend:5000
+frontend_auth=<YOUR_FRONTEND_BACKEND_PASSWORD>
+per_task_log_dir=/var/lib/copr-dist-git/per-task-logs/

--- a/openshift/config/distgit-distgit.conf
+++ b/openshift/config/distgit-distgit.conf
@@ -1,0 +1,10 @@
+[dist-git]
+git_author_name  = Copr Dist Git
+git_author_email = <copr-devel@lists.fedoraproject.org>
+
+cache_dir   = /var/lib/dist-git/cache
+gitroot_dir = /var/lib/dist-git/git
+#this is difference from standard config!
+git_gc_depth   = 3
+
+gitolite    = False

--- a/openshift/config/resalloc-aws-credentials.example
+++ b/openshift/config/resalloc-aws-credentials.example
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=<YOUR_AWS_ACCESS_KEY_ID>
+aws_secret_access_key=<YOUR_AWS_SECRET_ACCESS_KEY>

--- a/openshift/config/resalloc-pool.yaml.example
+++ b/openshift/config/resalloc-pool.yaml.example
@@ -1,0 +1,51 @@
+# vi: ft=yaml
+---
+copr_os_<PROJECT_NAME_UNDERSCORED>_<DEPLOYMENT>_aws_x86:
+  max: 4
+  max_starting: 1
+  max_prealloc: 1
+  tags:
+    - copr_builder
+    - arch_noarch
+    - arch_x86_64
+    - arch_x86_64_native
+    - arch_i386
+    - arch_i386_native
+    - arch_i586
+    - arch_i586_native
+    - arch_i686
+    - arch_i686_native
+    - arch_s390x
+    - arch_s390x_emulated
+    - arch_ppc64le
+    - arch_ppc64le_emulated
+    - arch_aarch64
+    - arch_aarch64_emulated
+  cmd_new: |
+    set -x
+    /usr/bin/resalloc-aws-new \
+    --aws-profile default \
+    --ami ami-09127a5df568314d3 \
+    --ssh-key-name "<YOUR_AWS_SSH_KEY_NAME>" \
+    --debug \
+    --private-ip \
+    --security-group-id sg-07a0adee998a8fcde \
+    --possible-subnet subnet-0b853a752f0f7eba5 \
+    --possible-subnet subnet-05dd25fba5582bb6a \
+    --instance-type t3a.medium \
+    --tag RedHatGroup=copr \
+    --tag ServiceName=copr \
+    --tag ServiceComponent=builder-testing-copr-openshift \
+    --tag ServiceOwner=Copr \
+    --tag AppCode=COPR-001 \
+    --tag ServicePhase=Dev \
+    --tag CoprInstance=testing-openshift \
+    --tag arch=x86_64 \
+    --playbook /etc/resallocserver/spinup-playbook.yml
+
+  cmd_delete: /usr/bin/resalloc-aws-delete --aws-profile default
+  cmd_livecheck: "resalloc-check-vm-ip"
+  livecheck_period: 180
+  reuse_opportunity_time: 180
+  reuse_max_count: 8
+  reuse_max_time: 1800

--- a/openshift/config/resalloc-server.yaml
+++ b/openshift/config/resalloc-server.yaml
@@ -1,0 +1,4 @@
+db_url: 'sqlite:////var/lib/resallocserver/db.sqlite'
+logdir: '/var/log/resallocserver'
+hostname: '0.0.0.0'
+loglevel: 'debug'

--- a/openshift/config/resalloc-spinup-playbook.yml.example
+++ b/openshift/config/resalloc-spinup-playbook.yml.example
@@ -1,0 +1,68 @@
+---
+- name: provision AWS builder
+  hosts: all
+  become: true
+  user: fedora
+
+  vars:
+    devel: true
+    ansible_python_interpreter: /usr/bin/python3
+
+  tasks:
+    - name: setup the hostname so we can easily identify the box
+      hostname: name="{{ lookup('env', 'RESALLOC_NAME') | default('unknown-builder') | replace('_', '-') }}"
+
+    - name: disable updates-testing
+      file:
+        path: /etc/yum.repos.d/fedora-updates-testing.repo
+        state: absent
+
+    - name: stop and disable systemd-oomd, rhbz 2051154
+      service:
+        name: systemd-oomd
+        state: stopped
+        enabled: no
+
+    - name: install copr-builder and other latest packages
+      dnf: state=latest pkg=copr-builder
+
+    - name: run /bin/copr-update-builder from copr-builder package
+      shell: /usr/bin/copr-update-builder
+
+    - name: put copr-rpmbuild configuration file in the right place
+      copy:
+        dest: /etc/copr-rpmbuild/main.ini
+        content: |
+          [main]
+          frontend_url = <YOUR_FRONTEND_BASE_URL>
+          distgit_lookaside_url = https://{% raw %}{{ git_props:remote_netloc }}{% endraw %}/repo/pkgs/%(repo_path)s/%(filename)s/%(hashtype)s/%(hash)s/%(filename)s
+          distgit_clone_url = {scheme}://{netloc}/%(repo_path)s
+          rpm_vendor_copr_name = Testing Copr
+
+          [distgit0]
+          distgit_hostname_pattern = src.fedoraproject.org
+          distgit_lookaside_url = https://src.fedoraproject.org/repo/pkgs/%(ns1)s/%(name)s/%(filename)s/%(hashtype)s/%(hash)s/%(filename)s
+          distgit_clone_url = https://src.fedoraproject.org/%(repo_path)s
+
+    - name: install copr-distgit-client configuration
+      copy:
+        dest: /etc/copr-distgit-client/local-copr.ini
+        content: |
+          [local-copr]
+          clone_hostnames = <YOUR_DISTGIT_FQDN>
+          lookaside_location = http://<YOUR_DISTGIT_FQDN>
+          lookaside_uri_pattern = repo/pkgs/{namespace[1]}/{namespace[0]}/{name}/{filename}/{hash}/{filename}
+
+    - name: mockbuilder authorized_keys
+      authorized_key: user=mockbuilder key="<YOUR_AWS_SSH_PUBLIC_KEY>"
+
+    - name: root authorized_keys
+      authorized_key: user=root key="<YOUR_AWS_SSH_PUBLIC_KEY>"
+
+    - name: mount cache filesystem on /var/cache/mock
+      mount: path=/var/cache/mock state=mounted src=mock_cache_tmpfs fstype=tmpfs opts="size=32G"
+
+    - name: Collect facts about builder hardware
+      setup:
+        gather_subset:
+          - hardware

--- a/openshift/prepare-deployment.sh
+++ b/openshift/prepare-deployment.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Helper script to prepare Copr OpenShift deployment
+# This script helps you encode configuration files and generate a params.env file
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$SCRIPT_DIR/config"
+TMP_DIR="${TMP_DIR:-/tmp/copr-openshift-deploy}"
+
+mkdir -p "$TMP_DIR"
+
+echo "=== Copr OpenShift Deployment Preparation ==="
+echo
+
+# Check required config files exist
+check_config_file() {
+    if [ ! -f "$1" ]; then
+        echo "ERROR: Required config file not found: $1"
+        echo "Please create it from the .example file if available"
+        exit 1
+    fi
+}
+
+echo "Step 1: Checking configuration files..."
+check_config_file "$CONFIG_DIR/frontend-copr.conf"
+check_config_file "$CONFIG_DIR/backend-copr-be.conf"
+check_config_file "$CONFIG_DIR/backend-nginx.conf"
+check_config_file "$CONFIG_DIR/distgit-distgit.conf"
+check_config_file "$CONFIG_DIR/distgit-copr.conf"
+check_config_file "$CONFIG_DIR/resalloc-server.yaml"
+check_config_file "$CONFIG_DIR/resalloc-pool.yaml"
+check_config_file "$CONFIG_DIR/resalloc-spinup-playbook.yml"
+check_config_file "$CONFIG_DIR/resalloc-aws-credentials"
+echo "✓ All config files found"
+echo
+
+echo "Step 2: Base64 encoding configuration files..."
+base64 -w 0 < "$CONFIG_DIR/frontend-copr.conf" > "$TMP_DIR/frontend-copr.conf.b64"
+base64 -w 0 < "$CONFIG_DIR/backend-copr-be.conf" > "$TMP_DIR/backend-copr-be.conf.b64"
+base64 -w 0 < "$CONFIG_DIR/backend-nginx.conf" > "$TMP_DIR/backend-nginx.conf.b64"
+base64 -w 0 < "$CONFIG_DIR/distgit-distgit.conf" > "$TMP_DIR/distgit-distgit.conf.b64"
+base64 -w 0 < "$CONFIG_DIR/distgit-copr.conf" > "$TMP_DIR/distgit-copr.conf.b64"
+base64 -w 0 < "$CONFIG_DIR/resalloc-server.yaml" > "$TMP_DIR/resalloc-server.yaml.b64"
+base64 -w 0 < "$CONFIG_DIR/resalloc-pool.yaml" > "$TMP_DIR/resalloc-pool.yaml.b64"
+base64 -w 0 < "$CONFIG_DIR/resalloc-spinup-playbook.yml" > "$TMP_DIR/resalloc-spinup-playbook.yml.b64"
+base64 -w 0 < "$CONFIG_DIR/resalloc-aws-credentials" > "$TMP_DIR/resalloc-aws-credentials.b64"
+echo "✓ Config files encoded"
+echo
+
+echo "Step 3: Gathering deployment parameters..."
+read -p "Project name (OpenShift namespace): " PROJECT_NAME
+read -p "PostgreSQL username [copr-fe]: " POSTGRES_USER
+POSTGRES_USER="${POSTGRES_USER:-copr-fe}"
+read -sp "PostgreSQL password: " POSTGRES_PASSWORD
+echo
+read -p "PostgreSQL database name [copr-db]: " POSTGRES_DB
+POSTGRES_DB="${POSTGRES_DB:-copr-db}"
+read -p "PostgreSQL storage size (e.g., 1Gi for dev, 12Gi for prod) [1Gi]: " POSTGRES_STORAGE
+POSTGRES_STORAGE="${POSTGRES_STORAGE:-1Gi}"
+read -p "Path to AWS SSH private key: " AWS_KEY_PATH
+
+if [ ! -f "$AWS_KEY_PATH" ]; then
+    echo "ERROR: AWS SSH key not found at $AWS_KEY_PATH"
+    exit 1
+fi
+
+echo
+echo "Step 4: Encoding credentials..."
+echo -n "$POSTGRES_USER" | base64 > "$TMP_DIR/postgres-user.b64"
+echo -n "$POSTGRES_PASSWORD" | base64 > "$TMP_DIR/postgres-password.b64"
+echo -n "$POSTGRES_DB" | base64 > "$TMP_DIR/postgres-db.b64"
+base64 -w 0 < "$AWS_KEY_PATH" > "$TMP_DIR/aws-ssh-key.b64"
+echo "✓ Credentials encoded"
+echo
+
+echo "Step 5: Generating params.env file..."
+cat > "$TMP_DIR/params.env" <<EOF
+PROJECT_NAME=$PROJECT_NAME
+POSTGRES_USER_B64=$(cat "$TMP_DIR/postgres-user.b64")
+POSTGRES_PASSWORD_B64=$(cat "$TMP_DIR/postgres-password.b64")
+POSTGRES_DATABASE_NAME_B64=$(cat "$TMP_DIR/postgres-db.b64")
+POSTGRES_STORAGE_SIZE=$POSTGRES_STORAGE
+POSTGRESQL_IMAGE=
+REDIS_IMAGE=
+FRONTEND_CONFIG_B64=$(cat "$TMP_DIR/frontend-copr.conf.b64")
+COPR_FRONTEND_IMAGE=
+BACKEND_CONFIG_B64=$(cat "$TMP_DIR/backend-copr-be.conf.b64")
+BACKEND_HTTPD_CONFIG_B64=$(cat "$TMP_DIR/backend-nginx.conf.b64")
+COPR_BACKEND_IMAGE=
+NGINX_IMAGE=
+AWS_SSH_PRIVATE_KEY_B64=$(cat "$TMP_DIR/aws-ssh-key.b64")
+DISTGIT_CONFIG_B64=$(cat "$TMP_DIR/distgit-distgit.conf.b64")
+DISTGIT_COPR_CONFIG_B64=$(cat "$TMP_DIR/distgit-copr.conf.b64")
+COPR_DISTGIT_IMAGE=
+RESALLOC_POOL_YAML_B64=$(cat "$TMP_DIR/resalloc-pool.yaml.b64")
+RESALLOC_SERVER_YAML_B64=$(cat "$TMP_DIR/resalloc-server.yaml.b64")
+RESALLOC_SPINUP_PLAYBOOK_B64=$(cat "$TMP_DIR/resalloc-spinup-playbook.yml.b64")
+AWS_CREDENTIALS_B64=$(cat "$TMP_DIR/resalloc-aws-credentials.b64")
+RESALLOC_IMAGE=
+COPR_KEYGEN_IMAGE=
+EOF
+
+cp "$TMP_DIR/params.env" "$SCRIPT_DIR/params.env"
+echo "✓ Parameters file created: $SCRIPT_DIR/params.env"
+echo
+
+echo "=== Preparation Complete ==="
+echo
+echo "Next steps:"
+echo "1. Review the generated params.env file"
+echo "2. Source it before deployment:"
+echo "   source $SCRIPT_DIR/params.env"
+echo "3. Deploy the project:"
+echo "   envsubst < project.yaml | oc apply -f -"
+echo "4. Deploy services:"
+echo "   for svc in postgres redis frontend backend distgit resalloc keygen; do"
+echo "     envsubst < services/\${svc}.yml | oc apply -f -"
+echo "   done"
+echo
+echo "Or use the deploy.sh script if available."

--- a/openshift/project.yaml
+++ b/openshift/project.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: ${PROJECT_NAME}
+parameters:
+  - name: PROJECT_NAME
+    description: Name of the OpenShift project (namespace)
+    required: true

--- a/openshift/services/backend.yml
+++ b/openshift/services/backend.yml
@@ -1,0 +1,284 @@
+# vi: ft=yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-backend-results
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "3Gi"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-backend-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-backend-locks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "10M"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-backend-config
+type: Opaque
+data:
+  copr-be.conf: ${BACKEND_CONFIG_B64}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: backend-home
+type: Opaque
+data:
+  id_rsa: ${AWS_SSH_PRIVATE_KEY_B64}
+  ssh_config: SG9zdCAqCiAgIElkZW50aXR5RmlsZSB+Ly5zc2gvaWRfcnNhCiAgIFN0cmljdEhvc3RLZXlDaGVja2luZyAgbm8KICAgVXNlcktub3duSG9zdHNGaWxlIC9kZXYvbnVsbAogICBTZXJ2ZXJBbGl2ZUludGVydmFsIDIwCiAgIFNlcnZlckFsaXZlQ291bnRNYXggNQogICBDb25uZWN0VGltZW91dCA2MAo=
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-backend-httpd-config
+type: Opaque
+data:
+  nginx-copr-be.conf: ${BACKEND_HTTPD_CONFIG_B64}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: copr-backend
+spec:
+  ports:
+    - name: copr-backend-httpd
+      port: 8080
+      targetPort: 8080
+  selector:
+    name: copr-backend-httpd
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: copr-backend
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/copr/backend:test
+      importPolicy:
+        scheduled: true
+      name: test
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: copr-backend-httpd
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/centos7/nginx-120-centos7
+      importPolicy:
+        scheduled: true
+      name: test
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: copr-backend
+spec:
+  template:
+    metadata:
+      labels:
+        name: copr-backend
+    spec:
+      containers:
+        - name: log
+          image: ${COPR_BACKEND_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/bin/tini", "--"]
+          args: ["/usr/bin/copr_run_logger.py"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/copr
+            - name: logs
+              mountPath: /var/log/copr-backend
+
+        - name: actions
+          image: ${COPR_BACKEND_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config
+              mountPath: /etc/copr
+            - name: results
+              mountPath: /var/lib/copr/public_html
+            - name: locks
+              mountPath: /var/lock/copr-backend
+          command: ["/usr/bin/tini", "--"]
+          args: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher-backend", "actions"]
+
+        - name: builds
+          image: ${COPR_BACKEND_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: config
+              mountPath: /etc/copr
+            - name: results
+              mountPath: /var/lib/copr/public_html
+            - name: locks
+              mountPath: /var/lock/copr-backend
+            - name: home
+              mountPath: /backend-home
+          env:
+            - name: HOME
+              value: /backend-home
+          command: ["/usr/bin/tini", "--"]
+          args: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher-backend", "builds"]
+
+      # start these containers on the same node with copr-backend-httpd!
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - copr-backend-httpd
+              topologyKey: kubernetes.io/hostname
+
+
+      volumes:
+        - name: config
+          secret:
+            secretName: copr-backend-config
+            optional: false
+
+        - name: home
+          secret:
+            secretName: backend-home
+            optional: false
+            defaultMode: 0600
+            items:
+              - key: id_rsa
+                path: .ssh/id_rsa
+              - key: ssh_config
+                path: .ssh/config
+
+        - name: logs
+          persistentVolumeClaim:
+            claimName: copr-backend-logs
+
+        - name: results
+          persistentVolumeClaim:
+            claimName: copr-backend-results
+
+        - name: locks
+          persistentVolumeClaim:
+            claimName: copr-backend-locks
+
+      restartPolicy: Always
+
+  replicas: 1
+  strategy:
+    type: Recreate
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - actions
+          - builds
+          - log
+        from:
+          kind: ImageStreamTag
+          name: copr-backend:test
+      type: ImageChange
+
+    - type: ConfigChange
+
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: copr-backend-httpd
+spec:
+  template:
+    metadata:
+      labels:
+        name: copr-backend-httpd
+    spec:
+      containers:
+        - name: httpd
+          image: ${NGINX_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["nginx", "-g", "daemon off;"]
+          volumeMounts:
+            - name: results
+              mountPath: /opt/app-root/src
+            - name: config
+              mountPath: /opt/app-root/etc/nginx.d/
+
+      volumes:
+        - name: results
+          persistentVolumeClaim:
+            claimName: copr-backend-results
+
+        - name: config
+          secret:
+            secretName: copr-backend-httpd-config
+            optional: false
+
+      restartPolicy: Always
+
+  replicas: 1
+  strategy:
+    type: Recreate
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - httpd
+        from:
+          kind: ImageStreamTag
+          name: copr-backend-httpd:test
+      type: ImageChange
+
+    - type: ConfigChange
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: copr-backend
+spec:
+  port:
+    targetPort: copr-backend-httpd
+  to:
+    kind: Service
+    name: copr-backend

--- a/openshift/services/distgit.yml
+++ b/openshift/services/distgit.yml
@@ -1,0 +1,182 @@
+# vi: ft=yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-distgit-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "3Gi"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-distgit-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-distgit-locks
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "10M"
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: distgit-config
+type: Opaque
+data:
+  dist-git.conf: ${DISTGIT_CONFIG_B64}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: distgit-copr-config
+type: Opaque
+data:
+  copr-dist-git.conf: ${DISTGIT_COPR_CONFIG_B64}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: copr-distgit
+spec:
+  ports:
+    - name: copr-distgit-http
+      port: 5001
+      targetPort: 5001
+  selector:
+    name: copr-distgit
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: copr-distgit
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/copr/distgit:test
+      importPolicy:
+        scheduled: true
+      name: test
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: copr-distgit
+spec:
+  template:
+    metadata:
+      labels:
+        name: copr-distgit
+    spec:
+      containers:
+        - name: imports
+          image: ${COPR_DISTGIT_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: distgit-copr-config
+              mountPath: /etc/copr
+            - name: distgit-config
+              mountPath: /etc/dist-git
+            - name: storage
+              mountPath: /var/lib/dist-git
+            - name: logs
+              mountPath: /var/lib/copr-dist-git
+            - name: logs
+              mountPath: /var/log/copr-dist-git
+            - name: locks
+              mountPath: /var/lock/copr-dist-git
+
+        - name: httpd
+          image: ${COPR_DISTGIT_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: distgit-copr-config
+              mountPath: /etc/copr
+            - name: distgit-config
+              mountPath: /etc/dist-git
+            - name: storage
+              mountPath: /var/lib/dist-git
+            - name: logs
+              mountPath: /var/lib/copr-dist-git
+            - name: logs
+              mountPath: /var/log/copr-dist-git
+            - name: logs
+              mountPath: /var/log/httpd
+          command: ["/usr/sbin/httpd", "-DFOREGROUND"]
+
+      volumes:
+        - name: distgit-config
+          secret:
+            secretName: distgit-config
+            optional: false
+
+        - name: distgit-copr-config
+          secret:
+            secretName: distgit-copr-config
+            optional: false
+
+        - name: storage
+          persistentVolumeClaim:
+            claimName: copr-distgit-data
+
+        - name: logs
+          persistentVolumeClaim:
+            claimName: copr-distgit-logs
+
+        - name: locks
+          persistentVolumeClaim:
+            claimName: copr-distgit-locks
+
+      restartPolicy: Always
+
+  replicas: 1
+  strategy:
+    type: Recreate
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - imports
+          - httpd
+        from:
+          kind: ImageStreamTag
+          name: copr-distgit:test
+      type: ImageChange
+
+    - type: ConfigChange
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: copr-distgit
+spec:
+  port:
+    targetPort: copr-distgit-http
+  to:
+    kind: Service
+    name: copr-distgit

--- a/openshift/services/frontend.yml
+++ b/openshift/services/frontend.yml
@@ -1,0 +1,95 @@
+# vim: ft=yaml
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-frontend-config
+type: Opaque
+data:
+  copr.conf: ${FRONTEND_CONFIG_B64}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: copr-frontend
+spec:
+  ports:
+    - name: copr-frontend-httpd
+      port: 5000
+      targetPort: 5000
+  selector:
+    name: copr-frontend
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: copr-frontend
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/copr/frontend:test
+      importPolicy:
+        scheduled: true
+      name: test
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: copr-frontend
+spec:
+  template:
+    metadata:
+      labels:
+        name: copr-frontend
+    spec:
+      containers:
+        - name: copr-frontend
+          image: ${COPR_FRONTEND_IMAGE}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 5000
+              protocol: TCP
+          resources:
+            limits:
+              memory: "500Mi"
+              cpu: "200m"
+          volumeMounts:
+            - name: copr-frontend-config
+              mountPath: /etc/copr
+      volumes:
+        - name: copr-frontend-config
+          secret:
+            secretName: copr-frontend-config
+            optional: false
+
+  replicas: 1
+  strategy:
+    type: Recreate
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - copr-frontend
+        from:
+          kind: ImageStreamTag
+          name: copr-frontend:test
+      type: ImageChange
+    - type: ConfigChange
+
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: copr-frontend
+spec:
+  port:
+    targetPort: copr-frontend-httpd
+  to:
+    kind: Service
+    name: copr-frontend

--- a/openshift/services/keygen.yml
+++ b/openshift/services/keygen.yml
@@ -1,0 +1,120 @@
+# vi: ft=yaml
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: copr-keygen
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/copr/keygen:test
+      importPolicy:
+        scheduled: true
+      name: test
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-keygen-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: copr-keygen-logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: copr-keygen
+spec:
+  ports:
+    - name: copr-keygen-httpd
+      port: 5003
+      targetPort: 5003
+    - name: copr-keygen-signd
+      port: 5167
+      targetPort: 5167
+  selector:
+    name: copr-keygen
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: copr-keygen
+spec:
+  template:
+    metadata:
+      labels:
+        name: copr-keygen
+    spec:
+      containers:
+        - name: signer
+          image: ${COPR_KEYGEN_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/bin/tini", "--"]
+          args: ["/signd-entrypoint", "0.0.0.0/0"]
+          volumeMounts:
+            - name: storage
+              mountPath: /var/lib/copr-keygen
+            - name: logs
+              mountPath: /var/log/copr-keygen
+          ports:
+            - containerPort: 5167
+              protocol: TCP
+
+        - name: httpd
+          image: ${COPR_KEYGEN_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/usr/sbin/httpd", "-DFOREGROUND"]
+          volumeMounts:
+            - name: storage
+              mountPath: /var/lib/copr-keygen
+            - name: logs
+              mountPath: /var/log/copr-keygen
+          ports:
+            - containerPort: 5003
+              protocol: TCP
+
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: copr-keygen-data
+        - name: logs
+          persistentVolumeClaim:
+            claimName: copr-keygen-logs
+
+      restartPolicy: Always
+
+  replicas: 1
+  strategy:
+    type: Recreate
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - signer
+          - httpd
+        from:
+          kind: ImageStreamTag
+          name: copr-keygen:test
+      type: ImageChange
+
+    - type: ConfigChange

--- a/openshift/services/postgres.yml
+++ b/openshift/services/postgres.yml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql
+type: Opaque
+data:
+  database-user: ${POSTGRES_USER_B64}
+  database-password: ${POSTGRES_PASSWORD_B64}
+  database-name: ${POSTGRES_DATABASE_NAME_B64}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+spec:
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: 5432
+  selector:
+    name: postgresql
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgresql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: ${POSTGRES_STORAGE_SIZE}
+
+---
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: postgresql
+spec:
+  replicas: 1
+  selector:
+    name: postgresql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: postgresql
+        test: test-postgresql-tag
+    spec:
+      containers:
+        - env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  key: database-user
+                  name: postgresql
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: database-password
+                  name: postgresql
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  key: database-name
+                  name: postgresql
+          image: ${POSTGRESQL_IMAGE}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+                - --live
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+          name: postgresql
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /var/lib/pgsql/data
+              name: postgresql-data
+      restartPolicy: Always
+      volumes:
+        - name: postgresql-data
+          persistentVolumeClaim:
+            claimName: postgresql
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - postgresql
+        from:
+          kind: ImageStreamTag
+          name: postgresql:12-el8
+          namespace: openshift
+      type: ImageChange
+    - type: ConfigChange

--- a/openshift/services/redis.yml
+++ b/openshift/services/redis.yml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+  selector:
+    name: redis
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: redis
+spec:
+  replicas: 1
+  selector:
+    name: redis
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: redis
+    spec:
+      containers:
+        - image: ${REDIS_IMAGE}
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: 6379
+            timeoutSeconds: 1
+          name: redis
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - test "$(redis-cli -h 127.0.0.1 ping)" == "PONG"
+            initialDelaySeconds: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /var/lib/redis/data
+              name: redis-data
+      restartPolicy: Always
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - redis
+        from:
+          kind: ImageStreamTag
+          name: redis:5-el8
+          namespace: openshift
+      type: ImageChange
+    - type: ConfigChange

--- a/openshift/services/resalloc.yml
+++ b/openshift/services/resalloc.yml
@@ -1,0 +1,142 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: resalloc-config
+type: Opaque
+data:
+  pools.yaml: ${RESALLOC_POOL_YAML_B64}
+  server.yaml: ${RESALLOC_SERVER_YAML_B64}
+  spinup-playbook.yml: ${RESALLOC_SPINUP_PLAYBOOK_B64}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: resalloc-home
+type: Opaque
+data:
+  aws_config: W2RlZmF1bHRdCnJlZ2lvbiA9IHVzLWVhc3QtMQo=
+  aws_credentials: ${AWS_CREDENTIALS_B64}
+  id_rsa: ${AWS_SSH_PRIVATE_KEY_B64}
+  ssh_config: SG9zdCAqCiAgIElkZW50aXR5RmlsZSB+Ly5zc2gvaWRfcnNhCiAgIFN0cmljdEhvc3RLZXlDaGVja2luZyAgbm8KICAgVXNlcktub3duSG9zdHNGaWxlIC9kZXYvbnVsbAogICBTZXJ2ZXJBbGl2ZUludGVydmFsIDIwCiAgIFNlcnZlckFsaXZlQ291bnRNYXggNQogICBDb25uZWN0VGltZW91dCA2MAo=
+  ansible_conf: W2RlZmF1bHRzXQpsb2NhbF90bXA9L3RtcC8uYW5zaWJsZQpbc3NoX2Nvbm5lY3Rpb25dCmNvbnRyb2xfcGF0aF9kaXI9L3RtcC8uYW5zaWJsZQo=
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: resalloc-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: resalloc
+spec:
+  ports:
+    - name: resalloc
+      port: 49100
+      targetPort: 49100
+  selector:
+    name: resalloc
+
+
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: resalloc
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: quay.io/copr/resalloc:test
+      importPolicy:
+        scheduled: true
+      name: test
+
+---
+kind: DeploymentConfig
+apiVersion: v1
+metadata:
+  name: resalloc
+spec:
+  template:
+    metadata:
+      labels:
+        name: resalloc
+    spec:
+      containers:
+        - name: server
+          image: ${RESALLOC_IMAGE}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: resalloc-data
+              mountPath: /var/lib/resallocserver
+            - name: resalloc-data
+              mountPath: /var/log/resallocserver
+            - name: resalloc-config
+              mountPath: /etc/resallocserver
+            - name: resalloc-home
+              mountPath: /resalloc-home
+          env:
+            - name: CONFIG_DIR
+              value: /etc/resallocserver
+            - name: HOME
+              value: /resalloc-home
+
+          command: ["/usr/bin/resalloc-server"]
+
+      volumes:
+        - name: resalloc-config
+          secret:
+            secretName: resalloc-config
+            optional: false
+
+        - name: resalloc-home
+          secret:
+            secretName: resalloc-home
+            optional: false
+            defaultMode: 0600
+            items:
+              - key: aws_config
+                path: .aws/config
+              - key: aws_credentials
+                path: .aws/credentials
+              - key: id_rsa
+                path: .ssh/id_rsa
+              - key: ssh_config
+                path: .ssh/config
+              - key: ansible_conf
+                path: .ansible.cfg
+
+        - name: resalloc-data
+          persistentVolumeClaim:
+            claimName: resalloc-data
+
+      restartPolicy: Always
+
+  replicas: 1
+  strategy:
+    type: Recreate
+
+  triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+          - server
+        from:
+          kind: ImageStreamTag
+          name: resalloc:test
+      type: ImageChange
+
+    - type: ConfigChange
+
+# vim: ft=yaml


### PR DESCRIPTION
Convert all OpenShift deployment templates from Jinja2/Ansible format to plain YAML templates with parameter substitution. This is needed for our patner repos deployment.