### PR TITLE
ci: provide PULP_SECRET_KEY for testing-farm use-case

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -201,6 +201,7 @@ services:
     tty: true
     environment:
       - PULP_DEFAULT_ADMIN_PASSWORD=admin
+      - PULP_SECRET_KEY=change-me-to-something-secret
     ports:
       - 5006:80
     volumes:

--- a/kube-deploy/manifests/base/pulp.yaml
+++ b/kube-deploy/manifests/base/pulp.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: PULP_DEFAULT_ADMIN_PASSWORD
               value: "admin"
+            - name: PULP_SECRET_KEY
+              value: "change-me-to-something-secret"
           ports:
             - containerPort: 80
               protocol: TCP

--- a/testing-farm/prepare/roles/credentials/tasks/main.yaml
+++ b/testing-farm/prepare/roles/credentials/tasks/main.yaml
@@ -99,6 +99,15 @@
   no_log: true
   when: with_pulp | default(false) | bool
 
+- name: Generate Pulp SECRET_KEY
+  copy:
+    content: "{{ lookup('ansible.builtin.password', '/dev/null', length=50, chars=['ascii_letters', 'digits']) }}"
+    dest: /root/pulp-secret-key
+    mode: "0400"
+    force: false
+  no_log: true
+  when: with_pulp | default(false) | bool
+
 - name: generate backend -> builder keypair
   community.crypto.openssh_keypair:
     path: /root/backend_builder

--- a/testing-farm/prepare/roles/pulp/tasks/main.yaml
+++ b/testing-farm/prepare/roles/pulp/tasks/main.yaml
@@ -6,6 +6,13 @@
   register: pulp_admin_password
   no_log: true
 
+- name: Fetch the Pulp SECRET_KEY
+  ansible.builtin.slurp:
+    src: /root/pulp-secret-key
+  delegate_to: "{{ host_with_secrets }}"
+  register: pulp_secret_key
+  no_log: true
+
 - name: Start Pulp container
   containers.podman.podman_container:
     name: pulp
@@ -13,6 +20,7 @@
     state: started
     env:
       PULP_DEFAULT_ADMIN_PASSWORD: "{{ pulp_admin_password['content'] | b64decode }}"
+      PULP_SECRET_KEY: "{{ pulp_secret_key['content'] | b64decode }}"
     ports:
       - "5006:80"
     device:


### PR DESCRIPTION
To make tests work, we also need to provide this, per: https://pulpproject.org/pulpcore/docs/admin/reference/settings/#secret_key

This is a new thing, got to the ghcr.io/pulp/pulp:latest yesterday :-)

Relates: #4421