### PR TITLE
backend: retry failed Pulp background tasks with exponential backoff

### DIFF
--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -32,6 +32,7 @@ BuildRequires: util-linux
 
 BuildRequires: python3-devel
 
+BuildRequires: python3-backoff
 BuildRequires: python3-copr
 BuildRequires: python3-copr-common >= %copr_common_version
 BuildRequires: python3-daemon
@@ -88,6 +89,7 @@ Requires:   python3-resalloc >= 3.0
 Requires:   python3-retask
 Requires:   python3-setproctitle
 Requires:   python3-tabulate
+Requires:   python3-backoff
 Requires:   python3-boto3
 Requires:   python3-cachetools
 Requires:   redis

--- a/backend/copr-backend.spec
+++ b/backend/copr-backend.spec
@@ -32,7 +32,6 @@ BuildRequires: util-linux
 
 BuildRequires: python3-devel
 
-BuildRequires: python3-backoff
 BuildRequires: python3-copr
 BuildRequires: python3-copr-common >= %copr_common_version
 BuildRequires: python3-daemon
@@ -89,7 +88,6 @@ Requires:   python3-resalloc >= 3.0
 Requires:   python3-retask
 Requires:   python3-setproctitle
 Requires:   python3-tabulate
-Requires:   python3-backoff
 Requires:   python3-boto3
 Requires:   python3-cachetools
 Requires:   redis

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -13,8 +13,6 @@ import hashlib
 from itertools import batched
 from urllib.parse import urlencode
 
-import backoff
-
 from copr_common.request import SafeRequest
 from copr_common.lock import Lock
 from copr_common.redis_helpers import get_redis_connection
@@ -219,21 +217,20 @@ class BatchedAddRemoveContent:
         """
         if self.check_processed():
             self.log.info("Task processed by other process")
-            return True
+            return
 
         data = self.options()
         dirs_to_delete = data.pop("dirs_to_delete", [])
 
         try:
             if not data["add_content_units"] and not data["remove_content_units"]:
-                return True
-            if not self.client.request_and_wait(
-                lambda: self.client.modify_repository_content(repository, **data),
-                f"modify repository content {repository}",
-            ):
-                return False
-
-            return self.client.publish(repository)
+                return
+            self.client.deliver_and_wait([
+                self.client.modify_repository_content(repository, **data),
+            ])
+            self.client.deliver_and_wait([
+                self.client.publish(repository),
+            ])
         finally:
             self._delete_dirs(dirs_to_delete)
 
@@ -247,9 +244,19 @@ class BatchedAddRemoveContent:
         Acquire the lock and execute the _execute_locked() method.
         """
         with Lock(self.redis, self.log).lock(repository):
-            if self._execute_locked(repository):
-                self.commit()
-                self.log.debug("Repository version and Publication created by this process")
+            self._execute_locked(repository)
+            self.commit()
+
+
+class PulpRequest:
+    """
+    A deferred Pulp API request that can be submitted and waited on.
+    """
+    def __init__(self, method, url, data=None, description=""):
+        self.method = method
+        self.url = url
+        self.data = data
+        self.description = description
 
 
 class PulpClient:
@@ -354,7 +361,7 @@ class PulpClient:
 
     def create_repository(self, name, persistent=False):
         """
-        Create an RPM repository
+        Build a PulpRequest to create an RPM repository.
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_create
         """
         uri = "/api/v3/repositories/rpm/rpm/"
@@ -364,8 +371,8 @@ class PulpClient:
             # Temporarily retain all packages, workaround for #4071
             "retain_package_versions": 0 if persistent else 0,
         }
-        self.log.info("Pulp: create_repository: %s %s", uri, name)
-        return self.send("POST", uri, data)
+        return PulpRequest("POST", uri, data,
+                           f"create repository {name}")
 
     def get_repository(self, name):
         """
@@ -416,13 +423,13 @@ class PulpClient:
             "repository": repository,
             "base_path": basepath or name,
         }
-        self.log.info("Pulp: create_distribution: %s %s", uri, data)
-        return self.send("POST", uri, data)
+        return PulpRequest("POST", uri, data,
+                           f"create distribution {name}")
 
-    def _send_update_distribution(self, distribution, publication=None,
-                                   repository=None):
+    def update_distribution(self, distribution, publication=None,
+                            repository=None):
         """
