### PR TITLE
Fair locking using Redis DB

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -2,7 +2,7 @@
 %global tests_version 5
 %global tests_tar test-data-copr-backend
 
-%global copr_common_version 1.2.1
+%global copr_common_version 1.7.2
 
 Name:       copr-backend
 Version:    2.13

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -14,7 +14,7 @@ from itertools import batched
 from urllib.parse import urlencode
 
 from copr_common.request import SafeRequest
-from copr_common.lock import lock, LockTimeout
+from copr_common.lock import lock
 from copr_common.redis_helpers import get_redis_connection
 
 
@@ -247,29 +247,12 @@ class BatchedAddRemoveContent:
 
     def try_lock(self, repository):
         """
-        Periodically try to acquire the lock, and execute the _execute_locked() method.
+        Acquire the lock and execute the _execute_locked() method.
         """
-
-        while True:
-
-            if self.check_processed(delete_if_not=False):
-                self.log.info("Task processed by other process (no-lock)")
-                return
-
-            try:
-                lockdir = os.environ.get(
-                    "COPR_TESTSUITE_LOCKPATH", "/var/lock/copr-backend")
-                with lock(repository, lockdir=lockdir, timeout=5, log=self.log):
-                    if self._execute_locked(repository):
-                        self.commit()
-                        self.log.debug("Repository version and Publication created by this process")
-                        break
-
-            except LockTimeout:
-                continue  # Try again...
-
-            # we never loop, only upon timeout
-            assert False
+        with lock(repository, redis_conn=self.redis, log=self.log):
+            if self._execute_locked(repository):
+                self.commit()
+                self.log.debug("Repository version and Publication created by this process")
 
 
 class PulpClient:

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -14,7 +14,7 @@ from itertools import batched
 from urllib.parse import urlencode
 
 from copr_common.request import SafeRequest
-from copr_common.lock import lock
+from copr_common.lock import Lock
 from copr_common.redis_helpers import get_redis_connection
 
 
@@ -249,7 +249,7 @@ class BatchedAddRemoveContent:
         """
         Acquire the lock and execute the _execute_locked() method.
         """
-        with lock(repository, redis_conn=self.redis, log=self.log):
+        with Lock(self.redis, self.log).lock(repository):
             if self._execute_locked(repository):
                 self.commit()
                 self.log.debug("Repository version and Publication created by this process")

--- a/backend/copr_backend/pulp_http_redirect.py
+++ b/backend/copr_backend/pulp_http_redirect.py
@@ -13,12 +13,14 @@ class PulpHTTPRedirect:
     https://pagure.io/fedora-infra/ansible/blob/main/f/roles/copr/backend/templates/lighttpd/pulp-redirect.lua.j2
     """
 
-    def __init__(self, path=None, lockdir=None, log=None):
+    def __init__(self, path=None, redis_conn=None, log=None):
         self.path = path or PULP_REDIRECT_FILE
-        self.lockdir = lockdir or "/var/lock/copr-backend"
+        self.redis_conn = redis_conn
         self.log = log
         if not self.log:
             raise NotImplementedError("Default logger not implemented yet")
+        if not self.redis_conn:
+            raise NotImplementedError("Redis connection is required")
 
     def add(self, owner, project):
         """
@@ -32,7 +34,7 @@ class PulpHTTPRedirect:
             if fullname in projects:
                 return
 
-            with lock(self.path, lockdir=self.lockdir, timeout=-1, log=self.log):
+            with lock(self.path, redis_conn=self.redis_conn, log=self.log):
                 with open(self.path, "r", encoding="utf-8") as fp:
                     projects = fp.read().splitlines()
 
@@ -55,7 +57,7 @@ class PulpHTTPRedirect:
             if fullname not in projects:
                 return
 
-            with lock(self.path, lockdir=self.lockdir, timeout=-1, log=self.log):
+            with lock(self.path, redis_conn=self.redis_conn, log=self.log):
                 with open(self.path, "r", encoding="utf-8") as fp:
                     projects = fp.read().splitlines()
 

--- a/backend/copr_backend/pulp_http_redirect.py
+++ b/backend/copr_backend/pulp_http_redirect.py
@@ -2,7 +2,6 @@
 Maintain a list of HTTP redirects to Pulp
 """
 
-from copr_common.lock import lock
 from .constants import PULP_REDIRECT_FILE
 
 
@@ -13,14 +12,9 @@ class PulpHTTPRedirect:
     https://pagure.io/fedora-infra/ansible/blob/main/f/roles/copr/backend/templates/lighttpd/pulp-redirect.lua.j2
     """
 
-    def __init__(self, path=None, redis_conn=None, log=None):
+    def __init__(self, lock, path=None):
+        self.lock = lock
         self.path = path or PULP_REDIRECT_FILE
