### PR TITLE
cli: add --with-deps option to buildpypi

### DIFF
--- a/cli/copr-cli.spec
+++ b/cli/copr-cli.spec
@@ -31,6 +31,7 @@ Requires:      python3-rich
 
 Recommends:    python3-progress
 Recommends:    python3-ConfigUpdater
+Recommends:    python3-coprtree
 Suggests:      python3-beautifulsoup4
 
 BuildRequires: python3-copr >= %min_python_copr_version

--- a/cli/copr_cli/helpers.py
+++ b/cli/copr_cli/helpers.py
@@ -9,6 +9,7 @@ information per line. The text-row format prints all information separated
 by a space on a single line.
 """
 
+
 def cli_use_output_format(parser, default='json'):
     """
     Add '--output-format' option to given parser.
@@ -18,6 +19,19 @@ def cli_use_output_format(parser, default='json'):
         choices=["text", "json", "text-row"],
         help=output_format_help,
         default=default,
+    )
+
+
+def cli_with_deps_option(parser):
+    """
+    Add '--with-deps' option to given parser.
+    """
+    parser.add_argument(
+        "--with-deps",
+        action="store_true",
+        help="Build the package dependencies for a given package using the "
+             "coprtree library. More information can be found at: "
+             "https://github.com/sundaram123krishnan/coprtree",
     )
 
 

--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -6,13 +6,15 @@ import io
 import argparse
 import datetime
 import logging
+from copy import copy
 import os
 import re
 import subprocess
 import sys
 import time
+from types import SimpleNamespace
 import warnings
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from configparser import ConfigParser
 from rich.text import Text
 from rich.console import Console
@@ -44,6 +46,7 @@ from copr.v3.pagination import next_page
 import copr.v3.requests as copr_requests
 from copr_cli.helpers import (
     cli_use_output_format,
+    cli_with_deps_option,
     print_project_info,
     colorize_status,
 )
@@ -75,6 +78,8 @@ BOOTSTRAP_MAP = {
     "image": "image",
     None: "default",
 }
+
+SourceMethod = namedtuple("SourceMethod", ["provider", "build_function"])
 
 try:
     input = raw_input
@@ -439,6 +444,16 @@ class Commands(object):
 
         self.print_build_info_and_wait(builds, args)
 