-        Send a request to update an RPM distribution.
+        Build a PulpRequest to update an RPM distribution.
         https://pulpproject.org/pulp_rpm/restapi/#tag/Distributions:-Rpm/operation/distributions_rpm_rpm_update
 
         This allows us to point a distribution to either a publication or
@@ -437,40 +444,17 @@ class PulpClient:
             "publication": publication,
             "repository": repository,
         }
-        self.log.info("Pulp: updating distribution %s", distribution)
-        return self.send("PATCH", url, data)
+        return PulpRequest("PATCH", url, data,
+                           f"update distribution {distribution}")
 
-    def update_distribution(self, distribution, publication=None,
-                            repository=None):
+    def publish(self, repository):
         """
-        Update an RPM distribution and wait for the async task to finish.
-        """
-        return self.request_and_wait(
-            lambda: self._send_update_distribution(
-                distribution, publication=publication,
-                repository=repository,
-            ),
-            f"update distribution {distribution}",
-        )
-
-    def create_publication(self, repository):
-        """
-        Create an RPM publication
+        Build a PulpRequest to create an RPM publication.
         https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Publications:-Rpm/operation/publications_rpm_rpm_create
         """
         uri = "/api/v3/publications/rpm/rpm/"
         data = {"repository": repository}
-        self.log.info("Pulp: publishing %s %s", uri, repository)
-        return self.send("POST", uri, data)
-
-    def publish(self, repository):
-        """
-        Create a publication and wait for the task to finish.
-        """
-        return self.request_and_wait(
-            lambda: self.create_publication(repository),
-            f"publish {repository}",
-        )
+        return PulpRequest("POST", uri, data, f"publish {repository}")
 
     def get_publication(self, repository):
         """
@@ -558,12 +542,10 @@ class PulpClient:
 
         # We need to wait until the task finishes. This is the disadvantage
         # compared to standard uploads
-        data = self.request_and_wait(
-            lambda: self.send("POST", commit_url, data=commit_data),
-            f"upload chunked {path}",
-        )
-        if not data:
-            raise RuntimeError(f"Failed to upload chunked {path}")
+        data = self.deliver_and_wait([
+            PulpRequest("POST", commit_url, commit_data,
+                        f"upload chunked {path}"),
+        ])[0]
 
         resources = data["created_resources"]
         if len(resources) != 1:
@@ -589,13 +571,14 @@ class PulpClient:
 
     def modify_repository_content(self, repository, add_content_units, remove_content_units):
         """
-        Add and/or remove a list of artifacts to/from a repository
+        Build a PulpRequest to add/remove artifacts to/from a repository.
         https://pulpproject.org/pulp_rpm/restapi/#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_modify
         """
         path = os.path.join(repository, "modify/")
         url = self.config["base_url"] + path
         data = {"add_content_units": add_content_units or [], "remove_content_units": remove_content_units or []}
-        return self.send("POST", url, data)
+        return PulpRequest("POST", url, data,
+                           f"modify repository content {repository}")
 
     def add_content(self, repository, artifacts):
         """
@@ -705,8 +688,8 @@ class PulpClient:
         https://pulpproject.org/pulp_rpm/restapi/#tag/Repositories:-Rpm/operation/repositories_rpm_rpm_delete
         """
         url = self.config["base_url"] + repository
-        self.log.info("Pulp: delete_repository: %s", repository)
-        return self.send("DELETE", url)
+        return PulpRequest("DELETE", url,
+                           description=f"delete repository {repository}")
 
     def delete_distribution(self, distribution):
         """
@@ -714,61 +697,67 @@ class PulpClient:
         https://pulpproject.org/pulp_rpm/restapi/#tag/Distributions:-Rpm/operation/distributions_rpm_rpm_delete
         """
         url = self.config["base_url"] + distribution
-        self.log.info("Pulp: delete_distribution: %s", distribution)
-        return self.send("DELETE", url)
+        return PulpRequest("DELETE", url,
+                           description=f"delete distribution {distribution}")
 
-    def wait_for_finished_task(self, task, description="task", timeout=86400):
+    def deliver_and_wait(self, requests, timeout=86400):
         """