-        self.redis_conn = redis_conn
-        self.log = log
-        if not self.log:
-            raise NotImplementedError("Default logger not implemented yet")
-        if not self.redis_conn:
-            raise NotImplementedError("Redis connection is required")
 
     def add(self, owner, project):
         """
@@ -34,7 +28,7 @@ class PulpHTTPRedirect:
             if fullname in projects:
                 return
 
-            with lock(self.path, redis_conn=self.redis_conn, log=self.log):
+            with self.lock.lock(self.path):
                 with open(self.path, "r", encoding="utf-8") as fp:
                     projects = fp.read().splitlines()
 
@@ -57,7 +51,7 @@ class PulpHTTPRedirect:
             if fullname not in projects:
                 return
 
-            with lock(self.path, redis_conn=self.redis_conn, log=self.log):
+            with self.lock.lock(self.path):
                 with open(self.path, "r", encoding="utf-8") as fp:
                     projects = fp.read().splitlines()
 

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -16,6 +16,7 @@ from distutils.errors import DistutilsFileError # pylint: disable=deprecated-mod
 import shutil
 import requests
 from copr_common.enums import StorageEnum, CreaterepoReason
+from copr_common.lock import Lock
 from copr_common.redis_helpers import get_redis_connection
 from copr_common.request import RequestError, SafeRequest
 from copr_backend.helpers import (
@@ -307,6 +308,7 @@ class PulpStorage(Storage):
         super().__init__(*args, **kwargs)
         self.client = PulpClient.create_from_config_file(log=self.log, opts=self.opts)
         self._redis_conn = get_redis_connection(self.opts)
+        self._lock = Lock(self._redis_conn, self.log)
 
     def init_project(self, dirname, chroot, reason=None):
         repository_name = self._repository_name(chroot, dirname)
@@ -417,7 +419,7 @@ class PulpStorage(Storage):
         try:
             return self.client.publish(repository_href)
         finally:
-            redirect = PulpHTTPRedirect(redis_conn=self._redis_conn, log=self.log)
+            redirect = PulpHTTPRedirect(lock=self._lock)
             redirect.add(self.owner, self.project)
 
     def upload_rpm(self, path, labels):
@@ -541,7 +543,7 @@ class PulpStorage(Storage):
             if distribution["repository"]:
                 self.log.info("Removing Pulp repository for %s", name)
                 self.client.delete_repository(distribution["repository"])
-        redirect = PulpHTTPRedirect(redis_conn=self._redis_conn, log=self.log)
+        redirect = PulpHTTPRedirect(lock=self._lock)
         redirect.remove(self.owner, dirname)
 
     def delete_builds(self, dirname, chroot_builddirs, build_ids):

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -16,6 +16,7 @@ from distutils.errors import DistutilsFileError # pylint: disable=deprecated-mod
 import shutil
 import requests
 from copr_common.enums import StorageEnum, CreaterepoReason
+from copr_common.redis_helpers import get_redis_connection
 from copr_common.request import RequestError, SafeRequest
 from copr_backend.helpers import (
     build_chroot_log_name,
@@ -305,6 +306,7 @@ class PulpStorage(Storage):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.client = PulpClient.create_from_config_file(log=self.log, opts=self.opts)
+        self._redis_conn = get_redis_connection(self.opts)
 
     def init_project(self, dirname, chroot, reason=None):
         repository_name = self._repository_name(chroot, dirname)
@@ -415,7 +417,7 @@ class PulpStorage(Storage):
         try:
             return self.client.publish(repository_href)
         finally:
-            redirect = PulpHTTPRedirect(log=self.log)
+            redirect = PulpHTTPRedirect(redis_conn=self._redis_conn, log=self.log)
             redirect.add(self.owner, self.project)
 
     def upload_rpm(self, path, labels):
@@ -539,7 +541,7 @@ class PulpStorage(Storage):
             if distribution["repository"]:
                 self.log.info("Removing Pulp repository for %s", name)
                 self.client.delete_repository(distribution["repository"])
-        redirect = PulpHTTPRedirect(log=self.log)
+        redirect = PulpHTTPRedirect(redis_conn=self._redis_conn, log=self.log)
         redirect.remove(self.owner, dirname)
 
     def delete_builds(self, dirname, chroot_builddirs, build_ids):

--- a/backend/run/copr-repo
+++ b/backend/run/copr-repo
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 
-from copr_common.lock import lock, LockTimeout
+from copr_common.lock import lock
 from copr_backend.constants import CHROOTS_USING_SQLITE_REPODATA
 from copr_backend.createrepo import BatchedCreaterepo
 from copr_backend.helpers import (
@@ -374,38 +374,12 @@ def process_directory_path(opts):
 
 def main_try_lock(opts, batch):
     """
