### PR TITLE
Turn on rpmeta

### DIFF
--- a/backend/conf/copr-be.conf.example
+++ b/backend/conf/copr-be.conf.example
@@ -106,10 +106,13 @@ prune_days=14
 #rpmeta_enabled=false
 #rpmeta_url=https://rpmeta.fedorainfracloud.org
 #rpmeta_timeout=5
-# Mapping to hardware resources we have
+# Mapping to hardware resources we have. Only list architectures that
+# actually have a powerful builder pool available -- an architecture with
+# no entry here is skipped entirely (no prediction, tag never added). See
+# rpmeta-hw-pools.yaml.example.
 #rpmeta_hw_pools_config=/etc/copr/rpmeta-hw-pools.yaml
-# Predicted build time (in minutes) at/above which rpmeta recommends
-# routing the build to a more powerful builder.
+# Predicted build time (in minutes) at/above which rpmeta adds the
+# powerful builder tag to a build (see rpmeta_powerful_tag below).
 #rpmeta_powerful_threshold=120
 # Job tag used to route a build to a powerful builder VM. Must
 # match the tag name expected by resalloc pools / mock config snippets.

--- a/backend/conf/copr-be.conf.example
+++ b/backend/conf/copr-be.conf.example
@@ -108,6 +108,12 @@ prune_days=14
 #rpmeta_timeout=5
 # Mapping to hardware resources we have
 #rpmeta_hw_pools_config=/etc/copr/rpmeta-hw-pools.yaml
+# Predicted build time (in minutes) at/above which rpmeta recommends
+# routing the build to a more powerful builder.
+#rpmeta_powerful_threshold=120
+# Job tag used to route a build to a powerful builder VM. Must
+# match the tag name expected by resalloc pools / mock config snippets.
+#rpmeta_powerful_tag=on_demand_powerful
 
 [builder]
 # default is 1800

--- a/backend/conf/rpmeta-hw-pools.yaml.example
+++ b/backend/conf/rpmeta-hw-pools.yaml.example
@@ -1,6 +1,12 @@
 # Hardware specs of builder machines per architecture.
 # Used by copr-backend to call rpmeta with the correct HW info.
 # Update when builder hardware changes.
+#
+# IMPORTANT: only list architectures that actually have a powerful
+# builder pool (on_demand_powerful / rpmeta_powerful_tag) available.
+# rpmeta only promotes builds to a powerful builder for architectures
+# present here -- if an architecture is omitted, no prediction is made
+# for it and the powerful builder tag is never added.
 
 x86_64:
   cpu_model_name: "AMD EPYC 7R13 Processor"

--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -444,6 +444,10 @@ class BackendConfigReader(object):
         opts.rpmeta_hw_pools_config = _get_conf(
             cp, "backend", "rpmeta_hw_pools_config",
             "/etc/copr/rpmeta-hw-pools.yaml")
+        opts.rpmeta_powerful_threshold = _get_conf(
+            cp, "backend", "rpmeta_powerful_threshold", 120, mode="int")
+        opts.rpmeta_powerful_tag = _get_conf(
+            cp, "backend", "rpmeta_powerful_tag", "on_demand_powerful")
 
         # thoughts for later
         # ssh key for connecting to builders?

--- a/backend/copr_backend/rpmeta.py
+++ b/backend/copr_backend/rpmeta.py
@@ -90,6 +90,11 @@ def rpmeta_predict_build_time(job, opts, log):
     Returns the predicted build time as a number, or None when the
     prediction is unavailable (disabled, unsupported arch, API error, …).
 
