### PR TITLE
Fix create_file_logger guard for pytest >= 9.1 compatibility

### DIFF
--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -574,7 +574,11 @@ def get_redis_logger(opts, name, who):
 def create_file_logger(name, filepath, fmt=None):
     logger = logging.getLogger(name)
 
-    if not logger.handlers:
+    has_file_handler = any(
+        isinstance(h, logging.handlers.WatchedFileHandler)
+        for h in logger.handlers
+    )
+    if not has_file_handler:
         handler = logging.handlers.WatchedFileHandler(filename=filepath)
         handler.setFormatter(fmt if fmt is not None else default_log_format)
         logger.addHandler(handler)


### PR DESCRIPTION
pytest 9.1 injects its own capture handler into non-propagating loggers, causing the `if not logger.handlers:` guard to skip creating the WatchedFileHandler on subsequent calls with different file paths. Check specifically for WatchedFileHandler instead.

Assisted-by: Claude Opus 4.6