-    Periodically try to acquire the lock, and execute the main_locked() method.
+    Acquire the lock and execute the main_locked() method.
     """
-
-    while True:
-
-        # We don't have fair locking (locks-first => processes-first).  So to
-        # avoid potential indefinite waiting (see issue #1423) we check if the
-        # task isn't already processed _without_ having the lock.
-
-        if batch.check_processed(delete_if_not=False):
-            opts.log.info("Task processed by other process (no-lock)")
-            return
-
-        try:
-            lockdir = os.environ.get(
-                "COPR_TESTSUITE_LOCKPATH", "/var/lock/copr-backend")
-            with lock(opts.directory, lockdir=lockdir, timeout=5, log=opts.log):
-                main_locked(opts, batch, opts.log)
-
-                # While we still hold the lock, notify others we processed their
-                # task.  Note that we do not commit in case of random exceptions
-                # above.
-                batch.commit()
-
-                # If no exception happened, we are done (break).
-                opts.log.debug("Metadata built by this process")
-                break
-        except LockTimeout:
-            continue  # Try again...
-
-        # we never loop, only upon timeout
-        assert False
+    with lock(opts.directory, redis_conn=batch.redis, log=opts.log):
+        main_locked(opts, batch, opts.log)
+        batch.commit()
+        opts.log.debug("Metadata built by this process")
 
 
 def main():

--- a/backend/run/copr-repo
+++ b/backend/run/copr-repo
@@ -18,7 +18,7 @@ import shutil
 import subprocess
 import sys
 
-from copr_common.lock import lock
+from copr_common.lock import Lock
 from copr_backend.constants import CHROOTS_USING_SQLITE_REPODATA
 from copr_backend.createrepo import BatchedCreaterepo
 from copr_backend.helpers import (
@@ -376,7 +376,7 @@ def main_try_lock(opts, batch):
     """
     Acquire the lock and execute the main_locked() method.
     """
-    with lock(opts.directory, redis_conn=batch.redis, log=opts.log):
+    with Lock(batch.redis, opts.log).lock(opts.directory):
         main_locked(opts, batch, opts.log)
         batch.commit()
         opts.log.debug("Metadata built by this process")

--- a/backend/tests/test_action.py
+++ b/backend/tests/test_action.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,attribute-defined-outside-init
 
 import os
 import json
@@ -18,7 +18,9 @@ import pytest
 from requests import RequestException
 
 from copr_common.enums import ActionTypeEnum, BackendResultEnum, StorageEnum
+from copr_common.redis_helpers import get_redis_connection
 
+from testlib import minimal_be_config
 from testlib.repodata import load_primary_xml
 from copr_backend.actions import Action
 from copr_backend.exceptions import CoprKeygenRequestError
@@ -65,17 +67,19 @@ class TestAction(object):
             keygen_host="example.com"
         )
 
-        self.lockpath = tempfile.mkdtemp(prefix="copr-test-lockpath")
+        self.redis = get_redis_connection(self.opts)
+        self.config_dir = tempfile.mkdtemp(prefix="copr-test-action-cfg-")
+        self.be_config = minimal_be_config(self.config_dir)
         self.os_env_patcher = mock.patch.dict(os.environ, {
             'COPR_TESTSUITE_NO_OUTPUT': '1',
-            'COPR_TESTSUITE_LOCKPATH': self.lockpath,
             'PATH': os.environ['PATH']+':run',
+            'COPR_BE_CONFIG': self.be_config,
         })
         self.os_env_patcher.start()
 
     def teardown_method(self, method):
         self.rm_tmp_dir()
-        shutil.rmtree(self.lockpath)
+        shutil.rmtree(self.config_dir)
         self.os_env_patcher.stop()
 
     def rm_tmp_dir(self):

--- a/backend/tests/test_modifyrepo.py
+++ b/backend/tests/test_modifyrepo.py
@@ -41,14 +41,13 @@ fix_gpg_script = 'run/copr_fix_gpg.py'
 # pylint: disable=too-many-public-methods
 
 @contextlib.contextmanager
-def _lock(directory="non-existent"):
+def _lock(redis_conn, directory="non-existent"):
     filedict = runpy.run_path(modifyrepo)
     opts = munch.Munch()
     opts.log = logging.getLogger()
     opts.directory = directory
     lock = filedict['lock']
-    lockdir = os.environ.get("COPR_TESTSUITE_LOCKPATH")
-    with lock(opts.directory, lockdir=lockdir, timeout=-1, log=opts.log):
+    with lock(opts.directory, redis_conn=redis_conn, log=opts.log):
         yield opts
 
 class TestModifyRepo(object):
@@ -57,7 +56,6 @@ class TestModifyRepo(object):
         self.be_config = minimal_be_config(self.workdir)
         self.os_env_patcher = mock.patch.dict(os.environ, {
             'PATH': os.environ['PATH']+':run',
-            'COPR_TESTSUITE_LOCKPATH': self.workdir,
             'COPR_BE_CONFIG': self.be_config,
         })
         self.os_env_patcher.start()
@@ -71,7 +69,7 @@ class TestModifyRepo(object):
         self.redis.flushdb()
 
     def test_copr_modifyrepo_locks(self):
-        with _lock(self.workdir) as opts:
+        with _lock(self.redis, self.workdir) as opts:
             cmd = [modifyrepo, opts.directory, '--log-to-stdout']
             proc = subprocess.Popen(cmd,
                                     stdout=subprocess.PIPE,
@@ -149,7 +147,7 @@ class TestModifyRepo(object):
         repodata = os.path.join(chrootdir, 'repodata')
         repoinfo = load_primary_xml(repodata)
         assert repoinfo['hrefs'] == set()
-        with _lock(chrootdir) as opts:
+        with _lock(self.redis, chrootdir) as opts:
             # delay processing by lock
             cmd = [modifyrepo, "--batched", "--log-to-stdout",
                    opts.directory, "--add", ctx.builds[1]]
@@ -595,9 +593,8 @@ class TestModifyRepo(object):
         opts = ["--rpms-to-remove", rpm_name] * 9000
         assert call == ["copr-repo", "--batched", "/tmp"] + opts + ["--no-appstream-metadata"]
 
-    @pytest.mark.parametrize('run_bg', [True, False])
     @mock.patch.dict(os.environ, {'COPR_TESTSUITE_NO_OUTPUT': '1'})
-    def test_copr_repo_timeouted_check(self, f_second_build, run_bg):
+    def test_copr_repo_timeouted_check(self, f_second_build):
         _unused = self
         ctx = f_second_build
         chroot = ctx.chroots[0]
@@ -613,12 +610,11 @@ class TestModifyRepo(object):
             # give parent some time to lock the repo
             time.sleep(1)
             # Run the blocked (by parent) createrepo, it must finish soon
-            # anway because parent will claim the task is done.
+            # after the parent releases the lock.
             assert call_copr_repo(chrootdir, add=[ctx.builds[1]])
-            # sys.exit() can not be used in testsuite
             os._exit(0)  # pylint: disable=protected-access
 
-        with _lock(chrootdir):
+        with _lock(self.redis, chrootdir):
             # give the child some time to fill its Redis keys
             sleeper = 1
             while True:
@@ -629,24 +625,12 @@ class TestModifyRepo(object):
                 assert sleeper < 10*15  # 15s
 
             assert len(self.redis.keys()) == 1
-            key = self.redis.keys()[0]
 
-            # Claim we did that task (even if not) and check that the child
-            # finishes after some time.
-            if not run_bg:
-                self.redis.hset(key, "status", "success")
-                assert os.wait()[1] == 0
-                assert self.redis.get(key) is None
-
-        if run_bg:
-            # actually process the background job!
-            assert os.wait()[1] == 0
+        # lock released, child's copr-repo can now proceed
+        assert os.wait()[1] == 0
 
         repodata = load_primary_xml(repodata)
-        if run_bg:
-            assert repodata['names'] == {'example'}
-        else:
-            assert repodata['names'] == set()
+        assert repodata['names'] == {'example'}
 
 
 @mock.patch("copr_backend.helpers.subprocess.Popen")

--- a/backend/tests/test_modifyrepo.py
+++ b/backend/tests/test_modifyrepo.py
@@ -46,8 +46,8 @@ def _lock(redis_conn, directory="non-existent"):
     opts = munch.Munch()
     opts.log = logging.getLogger()
     opts.directory = directory
-    lock = filedict['lock']
-    with lock(opts.directory, redis_conn=redis_conn, log=opts.log):
+    lock = filedict['Lock']
+    with lock(redis_conn, opts.log).lock(opts.directory):
         yield opts
 
 class TestModifyRepo(object):

--- a/common/copr_common/lock.py
+++ b/common/copr_common/lock.py
@@ -1,48 +1,98 @@
 """
