### PR TITLE
Run Copr in OpenShift (locally for now)

### DIFF
--- a/kube-deploy/README.md
+++ b/kube-deploy/README.md
@@ -63,14 +63,45 @@ and pipes the result to `podman kube play`.
 
 Run `just` to see all available commands.
 
-## Future: OpenShift Deployment
+## Local OpenShift (CRC MicroShift)
 
-This setup is designed as the foundation for OpenShift deployment:
+Run Copr on a local OpenShift cluster using CRC
+with the MicroShift preset.
 
-- Deployment manifests in `base/` map directly to OpenShift resources
-- Service definitions are included for OpenShift service discovery
-- ConfigMaps and PVCs are defined as separate resources
-- Container images use standard patterns (non-root users, health checks)
-- Dynamic builder provisioning translates to OpenShift Jobs
-- The `containers/` directory is shared between local and OpenShift deployments
-- Kustomize overlays demonstrate the pattern used in OpenShift
+### Setup
+
+```bash
+crc setup
+crc config set preset microshift
+crc config set cpus 12
+crc config set memory 24576
+crc config set disk-size 80
+crc start
+```
+
+### Deploy
+
+```bash
+just up-openshift       # Build images, push to CRC, apply manifests
+just status-openshift   # Check pod status
+just down-openshift     # Tear down
+```
+
+Images are built locally with `podman`, transferred into the CRC VM via
+`podman save | ssh podman load`, and referenced as `localhost/copr-*` with
+`imagePullPolicy: Never`. The `overlays/openshift/` kustomization handles
+image name prefixing, pull policy, security contexts, and resalloc pool
+sizing.
+
+### Running tests
+
+TODO: still needs some tweaks... will fill out after https://github.com/fedora-copr/copr/pull/4305
+
+### Useful URLs
+
+| Service | URL |
+|---------|-----|
+| Frontend | http://copr-frontend-copr.apps.crc.testing |
+| Backend results | http://copr-backend-copr.apps.crc.testing |
+| Dist-git | http://copr-distgit-copr.apps.crc.testing |
+| Resalloc WebUI | http://copr-resalloc-copr.apps.crc.testing/pools |

--- a/kube-deploy/containers/resalloc/Containerfile
+++ b/kube-deploy/containers/resalloc/Containerfile
@@ -5,6 +5,7 @@ LABEL description="COPR Resalloc - resource allocation with dynamic builder prov
 RUN --mount=type=cache,target=/var/cache/dnf \
     dnf -y install \
         ansible \
+        kubernetes-client \
         openssh-clients \
         podman-remote \
         resalloc \
@@ -19,7 +20,8 @@ RUN set -ex && \
     mkdir -p /persistent /var/lib/resallocserver/.ssh /var/lib/resallocserver/resalloc_provision \
         /var/log/resallocserver && \
     chmod 700 /var/lib/resallocserver/.ssh && \
-    chmod +x /home/resalloc/provision/local-new /home/resalloc/provision/local-delete && \
+    chmod +x /home/resalloc/provision/local-new /home/resalloc/provision/local-delete \
+        /home/resalloc/provision/k8s-new /home/resalloc/provision/k8s-delete && \
     chown -R resalloc:root /persistent /var/lib/resallocserver /home/resalloc \
         /var/log/resallocserver && \
     chmod -R g+rwX /persistent /var/lib/resallocserver /home/resalloc \

--- a/kube-deploy/containers/resalloc/rootfs/home/resalloc/provision/k8s-delete
+++ b/kube-deploy/containers/resalloc/rootfs/home/resalloc/provision/k8s-delete
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Remove a builder pod. Called by resalloc when a builder
+# resource is no longer needed.
+
+NAME="copr-builder-${RESALLOC_NAME}"
+NAME="${NAME//_/-}"
+NAMESPACE="${COPR_NAMESPACE:-copr}"
+
+kubectl delete pod "$NAME" \
+    --namespace="$NAMESPACE" \
+    --ignore-not-found \
+    --wait=false