+    def pypi_cb(self, package, **kwargs):
+        """
+        Callback function for building a PyPI package.
+        """
+        return self.client.build_proxy.create_from_pypi(
+            pypi_package_name=package.name,
+            pypi_package_version=package.version,
+            **kwargs)
+
+
     @requires_api_auth
     def action_build_pypi(self, args):
         """
@@ -453,6 +468,12 @@ class Commands(object):
             "spec_template": args.spec_template,
             "python_versions": args.pythonversions,
         }
+        if args.with_deps:
+            source_method = SourceMethod(
+                provider="pypi.org",
+                build_function=self.pypi_cb,
+            )
+            return self.process_build_with_deps(args, source_method)
         return self.process_build(args, self.client.build_proxy.create_from_pypi, data)
 
     @requires_api_auth
@@ -536,6 +557,91 @@ class Commands(object):
                                 project_dirname=project_dirname,
                                 buildopts=buildopts, **data)
         builds = result if type(result) == list else [result]
+        self.print_build_info_and_wait(builds, args)
+
+
+    def process_build_with_deps(self, args, source_method):
+        """
+        Resolve the dependency tree of the requested package, and submit each
+        level of the tree as a separate batch.
+        """
+        # pylint: disable=too-many-locals
+        try:
+            # We want this to be an optional feature and don't require every
+            # user to install the dependency. It may not even be available on
+            # all systems where we need the copr-cli to run.
+            # pylint: disable=import-outside-toplevel
+            from coprtree.coprtree import resolve_dependencies
+            from coprtree.exceptions import CoprtreeError
+            from coprtree.models import BuildEnv, BuildTarget
+        except ImportError as err:
+            raise CoprException(
+                "The --with-deps option requires the coprtree library to be "
+                "installed, install it using sudo dnf install python3-coprtree"
+            ) from err
+
+        if not args.chroots or len(args.chroots) > 1:
+            raise argparse.ArgumentTypeError(
+                "The --with-deps option requires exactly one --chroot for now"
+            )
+
+        username, projectname, project_dirname = self.parse_dirname(args.copr_repo)
+
+        target = BuildTarget(
+            provider=source_method.provider, # only pypi is supported for now
+            name=args.packagename,
+            version=args.packageversion,
+        )
+        env = BuildEnv(chroot=args.chroots[0],
+                       copr_project="{0}/{1}".format(username, projectname))
+
+        if not target.version:
+            print("No package version specified, building the latest version "
+                  "of {0}".format(target.name))
+
+        try:
+            levels = list(resolve_dependencies(target, env))
+        except CoprtreeError as err:
+            raise CoprException(
+                "Can not resolve the dependencies: {0}\n"
+                "Please report this at "
+                "https://github.com/sundaram123krishnan/coprtree/issues"
+                .format(err)) from err
+
+        builds = []
+        build_opts = buildopts_from_args(args)
+
+        batch = build_opts.pop("with_build_id", None)
+        previous_batch = build_opts.pop("after_build_id", None)
+        for number, level in enumerate(levels):
+            for index, package in enumerate(level):
+                actual_options = copy(build_opts)
+                if batch is not None:
+                    actual_options.update({"with_build_id": batch})
+                elif previous_batch is not None:
+                    actual_options.update({"after_build_id": previous_batch})
+
+                package_details = SimpleNamespace(
+                    name=package.name,
+                    version=package.version,
+                )
+                build = source_method.build_function(
+                    package=package_details,
+                    ownername=username,
+                    projectname=projectname,
+                    project_dirname=project_dirname,
+                    buildopts=actual_options,
+                )
+                if index == 0:
+                    print("level {0}:".format(number))
+                print("{0} {1} -> build {2}".format(
+                    package.name, package.version, build.id))
+                builds.append(build)
+                batch = batch or build.id
+            previous_batch = batch
+            batch = None
+
+
         self.print_build_info_and_wait(builds, args)
 
 
@@ -1601,6 +1707,7 @@ def setup_parser():
     parser_build_pypi = subparsers.add_parser("buildpypi", parents=[parser_pypi_args_parent, parser_build_parent],
                                               help="Build PyPI package to a specified copr")
     parser_build_pypi.set_defaults(func="action_build_pypi")
+    cli_with_deps_option(parser_build_pypi)
 
     # create the parser for the "buildgem" command
     parser_build_rubygems = subparsers.add_parser("buildgem", parents=[parser_rubygems_args_parent, parser_build_parent],

--- a/cli/man/copr-cli.1.asciidoc
+++ b/cli/man/copr-cli.1.asciidoc
@@ -268,7 +268,7 @@ This limitation comes from the COPR API.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 usage: copr buildpypi [-h] [-r, --chroot CHROOTS] [--memory MEMORY] [--timeout TIMEOUT] [--nowait]
-                      [--background]
+                      [--background] [--with-deps]
                       [--pythonversions [VERSION [VERSION ...]]] [--packageversion PYPIVERSION]
                       --packagename PYPINAME
                       project
@@ -281,6 +281,10 @@ Version of the PyPI package to be built (by default latest)
 
 --packagename PYPINAME::
 Name of the PyPI package to be built, required.
+
+--with-deps::
+Build also the dependencies of the package. The dependency tree is resolved by the coprtree library. Requires the python3-coprtree package to be installed.  Please report bugs in the dependency resolution to
+https://github.com/sundaram123krishnan/coprtree
 
 
 For the rest of the arguments, see `copr-cli build` command above.

--- a/cli/man/copr-cli.cheat
+++ b/cli/man/copr-cli.cheat
@@ -28,5 +28,8 @@ copr-cli cancel <build_id>
 # to build rpm(s) from GIT
 copr-cli buildscm test-project --clone-url https://github.com/fedora-copr/copr.git --subdir cli
 
+# to build a PyPI package together with its dependencies
+copr-cli buildpypi test-project --packagename pydantic-ai --with-deps --chroot fedora-rawhide-x86_64
+
 # to regenerate repository metadata for a project
 copr-cli regenerate-repos test-project


### PR DESCRIPTION
Resolves: #4373
This PR introduces the integration of [coprtree](https://github.com/sundaram123krishnan/coprtree) library with `copr-cli`
As per @FrostyX's guidelines, the library is packaged in official fedora repositories and is loosely coupled with `copr-cli`.
Anyone who wants to use `--with-deps` should install it with:
```sh
sudo dnf install python3-coprtree
```
It supports `pypi` for now.
It's still in early stages, and I would like to add support for other package managers soon.
Feel free to open issues in the `coprtree` repo, if you hit any bugs in the dependency resolution. 
Quick demo:

https://github.com/user-attachments/assets/b0c712b4-513f-417c-9d49-12984b5d3105

Would like to hear the team's thought on the approach.