-        Wait for a Pulp task to finish.  Return the task data dict on
-        success, or None on failure.
+        Submit multiple PulpRequests and wait for all background tasks to
+        finish.  Retry failed requests/tasks until timeout.  Raise
+        RuntimeError if any request cannot be completed within the timeout.
         """
-        start = time.monotonic()
-        while True:
-            if time.monotonic() > start + timeout:
-                self.log.error("Pulp %s %s timed out after %ss",
-                               description, task, timeout)
-                return None
-            self.log.info("Pulp: polling task status: %s", task)
-            response = self.get_task(task)
-            if not response.ok:
-                self.log.warning("Pulp %s %s: status request failed: %s",
-                                 description, task, response.text)
-                time.sleep(5)
-                continue
-            data = response.json()
-            if data["state"] not in ["waiting", "running"]:
-                break
-            time.sleep(5)
-        if data["state"] == "completed":
-            self.log.info("Pulp %s %s succeeded", description, task)
-            return data
-        self.log.error("Pulp %s %s failed: %s", description, task, data)
-        return None
+        if not requests:
+            return []
 
-    def request_and_wait(self, request_fn, description, timeout=86400):
-        """
-        Submit a Pulp request, wait for the background task to finish, and
-        retry the whole submit+wait cycle on task failure (with exponential
-        backoff) until timeout is reached.  Return the task data dict on
-        success, or None on timeout.
-        """
         deadline = time.monotonic() + timeout
+        results = [None] * len(requests)
 
-        @backoff.on_predicate(backoff.expo, max_time=timeout,
-                              max_value=300, logger=self.log)
-        def _try():
-            response = request_fn()
-            if not response.ok:
-                self.log.error("%s request failed: %s",
-                               description, response.text)
-                return None
-            if response.status_code != 202:
-                return response.json()
-            task = response.json()["task"]
-            self.log.info("Pulp: %s => task %s", description, task)
-            remaining = max(360, deadline - time.monotonic())
-            return self.wait_for_finished_task(task, description, remaining)
-        return _try()
+        # Initialize the todo-list.
+        # (index, request, task_href_or_None, backoff_sleep)
+        pending = [(i, req, None, 5) for i, req in enumerate(requests)]
+
+        while pending:
+            if time.monotonic() > deadline:
+                descriptions = ", ".join(
+                    req.description for _, req, _, _ in pending)
+                raise RuntimeError(
+                    f"Pulp tasks timed out after {timeout}s: {descriptions}")
+
+            still_pending = []
+            for i, req, task, backoff_sleep in pending:
+                if task is None:
+                    self.log.info("Pulp: submitting %s", req.description)
+                    response = self.send(req.method, req.url, req.data)
+                    if response.status_code != 202:
+                        results[i] = response.json()
+                        continue
+                    task = response.json()["task"]
+                    self.log.info("Pulp: %s => task %s",
+                                  req.description, task)
+                    still_pending.append((i, req, task, backoff_sleep))
+                    continue
+
+                response = self.get_task(task)
+                data = response.json()
+                if data["state"] in ("waiting", "running"):
+                    still_pending.append((i, req, task, backoff_sleep))
+                    continue
+                if data["state"] == "completed":
+                    self.log.info("Pulp %s %s succeeded",
+                                  req.description, task)
+                    results[i] = data
+                    continue
+                self.log.warning("Pulp %s %s failed, resubmitting: %s",
+                                  req.description, task, data)
+                # Re-add with None href.
+                still_pending.append((i, req, None,
+                                      min(backoff_sleep * 2, 300)))
+
+            pending = still_pending
+            if pending:
+                time.sleep(max(s for _, _, _, s in pending))
+
+        return results
 
     def list_distributions(self, prefix):
         """

--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -13,6 +13,8 @@ import hashlib
 from itertools import batched
 from urllib.parse import urlencode
 
