### PR TITLE
rpmbuild: do not build-depend on scl-utils

### DIFF
--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -28,7 +28,6 @@ RUN set -ex ; \
                    rpm \
                    glib2 \
                    ca-certificates \
-                   scl-utils-build \
                    ethtool \
     && dnf -y install copr-builder \
     && dnf clean all

--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -122,7 +122,6 @@ Requires: podman
 Requires: pyp2rpm
 Requires: pyp2spec >= 0.10.0
 Requires: rubygem-gem2rpm
-Requires: scl-utils-build
 Requires: fedora-review >= 0.8
 Requires: fedora-review-plugin-java
 %endif


### PR DESCRIPTION
scl-utils is reaching end-of-life in Fedora, and we were asked to remove this dependency to avoid future FTBFS issues.

Most of the time, users need to have scl-utils-build installed in the chroot anyway (for the required RPM macros).  If scl-utils-build is needed at source build time for any reason, users are advised to switch to the custom method, select an (older) chroot that still provides scl-utils-build, and specify it in the source build-time requirements.

Fixes: #4329