--- a/kube-deploy/containers/resalloc/rootfs/home/resalloc/provision/k8s-new
+++ b/kube-deploy/containers/resalloc/rootfs/home/resalloc/provision/k8s-new
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Provision a new builder pod via the Kubernetes API.
+# Resalloc calls this script when a builder resource is needed.
+# The builder pod runs SSHD so the backend can connect via SSH.
+
+set -e
+
+IMAGE="${BUILDER_IMAGE:-localhost/copr-builder:latest}"
+NAME="copr-builder-${RESALLOC_NAME:-manual-$(date +%s)}"
+NAME="${NAME//_/-}"
+NAMESPACE="${COPR_NAMESPACE:-copr}"
+
+kubectl run "$NAME" \
+    --namespace="$NAMESPACE" \
+    --image="$IMAGE" \
+    --image-pull-policy=IfNotPresent \
+    --restart=Never \
+    --labels="app=copr-builder" \
+    --overrides='{
+      "spec": {
+        "serviceAccountName": "copr-anyuid",
+        "containers": [{
+          "name": "builder",
+          "image": "'"$IMAGE"'",
+          "imagePullPolicy": "IfNotPresent",
+          "command": ["/usr/sbin/sshd", "-D"],
+          "securityContext": {"privileged": true},
+          "ports": [{"containerPort": 22}],
+          "volumeMounts": [{
+            "name": "ssh-pubkey",
+            "mountPath": "/root/.ssh/authorized_keys",
+            "subPath": "id_ed25519.pub",
+            "readOnly": true
+          }]
+        }],
+        "volumes": [{
+          "name": "ssh-pubkey",
+          "secret": {
+            "secretName": "copr-ssh-keys",
+            "defaultMode": 384
+          }
+        }]
+      }
+    }' >/dev/null
+
+kubectl wait --for=condition=Ready "pod/$NAME" \
+    --namespace="$NAMESPACE" \
+    --timeout=120s >/dev/null
+
+kubectl get pod "$NAME" \
+    --namespace="$NAMESPACE" \
+    --output=jsonpath='{.status.podIP}'

--- a/kube-deploy/justfile
+++ b/kube-deploy/justfile
@@ -101,6 +101,74 @@ up-local: build
     just kube-play dev-local
     @echo "COPR is running at http://localhost:5000 (local source at /opt/copr)"
 
+# ─── OpenShift (CRC MicroShift) ───────────────────────────────────────────
+
+crc_ssh_key := home_directory() / ".crc/machines/crc/id_ed25519"
+crc_ssh := "ssh -i " + crc_ssh_key + " -p 2222 -o StrictHostKeyChecking=no core@127.0.0.1"
+
+# Build images on host and push to CRC MicroShift VM
+push-images-to-crc: build
+    #!/bin/bash
+    set -euo pipefail
+    images=(copr-base copr-database copr-redis copr-frontend copr-backend copr-backend-httpd copr-distgit copr-keygen copr-resalloc copr-builder)
+    echo "Pushing ${#images[@]} images to CRC VM..."
+    for img in "${images[@]}"; do
+        echo "  $img..."
+        podman save "localhost/$img:latest" | {{crc_ssh}} "sudo TMPDIR=/var/home podman load"
+    done
+    echo "All images loaded into CRC VM"
+
+# Deploy to MicroShift (builds images, pushes to VM, applies manifests)
+up-openshift: generate-ssh-keys push-images-to-crc
+    #!/bin/bash
+    set -euo pipefail
+    eval $(crc oc-env)
+    echo "Creating namespace..."
+    oc create namespace copr 2>/dev/null || true
+    echo "Granting SCCs..."
+    oc adm policy add-scc-to-user anyuid -z copr-anyuid -n copr 2>/dev/null || true
+    oc adm policy add-scc-to-user privileged -z copr-anyuid -n copr 2>/dev/null || true
+    oc adm policy add-scc-to-user anyuid -z copr-builder-sa -n copr 2>/dev/null || true
+    echo "Injecting SSH keys as Secret..."
+    ssh_dir="{{justfile_directory()}}/containers/.ssh"
+    oc create secret generic copr-ssh-keys \
+        --namespace=copr \
+        --from-file=id_ed25519="$ssh_dir/id_ed25519" \
+        --from-file=id_ed25519.pub="$ssh_dir/id_ed25519.pub" \
+        --dry-run=client -o yaml | oc apply -f -
+    echo "Applying manifests..."
+    kustomize build manifests/overlays/openshift/ | oc apply -f -
+    echo "COPR is deploying on MicroShift"
+    echo "  just status-openshift       # check deployment"
+    echo "  oc logs -n copr <pod>       # view pod logs"
+
+# Stop OpenShift deployment
+down-openshift:
+    #!/bin/bash
+    eval $(crc oc-env)
+    oc delete pods -n copr -l app=copr-builder --ignore-not-found 2>/dev/null || true
+    kustomize build manifests/overlays/openshift/ | oc delete --ignore-not-found -f - 2>/dev/null || true
+    oc delete namespace copr --ignore-not-found 2>/dev/null || true
+    echo "Stopped"
+
+# Show OpenShift deployment status
+status-openshift:
+    #!/bin/bash
+    eval $(crc oc-env)
+    echo "=== Pods ==="
+    oc get pods -n copr 2>/dev/null || echo "  (namespace not found)"
+    echo ""
+    echo "=== Routes ==="
+    oc get routes -n copr 2>/dev/null || echo "  (none)"
+    echo ""
+    echo "=== PVCs ==="
+    oc get pvc -n copr 2>/dev/null || echo "  (none)"
+    echo ""
+    echo "=== Builder Pods ==="
+    oc get pods -n copr -l app=copr-builder 2>/dev/null || echo "  (none)"
+
+# ─── Stop ─────────────────────────────────────────────────────────────────
+
 # Stop all pods and dynamic builders
 down:
     #!/bin/bash