+import backoff
+
 from copr_common.request import SafeRequest
 from copr_common.lock import Lock
 from copr_common.redis_helpers import get_redis_connection
@@ -225,14 +227,9 @@ class BatchedAddRemoveContent:
         try:
             if not data["add_content_units"] and not data["remove_content_units"]:
                 return True
-            response = self.client.modify_repository_content(repository, **data)
-            if not response.ok:
-                self.log.error("Failed to create a new repository version for: %s, %s",
-                               repository, response.text)
-                return False
-            task = response.json()["task"]
-            if not self.client.wait_for_finished_task(
-                task, f"modify repository content {repository}",
+            if not self.client.request_and_wait(
+                lambda: self.client.modify_repository_content(repository, **data),
+                f"modify repository content {repository}",
             ):
                 return False
 
@@ -422,10 +419,11 @@ class PulpClient:
         self.log.info("Pulp: create_distribution: %s %s", uri, data)
         return self.send("POST", uri, data)
 
-    def update_distribution(self, distribution, publication=None, repository=None):
+    def _send_update_distribution(self, distribution, publication=None,
+                                   repository=None):
         """
-        Update an RPM distribution
-        https://docs.pulpproject.org/pulp_rpm/restapi.html#tag/Distributions:-Rpm/operation/distributions_rpm_rpm_update
+        Send a request to update an RPM distribution.
+        https://pulpproject.org/pulp_rpm/restapi/#tag/Distributions:-Rpm/operation/distributions_rpm_rpm_update
 
         This allows us to point a distribution to either a publication or
         a repository. Not both, that doesn't make sense and Pulp would raise
@@ -440,18 +438,20 @@ class PulpClient:
             "repository": repository,
         }
         self.log.info("Pulp: updating distribution %s", distribution)
-        response = self.send("PATCH", url, data)
-        if not response.ok:
-            self.log.error("Failed to update distribution %s: %s",
-                           distribution, response.text)
-            return False
-        if response.status_code == 202:
-            task = response.json()["task"]
-            if not self.wait_for_finished_task(
-                task, f"update distribution {distribution}",
-            ):
-                return False
-        return True
+        return self.send("PATCH", url, data)
+
+    def update_distribution(self, distribution, publication=None,
+                            repository=None):
+        """
+        Update an RPM distribution and wait for the async task to finish.
+        """
+        return self.request_and_wait(
+            lambda: self._send_update_distribution(
+                distribution, publication=publication,
+                repository=repository,
+            ),
+            f"update distribution {distribution}",
+        )
 
     def create_publication(self, repository):
         """
@@ -467,13 +467,10 @@ class PulpClient:
         """
         Create a publication and wait for the task to finish.
         """
-        response = self.create_publication(repository)
-        task = response.json()["task"]
-        if not self.wait_for_finished_task(
-            task, f"publish {repository}",
-        ):
-            return False
-        return True
+        return self.request_and_wait(
+            lambda: self.create_publication(repository),
+            f"publish {repository}",
+        )
 
     def get_publication(self, repository):
         """
@@ -555,16 +552,15 @@ class PulpClient:
 
         # Send the file request that we want to reassemble the file
         commit_url = self.config["base_url"] + upload_href + "commit/"
-        data = {
+        commit_data = {
             "sha256": sha256.hexdigest(),
         }
-        response = self.send("POST", commit_url, data=data)
 
         # We need to wait until the task finishes. This is the disadvantage
         # compared to standard uploads
-        task = response.json()["task"]
-        data = self.wait_for_finished_task(
-            task, f"upload chunked {path}",
+        data = self.request_and_wait(
+            lambda: self.send("POST", commit_url, data=commit_data),
+            f"upload chunked {path}",
         )
         if not data:
             raise RuntimeError(f"Failed to upload chunked {path}")
@@ -748,6 +744,31 @@ class PulpClient:
             return data
         self.log.error("Pulp %s %s failed: %s", description, task, data)
         return None
+
+    def request_and_wait(self, request_fn, description, timeout=86400):
+        """
+        Submit a Pulp request, wait for the background task to finish, and
+        retry the whole submit+wait cycle on task failure (with exponential
+        backoff) until timeout is reached.  Return the task data dict on
+        success, or None on timeout.
+        """
+        deadline = time.monotonic() + timeout
+
+        @backoff.on_predicate(backoff.expo, max_time=timeout,
+                              max_value=300, logger=self.log)
+        def _try():
+            response = request_fn()
+            if not response.ok:
+                self.log.error("%s request failed: %s",
+                               description, response.text)
+                return None
+            if response.status_code != 202:
+                return response.json()
+            task = response.json()["task"]
+            self.log.info("Pulp: %s => task %s", description, task)
+            remaining = max(360, deadline - time.monotonic())
+            return self.wait_for_finished_task(task, description, remaining)
+        return _try()
 
     def list_distributions(self, prefix):
         """

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -313,18 +313,15 @@ class PulpStorage(Storage):
     def init_project(self, dirname, chroot, reason=None):
         repository_name = self._repository_name(chroot, dirname)
         try:
-            response = self.client.create_repository(
-                repository_name,
-                persistent=self.persistent,
-            )
+            self.client.deliver_and_wait([
+                self.client.create_repository(
+                    repository_name,
+                    persistent=self.persistent,
+                ),
+            ])
         except RequestError as ex:
             if "This field must be unique" not in ex.response.text:
-                self.log.error(
-                    "Failed to create a Pulp repository %s because of %s",
-                    repository_name,
-                    ex.response.text,
-                )
-                return False
+                raise
 
         # When a repository is mentioned in other endpoints, it needs to be
         # mentioned by its href, not name
@@ -337,21 +334,13 @@ class PulpStorage(Storage):
         devel_distribution_name = self._distribution_name(chroot, dirname, devel=True)
 
         try:
-            if not self.client.request_and_wait(
-                lambda: self.client.create_distribution(
-                    distribution_name, repository_href,
-                ),
-                f"create distribution {distribution_name}",
-            ):
-                return False
+            self.client.deliver_and_wait([
+                self.client.create_distribution(
+                    distribution_name, repository_href),
+            ])
         except RequestError as ex:
             if "This field must be unique" not in ex.response.text:
-                self.log.error(
-                    "Failed to create a Pulp distribution %s because of %s",
-                    public_distribution_name,
-                    ex.response.text,
-                )
-                return False
+                raise
 
         # If a project enabled the manual createrepo mode, we need to create a
         # devel distribution to be consumed by other builds within the project
@@ -359,18 +348,18 @@ class PulpStorage(Storage):
             response = self.client.get_publication(repository_href)
             publication = response.json()["results"][0]["pulp_href"]
             public_distribution = self._get_distribution(chroot, dirname, devel=False)
-
-            if not self.client.update_distribution(public_distribution, publication=publication):
-                return False
+            self.client.deliver_and_wait([
+                self.client.update_distribution(
+                    public_distribution, publication=publication),
+            ])
 
         # We want to disable the manual createrepo feature on a project
         elif reason == CreaterepoReason.manual_createrepo_toggle:
             public_distribution = self._get_distribution(chroot)
-            if not self.client.update_distribution(
-                public_distribution,
-                repository=repository_href,
-            ):
-                return False
+            self.client.deliver_and_wait([
+                self.client.update_distribution(
+                    public_distribution, repository=repository_href),
+            ])
 
         # The "Regenerate" button was clicked for a manual createrepo project.
         # We want to copy packages from the devel repo to the public repo.
@@ -406,16 +395,18 @@ class PulpStorage(Storage):
                     devel_distribution_name,
                     publication,
                 )
