### PR TITLE
rpmbuild: fix typo, redundant mkdir, and file handle leak

### DIFF
--- a/rpmbuild/copr_rpmbuild/providers/base.py
+++ b/rpmbuild/copr_rpmbuild/providers/base.py
@@ -1,5 +1,4 @@
 import os
-import errno
 import logging
 import shutil
 import stat
@@ -46,11 +45,6 @@ class Provider(object):
         # A per-task uniquely named working directory.  Ideally all the
         # work-in-progress stuff should live here.
         self.workdir = tempfile.mkdtemp(dir=self.workspace, prefix="workdir-")
-        try:
-            os.mkdir(self.workdir)
-        except OSError as e:
-            if e.errno != errno.EEXIST:
-                raise
 
         self.copr_rpmbuild_config = Config()
         self.copr_rpmbuild_config.load_config()

--- a/rpmbuild/copr_rpmbuild/providers/scm.py
+++ b/rpmbuild/copr_rpmbuild/providers/scm.py
@@ -14,7 +14,7 @@ from copr_rpmbuild.providers.base import Provider
 
 log = logging.getLogger("__main__")
 
-MAKE_SRPM_TEPMLATE = (
+MAKE_SRPM_TEMPLATE = (
     "set -x && "
     'cd {0} && '
     'echo -e "[safe]\ndirectory = {4}\ndirectory = {4}/*" > ~/.gitconfig && '
@@ -83,9 +83,8 @@ class ScmProvider(Provider):
         config_path = os.path.join(config_dir_path, 'rpkg.conf')
         log.debug('Writing config into '+config_path)
 
-        f = open(config_path, "w+")
-        f.write(config)
-        f.close()
+        with open(config_path, "w", encoding="utf-8") as f:
+            f.write(config)
 
         return config_path
 
@@ -117,7 +116,7 @@ class ScmProvider(Provider):
             .format(self.workdir, mock_workdir, self.resultdir, mock_resultdir)
 
         makefile_path = os.path.join(mock_repodir, '.copr', 'Makefile')
-        make_srpm_cmd_part = MAKE_SRPM_TEPMLATE.format(mock_cwd, makefile_path,
+        make_srpm_cmd_part = MAKE_SRPM_TEMPLATE.format(mock_cwd, makefile_path,
                 mock_resultdir, mock_spec_path, mock_repodir)
 
         mock_config_file = self.generate_mock_config()

--- a/rpmbuild/tests/test_scm.py
+++ b/rpmbuild/tests/test_scm.py
@@ -4,7 +4,7 @@ import stat
 import configparser
 import shutil
 
-from copr_rpmbuild.providers.scm import ScmProvider, MAKE_SRPM_TEPMLATE
+from copr_rpmbuild.providers.scm import ScmProvider, MAKE_SRPM_TEMPLATE
 from copr_rpmbuild.helpers import read_config
 from . import TestCase
 
@@ -142,7 +142,7 @@ class TestScmProvider(TestCase):
         bind_mount_cmd_part = '--plugin-option=bind_mount:dirs=(("{0}", "/mnt/{1}"), ("{2}", "/mnt/{3}"))'\
                               .format(provider.workdir, workdir_base,
                                       resultdir, basename)
-        make_srpm_cmd_part = MAKE_SRPM_TEPMLATE.format(
+        make_srpm_cmd_part = MAKE_SRPM_TEMPLATE.format(
             "/mnt/{0}/somerepo/subpkg".format(workdir_base),
             "/mnt/{0}/somerepo/.copr/Makefile".format(workdir_base),
             "/mnt/{0}".format(basename),


### PR DESCRIPTION
- Fix MAKE_SRPM_TEPMLATE → MAKE_SRPM_TEMPLATE typo
- Remove redundant os.mkdir() after tempfile.mkdtemp() which already creates the directory
- Use context manager for file writing in ScmProvider to prevent resource leak on exception