-File locking for multithreading
+Fair (FIFO) distributed locking using a Redis queue.
+
+Waiters enqueue their PID and are served in arrival order.  Dead-process
+detection uses kill(pid, 0) so no heartbeat thread is needed.
 """
 
-import os
 import contextlib
-import filelock
+import errno
+import os
+
 from setproctitle import getproctitle, setproctitle
+
+BLPOP_TIMEOUT = 5  # seconds between dead-process checks
+NOTIFY_TTL = 120  # seconds; caps stale notify keys from slow releasers
+
+
+def _is_alive(pid):
+    """Return True if *pid* refers to a running (non-zombie) process."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError as e:
+        if e.errno == errno.ESRCH:
+            return False
+        # EPERM → process exists but we lack permission
+        return True
+
+
+def _queue_key(path):
+    return "copr:lock:queue:{}".format(path)
+
+
+def _notify_key(path, pid):
+    return "copr:lock:notify:{}:{}".format(path, pid)
 
 
 @contextlib.contextmanager
-def lock(path, lockdir, timeout, log):
+def lock(path, redis_conn, log):
     """
-    Create a lock file that can be accessed only by one thread at the time.
-    A practical use-case for this is to lock a repository so multiple versions
-    of the same package cannot be imported in paralel.
+    Fair (FIFO) distributed lock backed by a Redis list.
 
-    We want to pass a simple `path` parameter specifying what file or directory
-    should be locked. This however isn't where the lockfile is going to be
-    created. It will be created in the `lockdir`.
+    Processes waiting for the lock are served in the order they called
+    this function.  If the lock holder dies without releasing, the next
+    waiter detects it via kill(pid, 0) and removes the stale entry.
 
-    From FileLock docs:
-    Using a timeout < 0 makes the lock block until it can be acquired while
-    timeout == 0 results in only one attempt to acquire the lock before raising
-    a Timeout exception (-> non-blocking).
+    :param path:        Logical resource to lock (e.g. a repository path).
+    :param redis_conn:  A ``redis.StrictRedis`` connection.
+    :param log:         Logger instance.
     """
-    filename = path.replace("/", "_@_") + ".lock"
-    lockfile = os.path.join(lockdir, filename)
+    queue = _queue_key(path)
+    my_pid = os.getpid()
+    my_pid_str = str(my_pid)
+    notify = _notify_key(path, my_pid)
 
     title = getproctitle()
     setproctitle("{0} [locking]".format(title))
-    log.debug("acquiring lock")
+    log.debug("acquiring lock (fair/redis)")
+
+    redis_conn.rpush(queue, my_pid_str)
     try:
-        with filelock.FileLock(lockfile, timeout=timeout):
-            setproctitle("{0} [locked]".format(title))
-            log.debug("acquired lock")
-            yield
-    except filelock.Timeout as err:
-        log.debug("lock timeouted")
-        raise LockTimeout("Timeouted on lock for: {}".format(path)) from err
+        while True:
+            head = redis_conn.lindex(queue, 0)
+            if head is None:
+                # Queue disappeared (e.g. Redis flushed) — re-enqueue.
+                redis_conn.rpush(queue, my_pid_str)
+                continue
+
+            if head == my_pid_str:
+                break
+
+            head_pid = int(head)
+            if not _is_alive(head_pid):
+                log.debug("removing dead lock holder pid=%s", head)
+                redis_conn.lrem(queue, 1, head)
+                continue
+
+            redis_conn.blpop(notify, timeout=BLPOP_TIMEOUT)
+
+        setproctitle("{0} [locked]".format(title))
+        log.debug("acquired lock (fair/redis)")
+        yield
+
     finally:
-        setproctitle("{0} [locking]".format(title))
-
-
-class LockTimeout(OSError):
-    """
-    Raised for lock() timeout, if timeout= option is set to value >= 0
-    """
+        # lrem (not lpop) so we only ever remove our own entry — even if
+        # an exception/signal fires before we reached the queue head.
+        redis_conn.lrem(queue, 1, my_pid_str)
+        next_pid = redis_conn.lindex(queue, 0)
+        if next_pid is not None:
+            nk = _notify_key(path, next_pid)
+            redis_conn.rpush(nk, "1")
+            # After lrem the next waiter may already have proceeded (via
+            # BLPOP timeout) and finished before we get here.  In that
+            # case this "1" is never consumed and the key leaks.  A TTL
+            # bounds the accumulation of such orphaned notify keys.
+            redis_conn.expire(nk, NOTIFY_TTL)
+        redis_conn.delete(notify)
+        setproctitle(title)

--- a/common/copr_common/lock.py
+++ b/common/copr_common/lock.py
@@ -35,64 +35,76 @@ def _notify_key(path, pid):
     return "copr:lock:notify:{}:{}".format(path, pid)
 
 
-@contextlib.contextmanager
-def lock(path, redis_conn, log):
+class Lock:
     """
-    Fair (FIFO) distributed lock backed by a Redis list.
+    Factory for fair (FIFO) distributed locks backed by Redis lists.
 
-    Processes waiting for the lock are served in the order they called
-    this function.  If the lock holder dies without releasing, the next
-    waiter detects it via kill(pid, 0) and removes the stale entry.
-
-    :param path:        Logical resource to lock (e.g. a repository path).
     :param redis_conn:  A ``redis.StrictRedis`` connection.
     :param log:         Logger instance.
     """
-    queue = _queue_key(path)
-    my_pid = os.getpid()
-    my_pid_str = str(my_pid)
-    notify = _notify_key(path, my_pid)
 
-    title = getproctitle()
-    setproctitle("{0} [locking]".format(title))
-    log.debug("acquiring lock (fair/redis)")
+    def __init__(self, redis_conn, log):
+        self.redis_conn = redis_conn
+        self.log = log
 
-    redis_conn.rpush(queue, my_pid_str)
-    try:
-        while True:
-            head = redis_conn.lindex(queue, 0)
-            if head is None:
-                # Queue disappeared (e.g. Redis flushed) — re-enqueue.
-                redis_conn.rpush(queue, my_pid_str)
-                continue
+    @contextlib.contextmanager
+    def lock(self, path):
+        """
+        Fair (FIFO) distributed lock for *path*.
 
-            if head == my_pid_str:
-                break
+        Processes waiting for the lock are served in the order they called
+        this method.  If the lock holder dies without releasing, the next
+        waiter detects it via kill(pid, 0) and removes the stale entry.
 
-            head_pid = int(head)
-            if not _is_alive(head_pid):
-                log.debug("removing dead lock holder pid=%s", head)
-                redis_conn.lrem(queue, 1, head)
-                continue
+        :param path:  Logical resource to lock (e.g. a repository path).
+        """
+        redis_conn = self.redis_conn
+        log = self.log
+        queue = _queue_key(path)
+        my_pid = os.getpid()
+        my_pid_str = str(my_pid)
+        notify = _notify_key(path, my_pid)
 
-            redis_conn.blpop(notify, timeout=BLPOP_TIMEOUT)
+        title = getproctitle()
+        setproctitle("{0} [locking]".format(title))
+        log.debug("acquiring lock (fair/redis)")
 
-        setproctitle("{0} [locked]".format(title))
-        log.debug("acquired lock (fair/redis)")
-        yield
+        redis_conn.rpush(queue, my_pid_str)
+        try:
+            while True:
+                head = redis_conn.lindex(queue, 0)
+                if head is None:
+                    redis_conn.rpush(queue, my_pid_str)
+                    continue
 