-                if not self.client.update_distribution(
-                    public_distribution["pulp_href"],
-                    publication=publication,
-                ):
-                    return False
+                self.client.deliver_and_wait([
+                    self.client.update_distribution(
+                        public_distribution["pulp_href"],
+                        publication=publication),
+                ])
 
         # And finally, run the actual createrepo for either the devel or
         # the public repository
         try:
-            return self.client.publish(repository_href)
+            self.client.deliver_and_wait([
+                self.client.publish(repository_href),
+            ])
         finally:
             redirect = PulpHTTPRedirect(lock=self._lock)
             redirect.add(self.owner, self.project)
@@ -520,27 +511,35 @@ class PulpStorage(Storage):
         return True
 
     def delete_repository(self, chroot):
-        name = self._repository_name(chroot)
         repository = self._get_repository(chroot)
-        self.log.info("Removing Pulp repository: %s", name)
-        self.client.delete_repository(repository)
-
-        name = self._distribution_name(chroot)
         distribution = self._get_distribution(chroot)
-        self.log.info("Removing Pulp distribution: %s", name)
-        self.client.delete_distribution(distribution)
+        self.log.info("Removing Pulp repository and distribution for %s",
+                       chroot)
+        self.client.deliver_and_wait([
+            self.client.delete_distribution(distribution),
+        ])
+        self.client.deliver_and_wait([
+            self.client.delete_repository(repository),
+        ])
 
     def delete_project(self, dirname):
         prefix = "{0}/{1}/".format(self.owner, dirname)
         response = self.client.list_distributions(prefix)
         distributions = response.json()["results"]