--- a/kube-deploy/manifests/base/backend.yaml
+++ b/kube-deploy/manifests/base/backend.yaml
@@ -19,6 +19,8 @@ spec:
         app: copr
         component: backend
     spec:
+      securityContext:
+        fsGroup: 987
       initContainers:
         - name: wait-redis
           image: copr-backend:latest
@@ -50,22 +52,24 @@ spec:
             requests:
               memory: "32Mi"
               cpu: "50m"
-        - name: fix-ssh-perms
+        - name: render-config
           image: copr-backend:latest
           command:
-            [
-              "sh",
-              "-c",
-              "cp /ssh-host/id_ed25519 /ssh-ready/ && cp /ssh-host/id_ed25519.pub /ssh-ready/ && chown 987:987 /ssh-ready/* && chmod 600 /ssh-ready/id_ed25519 && chmod 644 /ssh-ready/id_ed25519.pub",
-            ]
-          securityContext:
-            runAsUser: 0
+            - sh
+            - "-c"
+            - 'python3 -c "import os,sys; sys.stdout.write(open(''/etc/copr-template/copr-be.conf'').read().replace(''__COPR_BACKEND_FRONTEND_AUTH__'', os.environ[''COPR_FRONTEND_AUTH'']))" > /etc/copr-rendered/copr-be.conf'
+          env:
+            - name: COPR_FRONTEND_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: copr-backend-secrets
+                  key: frontend-auth
           volumeMounts:
-            - name: ssh-keys
-              mountPath: /ssh-host
-              readOnly: true
-            - name: ssh-ready
-              mountPath: /ssh-ready
+            - name: backend-config
+              mountPath: /etc/copr-template/copr-be.conf
+              subPath: copr-be.conf
+            - name: backend-config-rendered
+              mountPath: /etc/copr-rendered
           resources:
             limits:
               memory: "64Mi"
@@ -83,7 +87,7 @@ spec:
           volumeMounts:
             - name: results-data
               mountPath: /var/lib/copr/public_html/results
-            - name: backend-config
+            - name: backend-config-rendered
               mountPath: /etc/copr/copr-be.conf
               subPath: copr-be.conf
           livenessProbe:
@@ -112,14 +116,14 @@ spec:
           volumeMounts:
             - name: results-data
               mountPath: /var/lib/copr/public_html/results
-            - name: backend-config
+            - name: backend-config-rendered
               mountPath: /etc/copr/copr-be.conf
               subPath: copr-be.conf
-            - name: ssh-ready
+            - name: ssh-keys
               mountPath: /home/copr/.ssh/id_ed25519
               subPath: id_ed25519
               readOnly: true
-            - name: ssh-ready
+            - name: ssh-keys
               mountPath: /home/copr/.ssh/id_ed25519.pub
               subPath: id_ed25519.pub
               readOnly: true
@@ -130,10 +134,10 @@ spec:
             periodSeconds: 30
           resources:
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "2Gi"
+              cpu: "1000m"
             requests:
-              memory: "320Mi"
+              memory: "512Mi"
               cpu: "300m"
 
         - name: backend-action
@@ -149,7 +153,7 @@ spec:
           volumeMounts:
             - name: results-data
               mountPath: /var/lib/copr/public_html/results
