### PR TITLE
Add support for migrating multiple owners

### DIFF
--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -52,6 +52,11 @@ def get_arg_parser():
         "--owner",
         help="Migrate all projects for this owner",
     )
+    target.add_argument(
+        "--blocked-owners",
+        action="store_true",
+        help="Migrate all projects for all currently blocked owners",
+    )
     parser.add_argument(
         "--delete",
         action="store_true",
@@ -331,6 +336,24 @@ def handle_project(fullname, config, dst):
     return 0
 
 
+def handle_projects(projects, config, dst):
+    """
+    Process a migration of multiple projects
+    """
+    result = 0
+    for i, fullname in enumerate(projects, start=1):
+        print(
+            "[{0}/{1}] Migrating {2} to {3}"
+            .format(i, len(projects), fullname, dst)
+        )
+        success = handle_project(fullname, config, dst) == 0
+        status = "Success." if success else "Failure."
+        log.info("Project migration for %s %s", fullname, status)
+        if not success:
+            result = 1
+    return result
+
+
 def main():
     """
     The main function
@@ -356,15 +379,14 @@ def main():
         sys.exit(handle_project(args.project, config, args.dst))
     elif args.owner:
         projects = all_projects_for_owner(args.owner, config)
-        for i, fullname in enumerate(projects, start=1):
-            print(
-                "[{0}/{1}] Migrating {2} to {3}"
-                .format(i, len(projects), fullname, args.dst)
-            )
-
-            status = "Success." if handle_project(fullname, config, args.dst) == 0 else "Failure."
-            log.info("Project migration for %s %s", fullname, status)
-
+        sys.exit(handle_projects(projects, config, args.dst))
+    elif args.blocked_owners:
+        result = 0
+        for owner in config.builds_limits["blocked_owners"]:
+            projects = all_projects_for_owner(owner, config)
+            if handle_projects(projects, config, args.dst) != 0:
+                result = 1
+        sys.exit(result)
     else:
         log.error("Unexpected choice. This should never happen")
         sys.exit(1)

--- a/frontend/coprs_frontend/commands/owners_in_storage.py
+++ b/frontend/coprs_frontend/commands/owners_in_storage.py
@@ -1,0 +1,53 @@
+"""
+List all owners that have projects in some storage
+"""
+
+from itertools import batched
+import click
+from copr_common.enums import StorageEnum
+from coprs.logic.coprs_logic import CoprsLogic
+from coprs import models
+
+
+@click.command()
+@click.option(
+    "--storage",
+    required=True,
+    type=click.Choice(["backend", "pulp"]),
+)
+@click.option(
+    "--prefix",
+    required=False,
+)
+@click.option(
+    "--chunks",
+    required=False,
+    type=click.IntRange(min=1),
+)
+@click.option(
+    "--commas",
+    is_flag=True,
+)
+def owners_in_storage(storage, prefix, chunks, commas):
+    """
+    List all owners that have projects in some storage
+    """
+    owners = set()
+    projects = CoprsLogic.get_all().filter(
+        models.Copr.storage == StorageEnum(storage)
+    )
+    for project in projects:
+        if prefix and not project.owner_name.startswith(prefix):
+            continue
+        owners.add(project.owner_name)
+
+    if not chunks:
+        chunks = len(owners) + 1
+
+    for chunk in batched(sorted(owners), chunks):
+        for i, owner in enumerate(chunk):
+            if commas and i != len(chunk) - 1:
+                print(f"{owner},")
+            else:
+                print(owner)
+        print("")

--- a/frontend/coprs_frontend/manage.py
+++ b/frontend/coprs_frontend/manage.py
@@ -45,6 +45,7 @@ import commands.warning_banner
 import commands.usage_treemap
 import commands.failed_to_succeeded_stats
 import commands.change_storage
+import commands.owners_in_storage
 
 from coprs import app
 
@@ -100,6 +101,7 @@ commands_list =	[
     "usage_treemap",
     "failed_to_succeeded_stats",
     "change_storage",
+    "owners_in_storage",
 ]
 
 


### PR DESCRIPTION
We don't have upstream tickets, but the plan is that we are going to migrate all group projects, then all projects for owners starting with "a", then "b", "c", etc.

See the migration schedule
https://docs.google.com/spreadsheets/d/1VNhH10UbisuUvS4xaZGXGClpBhjYODpxEdsTC7p4vzk/edit?gid=0#gid=0

These changes will make it much easier for us. We can run this on the frontend:

```
# In reality we will do larger chunks, maybe 100 owners at once
$ copr-frontend owners_in_storage --storage backend --prefix @ --chunks 5 --commas
@389ds,
@3dprinting,
@CESNET,
@ClusterLabs,
@CodeOrange

@CoreOS,
@ELN,
@Hawkular,
@MavrykDynamics,
@OKD

@OpenShiftOnlineOps,
@Serokell,
@abrt,
@ai-ml,
@an-anime-team
```

Then copy-paste the chunk into `/etc/copr/copr-be.conf` as `blocked_owners` and run

```
$ systemctl restart copr-backend.target
$ copr-change-storage --src backend --dst pulp --blocked-owners
```

And then the next chunk, and the next one ...