### PR TITLE
backend: fix race in PulpStorage.delete_builds()

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -62,13 +62,14 @@ class BatchedAddRemoveContent:
     Group a set of `add_and_remove` tasks for a single Pulp repository.
     """
     def __init__(self, repo_href, rpms_to_add, rpms_to_remove, backend_opts=None,
-                 log=None, noop=False, dirs_to_delete=None):
+                 log=None, noop=False, dirs_to_delete=None, client=None):
         self.repo_href = repo_href
         self.rpms_to_add = rpms_to_add or []
         self.rpms_to_remove = rpms_to_remove or []
         self.dirs_to_delete = dirs_to_delete or []
         self.log = log
         self.noop = noop
+        self.client = client
 
         if not backend_opts:
             self.log.error("can't get access to redis, batch disabled")
@@ -209,6 +210,66 @@ class BatchedAddRemoveContent:
         for key in self.notify_keys:
             self.log.info("Notifying %s that we succeeded", key)
             self.redis.hset(key, "status", "success")
+
+    def _execute_locked(self, repository):
+        """
+        Creates a new repository version and a new publication. Executed under lock.
+        """
+        if self.check_processed():
+            self.log.info("Task processed by other process")
+            return True
+
+        data = self.options()
+        dirs_to_delete = data.pop("dirs_to_delete", [])
+
+        try:
+            if not data["add_content_units"] and not data["remove_content_units"]:
+                return True
+            response = self.client.modify_repository_content(repository, **data)
+            if not response.ok:
+                self.log.error("Failed to create a new repository version for: %s, %s",
+                               repository, response.text)
+                return False
+            task = response.json()["task"]
+            if not self.client.wait_for_finished_task(
+                task, f"modify repository content {repository}",
+            ):
+                return False
+
+            return self.client.publish(repository)
+        finally:
+            self._delete_dirs(dirs_to_delete)
+
+    def _delete_dirs(self, dirs_to_delete):
+        for path in dirs_to_delete:
+            self.log.info("Removing directory %s", path)
+            shutil.rmtree(path)
+
+    def try_lock(self, repository):
+        """
+        Periodically try to acquire the lock, and execute the _execute_locked() method.
+        """
+
+        while True:
+
+            if self.check_processed(delete_if_not=False):
+                self.log.info("Task processed by other process (no-lock)")
+                return
+
+            try:
+                lockdir = os.environ.get(
+                    "COPR_TESTSUITE_LOCKPATH", "/var/lock/copr-backend")
+                with lock(repository, lockdir=lockdir, timeout=5, log=self.log):
+                    if self._execute_locked(repository):
+                        self.commit()
+                        self.log.debug("Repository version and Publication created by this process")
+                        break
+
+            except LockTimeout:
+                continue  # Try again...
+
+            # we never loop, only upon timeout
+            assert False
 
 
 class PulpClient:
@@ -547,76 +608,6 @@ class PulpClient:
             while content := fp.read(size):
                 yield content
 
-    def modify_repository_content_locked(self, repository, batch):
-        """
-        Creates a new repository version and a new publication. Executed under lock.
-        """
-        if batch.check_processed():
-            self.log.info("Task processed by other process")
-            return True
-
-        # Merge others' tasks with ours (if any).
-        data = batch.options()
-        dirs_to_delete = data.pop("dirs_to_delete", [])
-
-        try:
-            if not data["add_content_units"] and not data["remove_content_units"]:
-                return True
-            # Make the request to create a new repository version
-            response = self.modify_repository_content(repository, **data)
-            if not response.ok:
-                self.log.error("Failed to create a new repository version for: %s, %s",
-                               repository, response.text)
-                return False
-            task = response.json()["task"]
-            if not self.wait_for_finished_task(
-                task, f"modify repository content {repository}",
-            ):
-                return False
-
-            # Make a request to create a new publication
-            return self.publish(repository)
-        finally:
-            self._delete_dirs(dirs_to_delete)
-
-    def _delete_dirs(self, dirs_to_delete):
-        for path in dirs_to_delete:
-            self.log.info("Removing directory %s", path)
-            shutil.rmtree(path)
-
-    def try_lock(self, repository, batch):
-        """
-        Periodically try to acquire the lock, and execute the modify_repository_content_locked() method.
-        """
-
-        while True:
-
-            # We don't have fair locking (locks-first => processes-first).  So to
-            # avoid potential indefinite waiting (see issue #1423) we check if the
-            # task isn't already processed _without_ having the lock.
-
-            if batch.check_processed(delete_if_not=False):
-                self.log.info("Task processed by other process (no-lock)")
-                return
-
-            try:
-                lockdir = os.environ.get(
-                    "COPR_TESTSUITE_LOCKPATH", "/var/lock/copr-backend")
-                with lock(repository, lockdir=lockdir, timeout=5, log=self.log):
-                    if self.modify_repository_content_locked(repository, batch):
-                        # While we still hold the lock, notify others we processed their
-                        # task.  Note that we do not commit in case of random exceptions
-                        # above.
-                        batch.commit()
-                        self.log.debug("Repository version and Publication created by this process")
-                        break
-
-            except LockTimeout:
-                continue  # Try again...
-
-            # we never loop, only upon timeout
-            assert False
-
     def modify_repository_content(self, repository, add_content_units, remove_content_units):
         """
         Add and/or remove a list of artifacts to/from a repository