-            - name: backend-config
+            - name: backend-config-rendered
               mountPath: /etc/copr/copr-be.conf
               subPath: copr-be.conf
           livenessProbe:
@@ -159,10 +163,10 @@ spec:
             periodSeconds: 30
           resources:
             limits:
-              memory: "256Mi"
-              cpu: "200m"
+              memory: "1Gi"
+              cpu: "500m"
             requests:
-              memory: "160Mi"
+              memory: "256Mi"
               cpu: "120m"
 
         - name: backend-httpd
@@ -199,15 +203,16 @@ spec:
         - name: backend-config
           configMap:
             name: copr-backend-config
+        - name: backend-config-rendered
+          emptyDir: {}
         - name: results-data
           persistentVolumeClaim:
             claimName: copr-results-data
         - name: ssh-keys
-          hostPath:
-            path: REPLACE_COPR_SSH_DIR
-            type: Directory
-        - name: ssh-ready
-          emptyDir: {}
+          secret:
+            secretName: copr-ssh-keys
+            defaultMode: 0640
+            optional: true
       restartPolicy: Always
 ---
 apiVersion: v1

--- a/kube-deploy/manifests/base/configmaps/backend.yaml
+++ b/kube-deploy/manifests/base/configmaps/backend.yaml
@@ -13,7 +13,7 @@ data:
 
     frontend_base_url = http://frontend:5000
 
-    frontend_auth = 1234
+    frontend_auth = __COPR_BACKEND_FRONTEND_AUTH__
 
     destdir = /var/lib/copr/public_html/results
 

--- a/kube-deploy/manifests/base/configmaps/distgit.yaml
+++ b/kube-deploy/manifests/base/configmaps/distgit.yaml
@@ -8,7 +8,7 @@ data:
     [dist-git]
     frontend_base_url = http://frontend:5000
 
-    frontend_auth = 1234
+    frontend_auth = __COPR_DISTGIT_FRONTEND_AUTH__
 
     per_task_log_dir = /var/lib/copr-dist-git/per-task-logs/
 

--- a/kube-deploy/manifests/base/configmaps/frontend.yaml
+++ b/kube-deploy/manifests/base/configmaps/frontend.yaml
@@ -17,10 +17,14 @@ data:
     WHOOSHEE_MIN_STRING_LEN = 2
     WHOOSHEE_WRITER_TIMEOUT = 10
 
-    SECRET_KEY = 'local-dev-secret-key-not-for-production'
-    BACKEND_PASSWORD = '1234'
+    import os
+    SECRET_KEY = os.environ.get('COPR_SECRET_KEY', 'MISSING')
+    BACKEND_PASSWORD = os.environ.get('COPR_BACKEND_PASSWORD', 'MISSING')
 
-    SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://copr-fe:coprpass@database:5432/coprdb'
+    _db_user = os.environ.get('COPR_DB_USER', 'copr-fe')
+    _db_pass = os.environ.get('COPR_DB_PASSWORD', 'MISSING')
+    _db_name = os.environ.get('COPR_DB_NAME', 'coprdb')
+    SQLALCHEMY_DATABASE_URI = f'postgresql+psycopg2://{_db_user}:{_db_pass}@database:5432/{_db_name}'
 
     LOGGING_LEVEL = 'debug'
     DEBUG = True

--- a/kube-deploy/manifests/base/database.yaml
+++ b/kube-deploy/manifests/base/database.yaml
@@ -19,16 +19,30 @@ spec:
         app: copr
         component: database
     spec:
+      securityContext:
+        runAsUser: 26
+        fsGroup: 26
       containers:
         - name: database
           image: copr-database:latest
           env:
+            - name: PGDATA
+              value: /var/lib/pgsql/data/pgdata
             - name: POSTGRESQL_USER
-              value: "copr-fe"
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: username
             - name: POSTGRESQL_PASSWORD
-              value: "coprpass"
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: password
             - name: POSTGRESQL_DATABASE
-              value: "coprdb"
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: database
           ports:
             - containerPort: 5432
               protocol: TCP

--- a/kube-deploy/manifests/base/distgit.yaml
+++ b/kube-deploy/manifests/base/distgit.yaml
@@ -35,6 +35,31 @@ spec:
             requests:
               memory: "32Mi"
               cpu: "50m"