-    finally:
-        # lrem (not lpop) so we only ever remove our own entry — even if
-        # an exception/signal fires before we reached the queue head.
-        redis_conn.lrem(queue, 1, my_pid_str)
-        next_pid = redis_conn.lindex(queue, 0)
-        if next_pid is not None:
-            nk = _notify_key(path, next_pid)
-            redis_conn.rpush(nk, "1")
-            # After lrem the next waiter may already have proceeded (via
-            # BLPOP timeout) and finished before we get here.  In that
-            # case this "1" is never consumed and the key leaks.  A TTL
-            # bounds the accumulation of such orphaned notify keys.
-            redis_conn.expire(nk, NOTIFY_TTL)
-        redis_conn.delete(notify)
-        setproctitle(title)
+                if head == my_pid_str:
+                    break
+
+                head_pid = int(head)
+                if not _is_alive(head_pid):
+                    log.debug("removing dead lock holder pid=%s", head)
+                    redis_conn.lrem(queue, 1, head)
+                    continue
+
+                redis_conn.blpop(notify, timeout=BLPOP_TIMEOUT)
+
+            setproctitle("{0} [locked]".format(title))
+            log.debug("acquired lock (fair/redis)")
+            yield
+
+        finally:
+            # lrem (not lpop) so we only ever remove our own entry — even if
+            # an exception/signal fires before we reached the queue head.
+            redis_conn.lrem(queue, 1, my_pid_str)
+            next_pid = redis_conn.lindex(queue, 0)
+            if next_pid is not None:
+                nk = _notify_key(path, next_pid)
+                redis_conn.rpush(nk, "1")
+                # After lrem the next waiter may already have proceeded
+                # (via BLPOP timeout) and finished before we get here.
+                # In that case this "1" is never consumed and the key
+                # leaks.  A TTL bounds the accumulation of such orphaned
+                # notify keys.
+                redis_conn.expire(nk, NOTIFY_TTL)
+            redis_conn.delete(notify)
+            setproctitle(title)

--- a/common/copr_common/redis_helpers.py
+++ b/common/copr_common/redis_helpers.py
@@ -4,10 +4,13 @@ Copr common code related to redis
 
 from redis import StrictRedis
 
+_connections = {}
+
 
 def get_redis_connection(opts):
     """
-    Creates redis client object using backend config
+    Creates redis client object using backend config, or returns
+    a cached connection if one already exists for the same (host, port, db).
 
     :rtype: StrictRedis
     """
@@ -26,4 +29,15 @@ def get_redis_connection(opts):
             kwargs[key] = getattr(opts, config_key)
             continue
 
-    return StrictRedis(encoding="utf-8", decode_responses=True, **kwargs)
+    # WARNING: if you use password, note that you shouldn't use this
+    # get_redis_connection() helper with two different passwords (password is
+    # intentionally not hashed to not keep it in memory on more places).
+    cache_key = (
+        kwargs.get("host", "localhost"),
+        int(kwargs.get("port", 6379)),
+        int(kwargs.get("db", 0)),
+    )
+    if cache_key not in _connections:
+        _connections[cache_key] = StrictRedis(
+            encoding="utf-8", decode_responses=True, **kwargs)
+    return _connections[cache_key]

--- a/common/python-copr-common.spec
+++ b/common/python-copr-common.spec
@@ -1,7 +1,7 @@
 %global srcname copr-common
 
 Name:       python-copr-common
-Version:    1.7
+Version:    1.7.2
 Release:    1%{?dist}
 Summary:    Python code used by Copr
 
@@ -22,9 +22,10 @@ BuildRequires: python3-devel
 BuildRequires: python3-setuptools
 %endif
 BuildRequires: python3-pytest
+BuildRequires: python3-redis
 BuildRequires: python3-requests
-BuildRequires: python3-filelock
 BuildRequires: python3-setproctitle
+BuildRequires: redis
 
 %global _description\
 COPR is lightweight build system. It allows you to create new project in WebUI,\
@@ -69,7 +70,7 @@ version=%version %py3_install
 %endif
 
 %check
-%{_bindir}/python3 -m pytest -vv tests
+./run_tests.sh -vv --no-cov
 
 
 %files -n python3-%{srcname}

--- a/common/run_tests.sh
+++ b/common/run_tests.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+set -x
+set -e
+
+REDIS_PORT=7777
+redis-server --port $REDIS_PORT &> _redis.log &
+
+cleanup ()
+{
+    redis-cli -p "$REDIS_PORT" shutdown
+    wait
+}
+trap cleanup EXIT
+
 COVPARAMS=(--cov-report term-missing --cov ./copr_common/)
 
 KEEP_ARGS=()