+    When the prediction is at/above ``opts.rpmeta_powerful_threshold``
+    minutes, ``job.tags`` is mutated in place to add the
+    ``opts.rpmeta_powerful_tag``, so that the subsequent VM allocation
+    routes the build to a powerful builder.
+
     This function never raises -- all errors are caught and logged so that
     the build proceeds normally regardless of rpmeta availability.
     """
@@ -168,21 +173,39 @@ def _rpmeta_predict_inner(job, opts, log):  # pylint: disable=too-many-return-st
         log.warning("rpmeta: API returned 200 but no prediction value")
         return None
 
-    # 120 is a magic number here, logic of deciding which VM specs to use will change in the
-    # future. For now, anything above 120 minutes is considered in need of a powerful builder.
-    recommends_powerful = prediction >= 120
+    threshold = getattr(opts, "rpmeta_powerful_threshold", 120)
+    powerful_tag = getattr(opts, "rpmeta_powerful_tag", "on_demand_powerful")
+    recommends_powerful = prediction >= threshold
+    already_tagged = powerful_tag in job.tags
+
+    demoted = False
+    if already_tagged and not recommends_powerful:
+        job.tags.remove(powerful_tag)
+        demoted = True
 
     prediction_logger = _get_predictions_logger(opts.log_dir)
     prediction_logger.info(json.dumps({
         "build_id": job.build_id,
         "prediction": prediction,
+        "threshold": threshold,
         "recommends_powerful": recommends_powerful,
-        "has_powerful_tag": "on_demand_powerful" in job.tags,
+        "has_powerful_tag": already_tagged and not demoted,
+        "demoted": demoted,
     }))
 
-    if recommends_powerful:
+    if demoted:
+        log.info("rpmeta: predicted %d min for %s on %s (below threshold %d) "
+                 "-> demoted from powerful builder (tag '%s' removed)",
+                 prediction, job.package_name, job.chroot, threshold,
+                 powerful_tag)
+    elif already_tagged:
         log.info("rpmeta: predicted %d min for %s on %s "
-                 "-> recommends powerful builder (no build promotion)",
+                 "-> keeping powerful builder tag",
+                 prediction, job.package_name, job.chroot)
+    elif recommends_powerful:
+        log.info("rpmeta: predicted %d min for %s on %s "
+                 "-> would benefit from a powerful builder, but rpmeta "
+                 "never promotes builds on its own",
                  prediction, job.package_name, job.chroot)
     else:
         log.info("rpmeta: predicted %d min for %s on %s "

--- a/backend/copr_backend/rpmeta.py
+++ b/backend/copr_backend/rpmeta.py
@@ -91,7 +91,7 @@ def rpmeta_predict_build_time(job, opts, log):
     prediction is unavailable (disabled, unsupported arch, API error, …).
 
     When the prediction is at/above ``opts.rpmeta_powerful_threshold``
-    minutes, ``job.tags`` is mutated in place to add the
+    minutes, ``job.tags`` is mutated in place to add
     ``opts.rpmeta_powerful_tag``, so that the subsequent VM allocation
     routes the build to a powerful builder.
 
@@ -178,34 +178,33 @@ def _rpmeta_predict_inner(job, opts, log):  # pylint: disable=too-many-return-st
     recommends_powerful = prediction >= threshold
     already_tagged = powerful_tag in job.tags
 
-    demoted = False
-    if already_tagged and not recommends_powerful:
-        job.tags.remove(powerful_tag)
-        demoted = True
+    promoted = False
+    if recommends_powerful and not already_tagged:
+        job.tags.append(powerful_tag)
+        promoted = True
 
     prediction_logger = _get_predictions_logger(opts.log_dir)
     prediction_logger.info(json.dumps({
         "build_id": job.build_id,
+        "chroot": job.chroot,
+        "arch": job.arch,
+        "package_name": job.package_name,
+        "package_version": job.package_version,
         "prediction": prediction,
         "threshold": threshold,
         "recommends_powerful": recommends_powerful,
-        "has_powerful_tag": already_tagged and not demoted,
-        "demoted": demoted,
+        "has_powerful_tag": already_tagged or promoted,
+        "promoted": promoted,
     }))
 
-    if demoted:
-        log.info("rpmeta: predicted %d min for %s on %s (below threshold %d) "
-                 "-> demoted from powerful builder (tag '%s' removed)",
+    if promoted:
+        log.info("rpmeta: predicted %d min for %s on %s (at/above threshold %d) "
+                 "-> promoted to powerful builder (tag '%s' added)",
                  prediction, job.package_name, job.chroot, threshold,
                  powerful_tag)
     elif already_tagged:
         log.info("rpmeta: predicted %d min for %s on %s "
                  "-> keeping powerful builder tag",
-                 prediction, job.package_name, job.chroot)
-    elif recommends_powerful:
-        log.info("rpmeta: predicted %d min for %s on %s "
-                 "-> would benefit from a powerful builder, but rpmeta "
-                 "never promotes builds on its own",
                  prediction, job.package_name, job.chroot)
     else:
         log.info("rpmeta: predicted %d min for %s on %s "

--- a/backend/tests/test_rpmeta.py
+++ b/backend/tests/test_rpmeta.py
@@ -170,16 +170,16 @@ class TestRpmetaPredictBuildTime:
         assert "no HW info for arch" in log.info.call_args[0][0]
 
     @pytest.mark.parametrize(
-        "prediction_val,tags,expect_final_tag,expect_demoted,expect_log_substr", [
+        "prediction_val,tags,expect_final_tag,expect_promoted,expect_log_substr", [
             # Never tagged, below threshold -> stays untouched.
             (30, ["copr_builder", "arch_x86_64"],
              False, False, "normal builder sufficient"),
-            # Never tagged, above threshold -> rpmeta never promotes.
+            # Never tagged, above threshold -> promoted (tag added).
             (185, ["copr_builder", "arch_x86_64"],
-             False, False, "never promotes builds on its own"),
-            # Already tagged, below threshold -> demoted (tag removed).
+             True, True, "promoted to powerful builder"),
+            # Already tagged, below threshold -> rpmeta never demotes.
             (30, ["copr_builder", "arch_x86_64", "on_demand_powerful"],
-             False, True, "demoted from powerful builder"),
+             True, False, "keeping powerful builder tag"),
             # Already tagged, above threshold -> tag is kept.
             (185, ["copr_builder", "arch_x86_64", "on_demand_powerful"],
              True, False, "keeping powerful builder tag"),
@@ -187,7 +187,7 @@ class TestRpmetaPredictBuildTime:
     @mock.patch("copr_backend.rpmeta.requests.post")
     def test_successful_prediction(self, mock_post, tmpdir,
                                    prediction_val, tags, expect_final_tag,
-                                   expect_demoted, expect_log_substr):
+                                   expect_promoted, expect_log_substr):
         mock_post.return_value = _mock_prediction(prediction_val)
 
         log = mock.MagicMock()
@@ -209,14 +209,18 @@ class TestRpmetaPredictBuildTime:
             record = json.loads(fh.readline())
 
         assert record["build_id"] == 12345
+        assert record["chroot"] == "fedora-41-x86_64"
+        assert record["arch"] == "x86_64"
+        assert record["package_name"] == "test-pkg"
+        assert record["package_version"] == "0:1.2.3-1.fc41"
         assert record["prediction"] == prediction_val
         assert record["threshold"] == 120
         assert record["recommends_powerful"] is (prediction_val >= 120)
         assert record["has_powerful_tag"] is expect_final_tag
-        assert record["demoted"] is expect_demoted
+        assert record["promoted"] is expect_promoted
 
-    def test_never_promotes_untagged_job(self, tmpdir):
-        """rpmeta must never add the powerful tag on its own."""
+    def test_promotes_untagged_job_above_threshold(self, tmpdir):
+        """rpmeta adds the powerful tag to any build predicted above threshold."""
         log = mock.MagicMock()
         opts = _make_opts(tmpdir)
         job = _make_job(tags=["copr_builder", "arch_x86_64"])
@@ -225,10 +229,10 @@ class TestRpmetaPredictBuildTime:
             mock_post.return_value = _mock_prediction(500)
             rpmeta.rpmeta_predict_build_time(job, opts, log)
 
-        assert job.tags == ["copr_builder", "arch_x86_64"]
+        assert job.tags == ["copr_builder", "arch_x86_64", "on_demand_powerful"]
 
-    def test_demotes_tagged_job_below_threshold(self, tmpdir):
-        """rpmeta must mutate job.tags in place so VM allocation sees it."""
+    def test_never_removes_existing_tag(self, tmpdir):
+        """rpmeta must never demote a build that already has the powerful tag."""
         log = mock.MagicMock()
         opts = _make_opts(tmpdir)
         job = _make_job(tags=["copr_builder", "arch_x86_64", "on_demand_powerful"])
@@ -237,7 +241,7 @@ class TestRpmetaPredictBuildTime:
             mock_post.return_value = _mock_prediction(10)
             rpmeta.rpmeta_predict_build_time(job, opts, log)
 
-        assert job.tags == ["copr_builder", "arch_x86_64"]
+        assert job.tags == ["copr_builder", "arch_x86_64", "on_demand_powerful"]
 
     def test_keeps_tag_when_still_above_threshold(self, tmpdir):
         log = mock.MagicMock()
@@ -250,43 +254,43 @@ class TestRpmetaPredictBuildTime:
 
         assert job.tags == ["copr_builder", "arch_x86_64", "on_demand_powerful"]
 
-    @pytest.mark.parametrize("threshold,prediction_val,expect_demoted", [
-        (120, 119, True),
-        (120, 120, False),
-        (30, 29, True),
-        (300, 299, True),
-        (300, 300, False),
+    @pytest.mark.parametrize("threshold,prediction_val,expect_promoted", [
+        (120, 119, False),
+        (120, 120, True),
+        (30, 29, False),
+        (300, 299, False),
+        (300, 300, True),
     ])
     @mock.patch("copr_backend.rpmeta.requests.post")
     def test_configurable_threshold(self, mock_post, tmpdir,
-                                    threshold, prediction_val, expect_demoted):
+                                    threshold, prediction_val, expect_promoted):
         mock_post.return_value = _mock_prediction(prediction_val)
 
         log = mock.MagicMock()
         opts = _make_opts(tmpdir, rpmeta_powerful_threshold=threshold)
-        job = _make_job(tags=["copr_builder", "arch_x86_64", "on_demand_powerful"])
+        job = _make_job(tags=["copr_builder", "arch_x86_64"])
         result = rpmeta.rpmeta_predict_build_time(job, opts, log)
         assert result == prediction_val
-        assert ("on_demand_powerful" in job.tags) is not expect_demoted
+        assert ("on_demand_powerful" in job.tags) is expect_promoted
 
         pred_log = os.path.join(tmpdir, "rpmeta-predictions.log")
         with open(pred_log, encoding="utf-8") as fh:
             record = json.loads(fh.readline())
-        assert record["demoted"] is expect_demoted
+        assert record["promoted"] is expect_promoted
 
     @mock.patch("copr_backend.rpmeta.requests.post")
     def test_default_threshold_when_not_configured(self, mock_post, tmpdir):
-        mock_post.return_value = _mock_prediction(100)
+        mock_post.return_value = _mock_prediction(150)
 
         log = mock.MagicMock()
         opts = _make_opts(tmpdir)
         del opts["rpmeta_powerful_threshold"]
 
-        job = _make_job(tags=["copr_builder", "arch_x86_64", "on_demand_powerful"])
+        job = _make_job(tags=["copr_builder", "arch_x86_64"])
         result = rpmeta.rpmeta_predict_build_time(job, opts, log)
-        assert result == 100
-        # 100 < the default threshold of 120 -> demoted.
-        assert "on_demand_powerful" not in job.tags
+        assert result == 150
+        # 150 >= the default threshold of 120 -> promoted.
+        assert "on_demand_powerful" in job.tags
 
     @pytest.mark.parametrize("side_effect,status_code,expect_log_method,expect_log_substr", [
         (None, 404, "info", "not known to model"),

--- a/backend/tests/test_rpmeta.py
+++ b/backend/tests/test_rpmeta.py
@@ -58,10 +58,18 @@ def _make_opts(tmpdir, **overrides):
         "rpmeta_url": "http://localhost:44882",
         "rpmeta_timeout": 5,
         "rpmeta_hw_pools_config": hw_path,
+        "rpmeta_powerful_threshold": 120,
         "log_dir": tmpdir,
     }
     defaults.update(overrides)
     return Munch(defaults)
+
+
+def _mock_prediction(prediction_val):
+    mock_resp = mock.MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"prediction": prediction_val}
+    return mock_resp
 
 
 @pytest.fixture(autouse=True)
@@ -161,23 +169,30 @@ class TestRpmetaPredictBuildTime:
         log.info.assert_called()
         assert "no HW info for arch" in log.info.call_args[0][0]
 
-    @pytest.mark.parametrize("prediction_val,tags,expect_powerful,expect_powerful_tag,expect_log_substr", [
-        (30, ["copr_builder", "arch_x86_64"], False, False, "normal builder sufficient"),
-        (185, ["copr_builder", "arch_x86_64"], True, False, "recommends powerful"),
-        (10, ["copr_builder", "arch_x86_64", "on_demand_powerful"], False, True, "normal builder sufficient"),
-    ])
+    @pytest.mark.parametrize(
+        "prediction_val,tags,expect_final_tag,expect_demoted,expect_log_substr", [
+            # Never tagged, below threshold -> stays untouched.
+            (30, ["copr_builder", "arch_x86_64"],
+             False, False, "normal builder sufficient"),
+            # Never tagged, above threshold -> rpmeta never promotes.
+            (185, ["copr_builder", "arch_x86_64"],
+             False, False, "never promotes builds on its own"),
+            # Already tagged, below threshold -> demoted (tag removed).
+            (30, ["copr_builder", "arch_x86_64", "on_demand_powerful"],
+             False, True, "demoted from powerful builder"),
+            # Already tagged, above threshold -> tag is kept.
+            (185, ["copr_builder", "arch_x86_64", "on_demand_powerful"],
+             True, False, "keeping powerful builder tag"),
+        ])
     @mock.patch("copr_backend.rpmeta.requests.post")
     def test_successful_prediction(self, mock_post, tmpdir,
-                                   prediction_val, tags, expect_powerful,
-                                   expect_powerful_tag, expect_log_substr):
-        mock_resp = mock.MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"prediction": prediction_val}
-        mock_post.return_value = mock_resp
+                                   prediction_val, tags, expect_final_tag,
+                                   expect_demoted, expect_log_substr):
+        mock_post.return_value = _mock_prediction(prediction_val)
 
         log = mock.MagicMock()
         opts = _make_opts(tmpdir)
-        job = _make_job(tags=tags)
+        job = _make_job(tags=list(tags))
 
         result = rpmeta.rpmeta_predict_build_time(job, opts, log)
         assert result == prediction_val
@@ -187,14 +202,91 @@ class TestRpmetaPredictBuildTime:
         assert payload["hw_info"]["cpu_arch"] == "x86_64"
         assert expect_log_substr in log.info.call_args[0][0]
 
+        assert ("on_demand_powerful" in job.tags) is expect_final_tag
+
         pred_log = os.path.join(tmpdir, "rpmeta-predictions.log")
         with open(pred_log, encoding="utf-8") as fh:
             record = json.loads(fh.readline())
 
         assert record["build_id"] == 12345
         assert record["prediction"] == prediction_val
-        assert record["recommends_powerful"] is expect_powerful
-        assert record["has_powerful_tag"] is expect_powerful_tag
+        assert record["threshold"] == 120
+        assert record["recommends_powerful"] is (prediction_val >= 120)
+        assert record["has_powerful_tag"] is expect_final_tag
+        assert record["demoted"] is expect_demoted
+
+    def test_never_promotes_untagged_job(self, tmpdir):
+        """rpmeta must never add the powerful tag on its own."""
+        log = mock.MagicMock()
+        opts = _make_opts(tmpdir)
+        job = _make_job(tags=["copr_builder", "arch_x86_64"])
+
+        with mock.patch("copr_backend.rpmeta.requests.post") as mock_post:
+            mock_post.return_value = _mock_prediction(500)
+            rpmeta.rpmeta_predict_build_time(job, opts, log)
+
+        assert job.tags == ["copr_builder", "arch_x86_64"]
+
+    def test_demotes_tagged_job_below_threshold(self, tmpdir):
+        """rpmeta must mutate job.tags in place so VM allocation sees it."""
+        log = mock.MagicMock()
+        opts = _make_opts(tmpdir)
+        job = _make_job(tags=["copr_builder", "arch_x86_64", "on_demand_powerful"])
+
+        with mock.patch("copr_backend.rpmeta.requests.post") as mock_post:
+            mock_post.return_value = _mock_prediction(10)
+            rpmeta.rpmeta_predict_build_time(job, opts, log)
+
+        assert job.tags == ["copr_builder", "arch_x86_64"]
+
+    def test_keeps_tag_when_still_above_threshold(self, tmpdir):
+        log = mock.MagicMock()
+        opts = _make_opts(tmpdir)
+        job = _make_job(tags=["copr_builder", "arch_x86_64", "on_demand_powerful"])
+
+        with mock.patch("copr_backend.rpmeta.requests.post") as mock_post:
+            mock_post.return_value = _mock_prediction(200)
+            rpmeta.rpmeta_predict_build_time(job, opts, log)
+
+        assert job.tags == ["copr_builder", "arch_x86_64", "on_demand_powerful"]
+
+    @pytest.mark.parametrize("threshold,prediction_val,expect_demoted", [
+        (120, 119, True),
+        (120, 120, False),
+        (30, 29, True),
+        (300, 299, True),
+        (300, 300, False),
+    ])
+    @mock.patch("copr_backend.rpmeta.requests.post")
+    def test_configurable_threshold(self, mock_post, tmpdir,
+                                    threshold, prediction_val, expect_demoted):
+        mock_post.return_value = _mock_prediction(prediction_val)
+
+        log = mock.MagicMock()
+        opts = _make_opts(tmpdir, rpmeta_powerful_threshold=threshold)
+        job = _make_job(tags=["copr_builder", "arch_x86_64", "on_demand_powerful"])
+        result = rpmeta.rpmeta_predict_build_time(job, opts, log)
+        assert result == prediction_val
+        assert ("on_demand_powerful" in job.tags) is not expect_demoted
+
+        pred_log = os.path.join(tmpdir, "rpmeta-predictions.log")
+        with open(pred_log, encoding="utf-8") as fh:
+            record = json.loads(fh.readline())
+        assert record["demoted"] is expect_demoted
+
+    @mock.patch("copr_backend.rpmeta.requests.post")
+    def test_default_threshold_when_not_configured(self, mock_post, tmpdir):
+        mock_post.return_value = _mock_prediction(100)
+
+        log = mock.MagicMock()
+        opts = _make_opts(tmpdir)
+        del opts["rpmeta_powerful_threshold"]
+
+        job = _make_job(tags=["copr_builder", "arch_x86_64", "on_demand_powerful"])
+        result = rpmeta.rpmeta_predict_build_time(job, opts, log)
+        assert result == 100
+        # 100 < the default threshold of 120 -> demoted.
+        assert "on_demand_powerful" not in job.tags
 
     @pytest.mark.parametrize("side_effect,status_code,expect_log_method,expect_log_substr", [
         (None, 404, "info", "not known to model"),


### PR DESCRIPTION
Enable rpmeta and make the powerful-builder threshold configurable
(rpmeta_powerful_threshold, default 120 min). rpmeta never promotes
builds on its own — it only demotes already on_demand_powerful-tagged
builds when the prediction is below the threshold.