+        - name: render-config
+          image: copr-distgit:latest
+          command:
+            - sh
+            - "-c"
+            - 'python3 -c "import os,sys; sys.stdout.write(open(''/etc/copr-template/copr-dist-git.conf'').read().replace(''__COPR_DISTGIT_FRONTEND_AUTH__'', os.environ[''COPR_FRONTEND_AUTH'']))" > /etc/copr-rendered/copr-dist-git.conf'
+          env:
+            - name: COPR_FRONTEND_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: copr-distgit-secrets
+                  key: frontend-auth
+          volumeMounts:
+            - name: distgit-config
+              mountPath: /etc/copr-template/copr-dist-git.conf
+              subPath: copr-dist-git.conf
+            - name: distgit-config-rendered
+              mountPath: /etc/copr-rendered
+          resources:
+            limits:
+              memory: "64Mi"
+              cpu: "100m"
+            requests:
+              memory: "32Mi"
+              cpu: "50m"
       containers:
         - name: distgit
           image: copr-distgit:latest
@@ -49,7 +74,7 @@ spec:
               mountPath: /var/lib/dist-git
             - name: distgit-logs
               mountPath: /var/lib/copr-dist-git
-            - name: distgit-config
+            - name: distgit-config-rendered
               mountPath: /etc/copr/copr-dist-git.conf
               subPath: copr-dist-git.conf
           resources:
@@ -97,6 +122,8 @@ spec:
         - name: distgit-config
           configMap:
             name: copr-distgit-config
+        - name: distgit-config-rendered
+          emptyDir: {}
         - name: distgit-data
           persistentVolumeClaim:
             claimName: copr-distgit-data

--- a/kube-deploy/manifests/base/frontend.yaml
+++ b/kube-deploy/manifests/base/frontend.yaml
@@ -56,6 +56,32 @@ spec:
             - /usr/bin/tini
             - "--"
             - /frontend-init
+          env:
+            - name: COPR_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: copr-frontend-secrets
+                  key: secret-key
+            - name: COPR_BACKEND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: copr-frontend-secrets
+                  key: backend-password
+            - name: COPR_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: username
+            - name: COPR_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: password
+            - name: COPR_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: database
           volumeMounts:
             - name: frontend-config
               mountPath: /etc/copr/copr.conf
@@ -73,6 +99,32 @@ spec:
           ports:
             - containerPort: 5000
               protocol: TCP
+          env:
+            - name: COPR_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: copr-frontend-secrets
+                  key: secret-key
+            - name: COPR_BACKEND_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: copr-frontend-secrets
+                  key: backend-password
+            - name: COPR_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: username
+            - name: COPR_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: password
+            - name: COPR_DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: copr-database-secrets
+                  key: database
           volumeMounts:
             - name: frontend-config
               mountPath: /etc/copr/copr.conf

--- a/kube-deploy/manifests/base/kustomization.yaml
+++ b/kube-deploy/manifests/base/kustomization.yaml
@@ -10,6 +10,12 @@ labels:
 
 resources:
   - volumes.yaml
+  - secrets/frontend.yaml
+  - secrets/backend.yaml
+  - secrets/database.yaml
+  - secrets/distgit.yaml
+  # ssh-keys.yaml intentionally excluded - injected at deploy time
+  # because it requires real key material from the host
   - configmaps/frontend.yaml
   - configmaps/backend.yaml
   - configmaps/resalloc.yaml

--- a/kube-deploy/manifests/base/resalloc.yaml
+++ b/kube-deploy/manifests/base/resalloc.yaml
@@ -67,6 +67,9 @@ spec:
           volumeMounts:
             - name: resalloc-data
               mountPath: /persistent
+            - name: resalloc-config
+              mountPath: /etc/resallocserver/pools.yaml
+              subPath: pools.yaml
           livenessProbe:
             tcpSocket:
               port: 5007

--- a/kube-deploy/manifests/base/secrets/backend.yaml
+++ b/kube-deploy/manifests/base/secrets/backend.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-backend-secrets
+type: Opaque
+stringData:
+  frontend-auth: "1234"

--- a/kube-deploy/manifests/base/secrets/database.yaml
+++ b/kube-deploy/manifests/base/secrets/database.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-database-secrets
+type: Opaque
+stringData:
+  username: "copr-fe"
+  password: "coprpass"
+  database: "coprdb"

--- a/kube-deploy/manifests/base/secrets/distgit.yaml
+++ b/kube-deploy/manifests/base/secrets/distgit.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-distgit-secrets
+type: Opaque
+stringData:
+  frontend-auth: "1234"