--- a/common/setup.py
+++ b/common/setup.py
@@ -19,14 +19,14 @@ __url__ = "https://github.com/fedora-copr/copr"
 
 
 requires = [
-    "filelock",
+    "redis",
     "setproctitle",
 ]
 
 
 setup(
     name='copr-common',
-    version="1.7",
+    version="1.7.2",
     description=__description__,
     long_description=long_description,
     author=__author__,

--- a/common/tests/test_lock.py
+++ b/common/tests/test_lock.py
@@ -1,0 +1,130 @@
+"""
+Test fair (FIFO) Redis-based locking: processes blocked on the lock
+are served in the order they enqueued.
+"""
+
+import logging
+import os
+import shutil
+import tempfile
+import time
+
+from redis import StrictRedis
+
+from copr_common.lock import lock
+
+CONCURRENCY = 8
+MAX_WAIT = 10  # seconds
+
+log = logging.getLogger("test_lock_fairness")
+
+
+def _get_redis():
+    return StrictRedis(
+        host="127.0.0.1",
+        port=7777,
+        db=9,
+        encoding="utf-8",
+        decode_responses=True,
+    )
+
+
+def _cleanup_keys(redis_conn, path):
+    for prefix in ["copr:lock:queue:", "copr:lock:notify:"]:
+        for key in redis_conn.keys(prefix + path + "*"):
+            redis_conn.delete(key)
+
+
+def test_lock_fairness():
+    redis_conn = _get_redis()
+    lock_name = "/test-fairness"
+    _cleanup_keys(redis_conn, lock_name)
+
+    workdir = tempfile.mkdtemp(prefix="copr-test-lock-")
+    result_file = os.path.join(workdir, "order.log")
+
+    children = []
+    try:
+        with lock(lock_name, redis_conn=redis_conn, log=log):
+            for i in range(CONCURRENCY):
+                pid = os.fork()
+                if pid == 0:
+                    child_redis = _get_redis()
+                    with lock(lock_name, redis_conn=child_redis, log=log):
+                        fd = os.open(result_file,
+                                     os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+                                     0o644)
+                        os.write(fd, "{}\n".format(i).encode())
+                        os.close(fd)
+                    os._exit(0)
+                children.append(pid)
+                time.sleep(0.05)
+
+            time.sleep(2)
+
+            assert not os.path.exists(result_file), \
+                "result file should not exist yet while parent holds the lock"
+
+            for pid in children:
+                result, _ = os.waitpid(pid, os.WNOHANG)
+                assert result == 0, \
+                    "child {} exited prematurely while lock is held".format(pid)
+
+        deadline = time.monotonic() + MAX_WAIT
+        remaining = set(children)
+        while remaining:
+            assert time.monotonic() < deadline, \
+                "children did not finish within {}s".format(MAX_WAIT)
+            for pid in list(remaining):
+                result, status = os.waitpid(pid, os.WNOHANG)
+                if result != 0:
+                    assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0, \
+                        "child {} exited with status {}".format(pid, status)
+                    remaining.discard(pid)
+                    children.remove(pid)
+            time.sleep(0.1)
+
+        with open(result_file, encoding="utf-8") as f:
+            order = [int(line.strip()) for line in f]
+
+        assert order == list(range(CONCURRENCY)), \
+            "expected FIFO order {}, got {}".format(
+                list(range(CONCURRENCY)), order)
+    finally:
+        for pid in children:
+            try:
+                os.kill(pid, 9)
+                os.waitpid(pid, 0)
+            except OSError:
+                pass
+        shutil.rmtree(workdir, ignore_errors=True)
+        _cleanup_keys(redis_conn, lock_name)
+
+
+def test_lock_dead_process_cleanup():
+    """
+    Simulate a dead lock holder by inserting a non-existent PID into the
+    Redis queue.  The next lock() caller should detect the dead PID via
+    kill(pid, 0) → ESRCH, remove the stale entry from the queue, and
+    successfully acquire the lock without waiting for the BLPOP timeout.
+    """
+    redis_conn = _get_redis()
+    lock_name = "/test-dead-cleanup"
+    _cleanup_keys(redis_conn, lock_name)
+
+    try:
+        # Insert a PID that definitely doesn't exist — this is what happens
+        # when a lock holder dies (kill -9, OOM, etc.) without running the
+        # finally block that would LPOP its entry.
+        dead_pid = "999999999"
+        queue_key = "copr:lock:queue:{}".format(lock_name)
+        redis_conn.rpush(queue_key, dead_pid)
+
+        # lock() should detect the dead PID at the head of the queue,
+        # remove it, and let us through.
+        acquired = False
+        with lock(lock_name, redis_conn=redis_conn, log=log):
+            acquired = True
+        assert acquired
+    finally:
+        _cleanup_keys(redis_conn, lock_name)

--- a/common/tests/test_lock.py
+++ b/common/tests/test_lock.py
@@ -11,7 +11,7 @@ import time
 
 from redis import StrictRedis
 
-from copr_common.lock import lock
+from copr_common.lock import Lock
 
 CONCURRENCY = 8
 MAX_WAIT = 10  # seconds
@@ -45,12 +45,12 @@ def test_lock_fairness():
 
     children = []
     try:
-        with lock(lock_name, redis_conn=redis_conn, log=log):
+        with Lock(redis_conn, log).lock(lock_name):
             for i in range(CONCURRENCY):
                 pid = os.fork()
                 if pid == 0:
                     child_redis = _get_redis()
-                    with lock(lock_name, redis_conn=child_redis, log=log):
+                    with Lock(child_redis, log).lock(lock_name):
                         fd = os.open(result_file,
                                      os.O_WRONLY | os.O_CREAT | os.O_APPEND,
                                      0o644)
@@ -123,7 +123,7 @@ def test_lock_dead_process_cleanup():
         # lock() should detect the dead PID at the head of the queue,
         # remove it, and let us through.
         acquired = False
-        with lock(lock_name, redis_conn=redis_conn, log=log):
+        with Lock(redis_conn, log).lock(lock_name):
             acquired = True
         assert acquired
     finally:

--- a/dist-git/copr-dist-git.spec
+++ b/dist-git/copr-dist-git.spec
@@ -1,4 +1,4 @@
-%global copr_common_version 1.5.1
+%global copr_common_version 1.7.2
 
 Name:       copr-dist-git
 Version:    1.6
@@ -25,6 +25,7 @@ BuildRequires: python3-copr-common >= %copr_common_version
 BuildRequires: python3-redis
 BuildRequires: python3-setproctitle
 BuildRequires: python3-sentry-sdk
+BuildRequires: redis
 
 Recommends: logrotate
 Requires: systemd

--- a/dist-git/copr_dist_git/importer.py
+++ b/dist-git/copr_dist_git/importer.py
@@ -9,6 +9,7 @@ from requests import get, post
 
 from copr_common.worker_manager import WorkerManager
 from copr_common.lock import lock
+from copr_common.redis_helpers import get_redis_connection
 
 from .package_import import import_package
 from .process_pool import Worker, Pool, SingleThreadWorker
@@ -83,7 +84,8 @@ class Importer(object):
             )
 
             repo = os.path.join(self.opts.lookaside_location, task.reponame)