@@ -636,11 +627,11 @@ class PulpClient:
         pages = [list(x) for x in batched(artifacts, size)]
         for i, page in enumerate(pages, start=1):
             batch = BatchedAddRemoveContent(
-                repository, page, None, self.opts, self.log)
+                repository, page, None, self.opts, self.log, client=self)
             # Put our task to Redis DB and allow _others_ to process our
-            # own task.  This needs to be run _before_ the lock() call.
+            # own task.  This needs to be run _before_ try_lock().
             batch.make_request()
-            self.try_lock(repository, batch)
+            batch.try_lock(repository)
             self.log.info(
                 "Pulp: add_content: %s (%s) [%s/%s]",
                 repository, page, i, len(pages),
@@ -657,11 +648,11 @@ class PulpClient:
         for i, page in enumerate(pages, start=1):
             batch = BatchedAddRemoveContent(
                 repository, None, page, self.opts, self.log,
-                dirs_to_delete=dirs_to_delete)
+                dirs_to_delete=dirs_to_delete, client=self)
             # Put our task to Redis DB and allow _others_ to process our
-            # own task.  This needs to be run _before_ the lock() call.
+            # own task.  This needs to be run _before_ try_lock().
             batch.make_request()
-            self.try_lock(repository, batch)
+            batch.try_lock(repository)
             self.log.info(
                 "Pulp: delete_content: %s (%s) [%s/%s]",
                 repository, page, i, len(pages),

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import shutil
 import time
 import tomllib
 import hashlib
@@ -60,10 +61,12 @@ class BatchedAddRemoveContent:
     """
     Group a set of `add_and_remove` tasks for a single Pulp repository.
     """
-    def __init__(self, repo_href, rpms_to_add, rpms_to_remove, backend_opts=None, log=None, noop=False):
+    def __init__(self, repo_href, rpms_to_add, rpms_to_remove, backend_opts=None,
+                 log=None, noop=False, dirs_to_delete=None):
         self.repo_href = repo_href
         self.rpms_to_add = rpms_to_add or []
         self.rpms_to_remove = rpms_to_remove or []
+        self.dirs_to_delete = dirs_to_delete or []
         self.log = log
         self.noop = noop
 
@@ -76,6 +79,7 @@ class BatchedAddRemoveContent:
         self._json_redis_task = json.dumps({
             "add_content_units": self.rpms_to_add,
             "remove_content_units": self.rpms_to_remove,
+            "dirs_to_delete": self.dirs_to_delete,
         })
 
         self.notify_keys = []
@@ -136,9 +140,12 @@ class BatchedAddRemoveContent:
         """
         rpms_to_add = set(self.rpms_to_add)
         rpms_to_remove = set(self.rpms_to_remove)
+        dirs_to_delete = set(self.dirs_to_delete)
 
         if self.noop:
-            return {"add_content_units": rpms_to_add, "remove_content_units": rpms_to_remove}
+            return {"add_content_units": rpms_to_add,
+                    "remove_content_units": rpms_to_remove,
+                    "dirs_to_delete": dirs_to_delete}
 
         for key in self.redis.keys(self.key_pattern):
             assert key != self.key
@@ -179,13 +186,16 @@ class BatchedAddRemoveContent:
             # append "add" tasks, if that makes sense
             rpms_to_add.update(task_opts["add_content_units"])
             rpms_to_remove.update(task_opts["remove_content_units"])
+            dirs_to_delete.update(task_opts.get("dirs_to_delete", []))
 
         # Make sure we are not adding and removing the same packages
         common = rpms_to_add & rpms_to_remove
         rpms_to_add -= common
         rpms_to_remove -= common
 
-        return {"add_content_units": list(rpms_to_add), "remove_content_units": list(rpms_to_remove)}
+        return {"add_content_units": list(rpms_to_add),
+                "remove_content_units": list(rpms_to_remove),
+                "dirs_to_delete": list(dirs_to_delete)}
 
     def commit(self):
         """
@@ -547,23 +557,32 @@ class PulpClient:
 
         # Merge others' tasks with ours (if any).
         data = batch.options()
-        if not data["add_content_units"] and not data["remove_content_units"]:
-            # No RPMs to add or remove
-            return True
-        # Make the request to create a new repository version
-        response = self.modify_repository_content(repository, **data)
-        if not response.ok:
-            self.log.error("Failed to create a new repository version for: %s, %s",
-                           repository, response.text)
-            return False
-        task = response.json()["task"]
-        if not self.wait_for_finished_task(
-            task, f"modify repository content {repository}",
-        ):
-            return False
+        dirs_to_delete = data.pop("dirs_to_delete", [])
 
-        # Make a request to create a new publication
-        return self.publish(repository)
+        try:
+            if not data["add_content_units"] and not data["remove_content_units"]:
+                return True
+            # Make the request to create a new repository version
+            response = self.modify_repository_content(repository, **data)
+            if not response.ok:
+                self.log.error("Failed to create a new repository version for: %s, %s",
+                               repository, response.text)
+                return False
+            task = response.json()["task"]
+            if not self.wait_for_finished_task(
+                task, f"modify repository content {repository}",
+            ):
+                return False
+
+            # Make a request to create a new publication
+            return self.publish(repository)
+        finally:
+            self._delete_dirs(dirs_to_delete)
+
+    def _delete_dirs(self, dirs_to_delete):
+        for path in dirs_to_delete:
+            self.log.info("Removing directory %s", path)
+            shutil.rmtree(path)
 
     def try_lock(self, repository, batch):
         """
@@ -628,7 +647,7 @@ class PulpClient:
             )
         return True
 
-    def delete_content(self, repository, artifacts):
+    def delete_content(self, repository, artifacts, dirs_to_delete=None):
         """
         Delete a list of artifacts from a repository
         https://pulpproject.org/pulp_rpm/restapi/#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_modify
@@ -637,7 +656,8 @@ class PulpClient:
         pages = [list(x) for x in batched(artifacts, size)]
         for i, page in enumerate(pages, start=1):
             batch = BatchedAddRemoveContent(
-                repository, None, page, self.opts, self.log)
+                repository, None, page, self.opts, self.log,
+                dirs_to_delete=dirs_to_delete)
             # Put our task to Redis DB and allow _others_ to process our
             # own task.  This needs to be run _before_ the lock() call.
             batch.make_request()

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -561,14 +561,13 @@ class PulpStorage(Storage):
             repository = self._get_repository(chroot)
             # Find the RPMs by list of build ids
             content_response = self.client.get_content(build_ids, fields=["prn"])