--- a/kube-deploy/manifests/base/secrets/frontend.yaml
+++ b/kube-deploy/manifests/base/secrets/frontend.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-frontend-secrets
+type: Opaque
+stringData:
+  secret-key: "local-dev-secret-key-not-for-production"
+  backend-password: "1234"

--- a/kube-deploy/manifests/base/secrets/ssh-keys.yaml
+++ b/kube-deploy/manifests/base/secrets/ssh-keys.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: copr-ssh-keys
+type: Opaque
+data: {}

--- a/kube-deploy/manifests/base/volumes.yaml
+++ b/kube-deploy/manifests/base/volumes.yaml
@@ -8,7 +8,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Gi
+      storage: 2Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -30,7 +30,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 50Gi
+      storage: 2Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -41,7 +41,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: 5Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -52,7 +52,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 1Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -74,7 +74,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 20Gi
+      storage: 1Gi
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -85,5 +85,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
-
+      storage: 1Gi

--- a/kube-deploy/manifests/overlays/dev/kustomization.yaml
+++ b/kube-deploy/manifests/overlays/dev/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 patches:
   - path: patch-ports.yaml
   - path: patch-resalloc.yaml
+  - path: patch-ssh.yaml

--- a/kube-deploy/manifests/overlays/dev/patch-ssh.yaml
+++ b/kube-deploy/manifests/overlays/dev/patch-ssh.yaml
@@ -1,0 +1,24 @@
+# Dev overlay: override SSH keys Secret with hostPath for podman kube play.
+# REPLACE_COPR_SSH_DIR is substituted at deploy time by the justfile.
+# Uses $patch:replace on the volumes list to avoid merging hostPath+secret.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-backend
+spec:
+  template:
+    spec:
+      volumes:
+        - $patch: replace
+        - name: backend-config
+          configMap:
+            name: copr-backend-config
+        - name: backend-config-rendered
+          emptyDir: {}
+        - name: results-data
+          persistentVolumeClaim:
+            claimName: copr-results-data
+        - name: ssh-keys
+          hostPath:
+            path: REPLACE_COPR_SSH_DIR
+            type: Directory

--- a/kube-deploy/manifests/overlays/openshift/kustomization.yaml
+++ b/kube-deploy/manifests/overlays/openshift/kustomization.yaml
@@ -1,0 +1,35 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: copr
+
+sortOptions:
+  order: fifo
+
+resources:
+  - ../../base
+  - routes.yaml
+  - rbac.yaml
+
+images:
+  - name: copr-frontend
+    newName: localhost/copr-frontend
+  - name: copr-backend
+    newName: localhost/copr-backend
+  - name: copr-backend-httpd
+    newName: localhost/copr-backend-httpd
+  - name: copr-database
+    newName: localhost/copr-database
+  - name: copr-redis
+    newName: localhost/copr-redis
+  - name: copr-distgit
+    newName: localhost/copr-distgit
+  - name: copr-keygen
+    newName: localhost/copr-keygen
+  - name: copr-resalloc
+    newName: localhost/copr-resalloc
+
+patches:
+  - path: patch-pullpolicy.yaml
+  - path: patch-resalloc.yaml
+  - path: patch-security.yaml

--- a/kube-deploy/manifests/overlays/openshift/patch-pullpolicy.yaml
+++ b/kube-deploy/manifests/overlays/openshift/patch-pullpolicy.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-frontend
+spec:
+  template:
+    spec:
+      $patch: merge
+      initContainers:
+        - name: wait-database
+          imagePullPolicy: Never
+        - name: wait-redis
+          imagePullPolicy: Never
+        - name: frontend-init
+          imagePullPolicy: Never
+      containers:
+        - name: frontend
+          imagePullPolicy: Never
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-backend
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-redis
+          imagePullPolicy: Never
+        - name: wait-resalloc
+          imagePullPolicy: Never
+        - name: render-config
+          imagePullPolicy: Never
+      containers:
+        - name: backend-log
+          imagePullPolicy: Never
+        - name: backend-build
+          imagePullPolicy: Never
+        - name: backend-action
+          imagePullPolicy: Never
+        - name: backend-httpd
+          imagePullPolicy: Never
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-distgit
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: wait-frontend
+          imagePullPolicy: Never
+        - name: render-config
+          imagePullPolicy: Never
+      containers:
+        - name: distgit
+          imagePullPolicy: Never
+        - name: distgit-httpd
+          imagePullPolicy: Never
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-keygen
+spec:
+  template:
+    spec:
+      containers:
+        - name: keygen-signd
+          imagePullPolicy: Never
+        - name: keygen-httpd
+          imagePullPolicy: Never
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-database
+spec:
+  template:
+    spec:
+      containers:
+        - name: database
+          imagePullPolicy: Never
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-redis
+spec:
+  template:
+    spec:
+      containers:
+        - name: redis
+          imagePullPolicy: Never
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-resalloc
+spec:
+  template:
+    spec:
+      containers:
+        - name: resalloc
+          imagePullPolicy: Never
+        - name: resalloc-webui
+          imagePullPolicy: Never