-            with lock(repo, lockdir=helpers.LOCK_PATH, timeout=-1, log=log):
+            redis_conn = get_redis_connection(self.opts)
+            with lock(repo, redis_conn=redis_conn, log=log):
                 result.update(import_package(
                     self.opts,
                     task.repo_namespace,

--- a/dist-git/copr_dist_git/importer.py
+++ b/dist-git/copr_dist_git/importer.py
@@ -8,7 +8,7 @@ import shutil
 from requests import get, post
 
 from copr_common.worker_manager import WorkerManager
-from copr_common.lock import lock
+from copr_common.lock import Lock
 from copr_common.redis_helpers import get_redis_connection
 
 from .package_import import import_package
@@ -85,7 +85,7 @@ class Importer(object):
 
             repo = os.path.join(self.opts.lookaside_location, task.reponame)
             redis_conn = get_redis_connection(self.opts)
-            with lock(repo, redis_conn=redis_conn, log=log):
+            with Lock(redis_conn, log).lock(repo):
                 result.update(import_package(
                     self.opts,
                     task.repo_namespace,

--- a/dist-git/run_tests.sh
+++ b/dist-git/run_tests.sh
@@ -6,6 +6,16 @@ set -e
 common_path=$(readlink -f ../common)
 export PYTHONPATH="${PYTHONPATH+$PYTHONPATH:}$common_path"
 
+REDIS_PORT=7777
+redis-server --port $REDIS_PORT &> _redis.log &
+
+cleanup ()
+{
+    redis-cli -p "$REDIS_PORT" shutdown
+    wait
+}
+trap cleanup EXIT
+
 COVPARAMS=( --cov-report term-missing --cov ./dist_git )
 
 KEEP_ARGS=()

--- a/dist-git/tests/base.py
+++ b/dist-git/tests/base.py
@@ -31,6 +31,8 @@ class Base(object):
             "git_user_name": "Test user",
             "git_user_email": "test@test.org",
             "max_workers": 10,
+            "redis_host": "127.0.0.1",
+            "redis_port": 7777,
         })
 
         self.importer = importer.Importer(self.opts)


### PR DESCRIPTION
    common, backend, distgit: fair FIFO locking via Redis queue
    
    Replace filelock with a Redis-based fair lock that guarantees FIFO
    ordering.  Neither filelock, fcntl.flock(), nor redis-py Lock guarantee
    that waiters are served in arrival order — flock wakes all waiters and
    lets the scheduler pick the winner, redis-py Lock polls with SET NX.
    
    When processes waiting for the lock are served in FIFO order, we can
    simplify the lock-retry logic.  Previously, callers used a 5s timeout
    loop — filelock polled in the kernel (not busy-waiting in python), but
    the retry loop existed because lock acquisition order wasn't guaranteed:
    a late arrival could starve an earlier waiter.  With FIFO ordering that
    can't happen, so the loop and LockTimeout are unnecessary.
    
    This also removes the pattern where the winning process marked tasks as
    "status=success" early to unblock losers — with fair locking, the losers
    simply wait their turn and proceed quickly (lock is very quickly
    re-released).
    
    The new implementation uses a Redis List as a FIFO queue of PIDs:
    - Acquire: RPUSH my PID, then loop checking LINDEX 0 until I'm at the
      head; sleep via BLPOP on a per-PID notification channel between checks
    - Release: LPOP myself, notify the next waiter via RPUSH to their channel
    - Dead holder: detected via kill(pid, 0) — no heartbeat thread needed;
      the next waiter removes the stale PID after a BLPOP timeout (5s)
    
    Also make get_redis_connection() a singleton keyed by (host, port, db)
    so callers sharing the same config reuse one connection instead of
    creating duplicates.
    
    - Replace filelock with Redis/Valkey locking
    - Drop LockTimeout and the retry/timeout loops in copr-repo, pulp.py,
      pulp_http_redirect.py, and importer.py
    - Remove filelock dependency, add redis dep
    - Bump copr-common to 1.7.1
    - Start Redis in common/ and dist-git/ run_tests.sh
    - Add fairness and dead-process-cleanup tests
    - Bump test configs to pass COPR_BE_CONFIG where copr-repo needs Redis
    