-            list_of_prns = [package["prn"] for package in content_response.json()["results"] ]
-            self.client.delete_content(repository, list_of_prns)
-            self.log.info("Deleted resources: %s", list_of_prns)
+            list_of_prns = [package["prn"] for package in content_response.json()["results"]]
 
-            # Delete results from the backend (logs, info files, etc)
-            for subdir in subdirs:
-                path = os.path.join(chroot_path, subdir)
-                shutil.rmtree(path)
+            dirs_to_delete = [os.path.join(chroot_path, subdir)
+                              for subdir in subdirs]
+            self.client.delete_content(repository, list_of_prns,
+                                       dirs_to_delete=dirs_to_delete)
+            self.log.info("Deleted resources: %s", list_of_prns)
         return result
 
     def repository_exists(self, dirname, chroot, baseurl):

--- a/backend/tests/test_createrepo.py
+++ b/backend/tests/test_createrepo.py
@@ -5,13 +5,18 @@ import tempfile
 import shutil
 
 import testlib
-from testlib import assert_logs_exist, AsyncCreaterepoRequestFactory
+from testlib import (
+    assert_logs_exist,
+    AsyncCreaterepoRequestFactory,
+    AsyncAddRemoveRequestFactory,
+)
 
 from copr_common.redis_helpers import get_redis_connection
 from copr_backend.createrepo import (
     BatchedCreaterepo,
     MAX_IN_BATCH,
 )
+from copr_backend.pulp import BatchedAddRemoveContent
 
 from copr_backend.helpers import BackendConfigReader
 
@@ -257,3 +262,92 @@ class TestBatchedCreaterepo:
                     without_status.add(add_dir)
         assert "add_2" in without_status
         assert len(without_status) == 3