--- a/kube-deploy/manifests/overlays/openshift/patch-resalloc.yaml
+++ b/kube-deploy/manifests/overlays/openshift/patch-resalloc.yaml
@@ -1,0 +1,60 @@
+# Resalloc: use K8s-based builder provisioning (oc run) instead of
+# host podman socket. Assigns the copr-builder-sa ServiceAccount
+# so resalloc can create/delete builder pods via the K8s API.
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-resalloc
+spec:
+  template:
+    spec:
+      serviceAccountName: copr-builder-sa
+      containers:
+        - name: resalloc
+          env:
+            - name: BUILDER_IMAGE
+              value: "localhost/copr-builder:latest"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: copr-resalloc-config
+data:
+  pools.yaml: |
+    openshift_x86_64:
+      max: 24
+      max_starting: 24
+      max_prealloc: 0
+
+      tags:
+        - arch_noarch
+        - arch_x86_64
+        - arch_x86_64_native
+        - arch_x86_64_v2
+        - arch_x86_64_v2_native
+        - arch_aarch64
+        - arch_aarch64_emulated
+        - arch_ppc64le
+        - arch_ppc64le_emulated
+        - arch_i386
+        - arch_i386_native
+        - arch_i586
+        - arch_i586_native
+        - arch_i686
+        - arch_i686_native
+        - arch_armhfp
+        - arch_armhfp_emulated
+        - arch_s390x
+        - arch_s390x_emulated
+
+      tags_on_demand:
+        - copr_builder
+
+      cmd_new: "/home/resalloc/provision/k8s-new"
+      cmd_delete: "/home/resalloc/provision/k8s-delete"
+
+      livecheck_period: 180
+      reuse_opportunity_time: 0
+      reuse_max_count: 0
+      reuse_max_time: 0

--- a/kube-deploy/manifests/overlays/openshift/patch-security.yaml
+++ b/kube-deploy/manifests/overlays/openshift/patch-security.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-database
+spec:
+  template:
+    spec:
+      serviceAccountName: copr-anyuid
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-keygen
+spec:
+  template:
+    spec:
+      serviceAccountName: copr-anyuid
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-distgit
+spec:
+  template:
+    spec:
+      serviceAccountName: copr-anyuid
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-backend
+spec:
+  template:
+    spec:
+      serviceAccountName: copr-anyuid
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-frontend
+spec:
+  template:
+    spec:
+      serviceAccountName: copr-anyuid
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: copr-pulp
+spec:
+  template:
+    spec:
+      serviceAccountName: copr-anyuid
+      securityContext:
+        runAsUser: 0

--- a/kube-deploy/manifests/overlays/openshift/rbac.yaml
+++ b/kube-deploy/manifests/overlays/openshift/rbac.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: copr-builder-sa
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: copr-anyuid
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: copr-builder-manager
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete", "list", "get", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: copr-builder-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: copr-builder-manager
+subjects:
+  - kind: ServiceAccount
+    name: copr-builder-sa

--- a/kube-deploy/manifests/overlays/openshift/routes.yaml
+++ b/kube-deploy/manifests/overlays/openshift/routes.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: copr-frontend
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: frontend
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: copr-backend
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: backend-httpd
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: copr-distgit
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: distgit


### PR DESCRIPTION
Kustomize overlay + targets for deploying Copr on a local CRC MicroShift cluster. Builders are provisioned as Kubernetes pods via resalloc to simplify it for now (k8s-new/k8s-delete).

Beaker tests: most tests passes, 9 failures. All failures are environmental (missing chroots, single arch, hardcoded testing environment for podman-kube not for openshift). I'll fix the testing environment later to work with both (mainly bad dnf copr instance issues). After that I'll also provide a short TODO how to run the tests since I still did some manual tweaking on my machine to make the some tests run.