+        dist_requests = []
+        repo_requests = []
         for distribution in distributions:
-            name = distribution["name"]
-            self.log.info("Removing Pulp distribution for %s", name)
-            self.client.delete_distribution(distribution["pulp_href"])
+            self.log.info("Removing Pulp distribution for %s",
+                          distribution["name"])
+            dist_requests.append(
+                self.client.delete_distribution(distribution["pulp_href"]))
             if distribution["repository"]:
-                self.log.info("Removing Pulp repository for %s", name)
-                self.client.delete_repository(distribution["repository"])
+                self.log.info("Removing Pulp repository for %s",
+                              distribution["name"])
+                repo_requests.append(
+                    self.client.delete_repository(distribution["repository"]))
+        self.client.deliver_and_wait(dist_requests)
+        self.client.deliver_and_wait(repo_requests)
         redirect = PulpHTTPRedirect(lock=self._lock)
         redirect.remove(self.owner, dirname)
 
@@ -587,9 +586,7 @@ class PulpStorage(Storage):
             # It should be a dirname here but since forking CoprDirs is not
             # supported yet, we pass the project name
             # See https://github.com/fedora-copr/copr/issues/3820
-            if not self.init_project(dst_project, chroot):
-                self.log.error("Failed to init the dst project")
-                return False
+            self.init_project(dst_project, chroot)
 
             for old_dir_name, new_dir_name in src_dst_dir.items():
                 src_dir, dst_dir = old_dir_name, new_dir_name
@@ -615,11 +612,11 @@ class PulpStorage(Storage):
                     chroot,
                 )
 
-            repository = self._get_repository(chroot)
-            if createrepo and not self.client.publish(repository):
-                return False
-
-        return True
+            if createrepo:
+                repository = self._get_repository(chroot)
+                self.client.deliver_and_wait([
+                    self.client.publish(repository),
+                ])
 
     def _fork_build(self, src_build_id, dst_build_id, src_owner, src_project,
                     dst_owner, dst_project, dst_dirname, chroot):

--- a/backend/copr_backend/storage.py
+++ b/backend/copr_backend/storage.py
@@ -337,13 +337,11 @@ class PulpStorage(Storage):
         devel_distribution_name = self._distribution_name(chroot, dirname, devel=True)
 
         try:
-            response = self.client.create_distribution(
-                distribution_name,
-                repository_href,
-            )
-            task = response.json()["task"]
-            if not self.client.wait_for_finished_task(
-                task, f"create distribution {distribution_name}",
+            if not self.client.request_and_wait(
+                lambda: self.client.create_distribution(
+                    distribution_name, repository_href,
+                ),
+                f"create distribution {distribution_name}",
             ):
                 return False
         except RequestError as ex:

--- a/backend/tests/test_pulp.py
+++ b/backend/tests/test_pulp.py
@@ -4,9 +4,9 @@ Test Pulp client
 
 # pylint: disable=attribute-defined-outside-init
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import pytest
-from copr_backend.pulp import PulpClient
+from copr_backend.pulp import PulpClient, PulpRequest
 
 
 class TestPulp:
@@ -139,3 +139,173 @@ class TestPulp:
             client.get_content([], fields=["prn"])
         assert "Content must be queried for specific builds" in str(ex)
         assert not client.send.called
+
+
+class TestDeliverRequests:
+
+    def setup_method(self, _method):
+        self.config = {
+            "api_root": "/pulp/",
+            "base_url": "http://pulp.fpo:24817",
+            "cert": "",
+            "domain": "default",
+            "dry_run": False,
+            "format": "json",
+            "key": "",
+            "password": "1234",
+            "timeout": 0,
+            "username": "admin",
+            "verbose": 0,
+            "verify_ssl": True,
+        }
+        self.client = PulpClient(self.config)
+
+    def _mock_response(self, status_code, json_data=None):
+        resp = Mock()
+        resp.ok = 200 <= status_code < 400
+        resp.status_code = status_code
+        resp.text = "mock"
+        resp.json.return_value = json_data or {}
+        return resp
+
+    def test_empty_list(self):
+        assert not self.client.deliver_and_wait([])
+
+    @patch("time.sleep")
+    def test_sync_request(self, _sleep):
+        self.client.send = Mock(return_value=self._mock_response(
+            201, {"pulp_href": "/repo/1/"}))
+        req = PulpRequest("POST", "/api/v3/repositories/rpm/rpm/",
+                          {"name": "test"}, "create repo")
+        results = self.client.deliver_and_wait([req])
+        assert results == [{"pulp_href": "/repo/1/"}]
+        self.client.send.assert_called_once_with("POST",
+            "/api/v3/repositories/rpm/rpm/", {"name": "test"})
+
+    @patch("time.sleep")
+    def test_async_task_completed(self, _sleep):
+        submit_resp = self._mock_response(202, {"task": "/tasks/abc/"})
+        task_resp = self._mock_response(200, {
+            "state": "completed",
+            "created_resources": ["/content/1/"],
+        })
+        self.client.send = Mock(return_value=submit_resp)
+        self.client.get_task = Mock(return_value=task_resp)
+
+        req = PulpRequest("POST", "/url/", None, "test task")
+        results = self.client.deliver_and_wait([req])
+        assert results[0]["state"] == "completed"
+        self.client.get_task.assert_called_once_with("/tasks/abc/")
+
+    @patch("time.sleep")
+    def test_async_task_waiting_then_completed(self, _sleep):
+        submit_resp = self._mock_response(202, {"task": "/tasks/abc/"})
+        waiting_resp = self._mock_response(200, {"state": "waiting"})
+        completed_resp = self._mock_response(200, {
+            "state": "completed",
+            "created_resources": [],
+        })
+        self.client.send = Mock(return_value=submit_resp)
+        self.client.get_task = Mock(side_effect=[waiting_resp, completed_resp])
+
+        req = PulpRequest("DELETE", "/url/", None, "delete thing")
+        results = self.client.deliver_and_wait([req])
+        assert results[0]["state"] == "completed"
+        assert self.client.get_task.call_count == 2
+        _sleep.assert_called()
+
+    @patch("time.sleep")
+    def test_failed_task_resubmitted(self, _sleep):
+        submit_resp = self._mock_response(202, {"task": "/tasks/1/"})
+        failed_resp = self._mock_response(200, {"state": "failed"})
+        resubmit_resp = self._mock_response(202, {"task": "/tasks/2/"})
+        completed_resp = self._mock_response(200, {
+            "state": "completed",
+            "created_resources": [],
+        })
+        self.client.send = Mock(side_effect=[submit_resp, resubmit_resp])
+        self.client.get_task = Mock(side_effect=[failed_resp, completed_resp])
+
+        req = PulpRequest("POST", "/url/", None, "retry task")
+        results = self.client.deliver_and_wait([req])
+        assert results[0]["state"] == "completed"
+        assert self.client.send.call_count == 2
+        assert self.client.get_task.call_count == 2
+
+    @patch("time.sleep")
+    @patch("time.monotonic")
+    def test_timeout_raises(self, mock_monotonic, _sleep):
+        mock_monotonic.side_effect = [0, 0, 100]
+        submit_resp = self._mock_response(202, {"task": "/tasks/1/"})
+        waiting_resp = self._mock_response(200, {"state": "waiting"})
+        self.client.send = Mock(return_value=submit_resp)
+        self.client.get_task = Mock(return_value=waiting_resp)
+
+        req = PulpRequest("POST", "/url/", None, "slow task")
+        with pytest.raises(RuntimeError, match="timed out"):
+            self.client.deliver_and_wait([req], timeout=10)
+
+    @patch("time.sleep")
+    def test_multiple_parallel_requests(self, _sleep):
+        submit1 = self._mock_response(202, {"task": "/tasks/1/"})
+        submit2 = self._mock_response(202, {"task": "/tasks/2/"})
+        completed1 = self._mock_response(200, {
+            "state": "completed", "result": "one"})
+        completed2 = self._mock_response(200, {
+            "state": "completed", "result": "two"})
+        self.client.send = Mock(side_effect=[submit1, submit2])
+        self.client.get_task = Mock(side_effect=[completed1, completed2])
+
+        reqs = [
+            PulpRequest("DELETE", "/repo/1/", None, "delete repo 1"),
+            PulpRequest("DELETE", "/dist/1/", None, "delete dist 1"),
+        ]
+        results = self.client.deliver_and_wait(reqs)
+        assert results[0]["result"] == "one"
+        assert results[1]["result"] == "two"
+
+    @patch("time.sleep")
+    def test_backoff_increases_on_failure(self, mock_sleep):
+        """
+        Backoff doubles on each task failure and persists across resubmits.
+        """
+        submit_resp = self._mock_response(202, {"task": "/tasks/1/"})
+        failed_resp = self._mock_response(200, {"state": "failed"})
+        resubmit_resp = self._mock_response(202, {"task": "/tasks/2/"})
+        failed_resp2 = self._mock_response(200, {"state": "failed"})
+        resubmit_resp2 = self._mock_response(202, {"task": "/tasks/3/"})
+        completed_resp = self._mock_response(200, {"state": "completed"})
+        self.client.send = Mock(
+            side_effect=[submit_resp, resubmit_resp, resubmit_resp2])
+        self.client.get_task = Mock(
+            side_effect=[failed_resp, failed_resp2, completed_resp])
+
+        req = PulpRequest("POST", "/url/", None, "backoff task")
+        results = self.client.deliver_and_wait([req])
+        assert results[0]["state"] == "completed"
+        sleeps = [call.args[0] for call in mock_sleep.call_args_list]
+        assert sleeps == [5, 10, 10, 20, 20]
+
+    @patch("time.sleep")
+    def test_backoff_capped_at_300(self, mock_sleep):
+        """
+        Backoff doubles on each failure but never exceeds 300s.
+        """
+        failed_resp = self._mock_response(200, {"state": "failed"})
+        completed_resp = self._mock_response(200, {"state": "completed"})
+
+        # 8 failures: backoff goes 5→10→20→40→80→160→320→640
+        # but capped: 5→10→20→40→80→160→300→300
+        task_responses = [failed_resp] * 8 + [completed_resp]
+        submit_responses = [
+            self._mock_response(202, {"task": f"/tasks/{i}/"})
+            for i in range(9)
+        ]
+        self.client.send = Mock(side_effect=submit_responses)
+        self.client.get_task = Mock(side_effect=task_responses)
+
+        req = PulpRequest("POST", "/url/", None, "capped backoff")
+        results = self.client.deliver_and_wait([req])
+        assert results[0]["state"] == "completed"
+        sleeps = [call.args[0] for call in mock_sleep.call_args_list]
+        assert max(sleeps) == 300


### PR DESCRIPTION
Introduce request_and_wait() that unifies the send-request + wait-for-task pattern and retries the whole cycle on task failure using exponential backoff (capped at 5 min between retries, 24 h total).

Fixes: #4317
Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>