+
+
+class TestBatchedAddRemoveContent:
+    def setup_method(self):
+        self.workdir = tempfile.mkdtemp(prefix="copr-batched-ar-test-")
+        self.config_file = testlib.minimal_be_config(self.workdir, {
+            "redis_db": 9,
+            "redis_port": 7777,
+        })
+        self.config = BackendConfigReader(self.config_file).read()
+        self.redis = get_redis_connection(self.config)
+        self.request_add_remove = AsyncAddRemoveRequestFactory(self.redis)
+        self.redis.flushdb()
+
+    def teardown_method(self):
+        shutil.rmtree(self.workdir)
+        self.redis.flushdb()
+
+    def _prep_batch(self, repo_href, rpms_to_add=None, rpms_to_remove=None,
+                    dirs_to_delete=None):
+        self.batch = BatchedAddRemoveContent(
+            repo_href,
+            rpms_to_add or [],
+            rpms_to_remove or ["prn:own"],
+            backend_opts=self.config,
+            log=logging.getLogger(),
+            dirs_to_delete=dirs_to_delete,
+        )
+        return self.batch
+
+    def test_dirs_to_delete_stored_in_redis(self):
+        repo = "/api/v3/repositories/rpm/rpm/abc/"
+        batch = self._prep_batch(repo, dirs_to_delete=["/some/path/build1"])
+        batch.make_request()
+
+        keys = self.redis.keys()
+        assert len(keys) == 1
+        task = json.loads(self.redis.hgetall(keys[0])["task"])
+        assert task["dirs_to_delete"] == ["/some/path/build1"]
+
+    def test_dirs_to_delete_collected_from_others(self):
+        repo = "/api/v3/repositories/rpm/rpm/def/"
+        batch = self._prep_batch(repo, dirs_to_delete=["/path/a"])
+        batch.make_request()
+
+        self.request_add_remove.get(repo, {
+            "remove_content_units": ["prn:2"],
+            "dirs_to_delete": ["/path/b", "/path/c"],
+        })
+        self.request_add_remove.get(repo, {
+            "remove_content_units": ["prn:3"],
+            "dirs_to_delete": ["/path/a"],
+        })
+
+        assert not batch.check_processed()
+        result = batch.options()
+        assert set(result["dirs_to_delete"]) == {"/path/a", "/path/b", "/path/c"}
+        assert len(batch.notify_keys) == 2
+
+    def test_dirs_to_delete_empty_by_default(self):
+        repo = "/api/v3/repositories/rpm/rpm/ghi/"
+        batch = self._prep_batch(repo)
+        batch.make_request()
+
+        self.request_add_remove.get(repo)
+
+        assert not batch.check_processed()
+        result = batch.options()
+        assert result["dirs_to_delete"] == []
+
+    def test_dirs_to_delete_backward_compat(self):
+        """Old Redis entries without dirs_to_delete should still work."""
+        repo = "/api/v3/repositories/rpm/rpm/compat/"
+        batch = self._prep_batch(repo, dirs_to_delete=["/path/new"])
+        batch.make_request()
+
+        # Simulate an old-format entry without dirs_to_delete
+        old_task = json.dumps({
+            "add_content_units": [],
+            "remove_content_units": ["prn:old"],
+        })
+        old_pid = os.getpid() + 999
+        old_key = "add_remove_batched::{}::{}".format(repo, old_pid)
+        self.redis.hset(old_key, "task", old_task)
+
+        assert not batch.check_processed()
+        result = batch.options()
+        assert set(result["dirs_to_delete"]) == {"/path/new"}
+        assert "prn:old" in result["remove_content_units"]

--- a/backend/tests/testlib/__init__.py
+++ b/backend/tests/testlib/__init__.py
@@ -310,6 +310,29 @@ class AsyncCreaterepoRequestFactory:
             self.redis.hset(key, "status", "success")
 
 
+class AsyncAddRemoveRequestFactory:
+    """ Generator for asynchronous add/remove content requests """
+    def __init__(self, redis):
+        self.pid = os.getpid()
+        self.redis = redis
+
+    def get(self, repo_href, overrides=None, done=False):
+        """ put new request to redis """
+        task = {
+            "add_content_units": [],
+            "remove_content_units": ["prn:1"],
+            "dirs_to_delete": [],
+        }
+        self.pid += 1
+        if overrides:
+            task.update(overrides)
+        key = "add_remove_batched::{}::{}".format(repo_href, self.pid)
+        task_json = json.dumps(task)
+        self.redis.hset(key, "task", task_json)
+        if done:
+            self.redis.hset(key, "status", "success")
+
+
 def patch_path(method, directory):
     directory = os.path.realpath(directory)
 

--- a/pylintrc
+++ b/pylintrc
@@ -135,7 +135,7 @@ min-public-methods=1
 max-public-methods=21
 
 # Maximum number of function arguments.
-max-positional-arguments=8
+max-positional-arguments=9
 
 
 [FORMAT]


### PR DESCRIPTION
Multiple copr-backend-process-action workers can concurrently process build deletion actions for the same project/chroot.  While the Pulp-side content removal already goes through BatchedAddRemoveContent (with proper locking), the subsequent shutil.rmtree() calls for local build directories ran without any lock.  This caused FileNotFoundError crashes when two workers raced to delete the same directory.

Move the local directory cleanup into the BatchedAddRemoveContent mechanism — dirs_to_delete paths are now stored in Redis alongside the Pulp content units, collected from concurrent tasks in options(), and executed under the repository lock in modify_repository_content_locked().

Assisted-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Fixes: #4363