### PR TITLE
discussion: add live metrics for copr-rpmbuild (backporting to mock)

### DIFF
--- a/rpmbuild/copr_rpmbuild/builders/mock.py
+++ b/rpmbuild/copr_rpmbuild/builders/mock.py
@@ -15,6 +15,10 @@ from copr_rpmbuild.helpers import (
     macros_for_task,
     mock_snippet_for_tags,
 )
+from copr_rpmbuild.resource_monitor import (
+    CgroupSampler,
+    write_resource_results,
+)
 
 log = logging.getLogger("__main__")
 
@@ -87,6 +91,7 @@ class MockBuilder(object):
             modules=self.module_setup_commands,
             copr_build_id=self.build_id,
             isolation=self.isolation,
+            resource_monitoring=self.copr_rpmbuild_config.resource_monitoring,
             macros=self.macros,
             mock_snippet=mock_snippet_for_tags(
                 self.copr_rpmbuild_config.tags_to_mock_snippet, self.tags
@@ -174,6 +179,20 @@ class MockBuilder(object):
 
         return tuples
 
+    def _wrap_with_systemd_run(self, cmd):
+        unit_name = "copr-build-{}".format(self.build_id)
+        wrapped = [
+            'systemd-run', '--quiet', '--wait', '--pipe', '--collect',
+            '--unit={}'.format(unit_name),
+            '-p', 'MemoryAccounting=yes',
+            '-p', 'CPUAccounting=yes',
+            '-p', 'IOAccounting=yes',
+            '--',
+        ] + cmd
+        cgroup_path = "/sys/fs/cgroup/system.slice/{}.service".format(
+            unit_name)
+        return wrapped, cgroup_path, unit_name
+
     def produce_rpm(self, spec, sources, resultdir):
         cmd = MOCK_CALL + [
                "--spec", spec,
@@ -194,8 +213,19 @@ class MockBuilder(object):
         if self.allow_user_ssh:
             cmd += ["--no-cleanup-after"]
 
+        monitoring = self.copr_rpmbuild_config.resource_monitoring
+        sampler = None
+        unit_name = None
+
+        if monitoring:
+            cmd, cgroup_path, unit_name = self._wrap_with_systemd_run(cmd)
+            sampler = CgroupSampler(cgroup_path)
+
         process = GentlyTimeoutedPopen(cmd, stdin=subprocess.PIPE,
                 timeout=self.timeout)
+
+        if sampler:
+            sampler.start()
 
         try:
             process.communicate()
@@ -203,6 +233,19 @@ class MockBuilder(object):
             raise RuntimeError(str(e))
         finally:
             process.done()
+            if sampler:
+                try:
+                    sampler.stop()
+                    write_resource_results(resultdir, sampler)
+                except Exception:
+                    log.warning("Resource monitoring failed, skipping",
+                                exc_info=True)
+            if unit_name:
+                subprocess.call(
+                    ['systemctl', 'stop', unit_name],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
 
         if process.returncode != 0:
             raise RuntimeError("Build failed")

--- a/rpmbuild/copr_rpmbuild/config.py
+++ b/rpmbuild/copr_rpmbuild/config.py
@@ -16,6 +16,7 @@ class Config:
     def __init__(self):
         self.tags_to_mock_snippet = []
         self.rhsm = []
+        self.resource_monitoring = False
 
     def load_config(self):
         """
@@ -30,3 +31,4 @@ class Config:
 
         self.tags_to_mock_snippet = config_data.get("tags_to_mock_snippet", [])
         self.rhsm = config_data.get("rhsm", [])
+        self.resource_monitoring = config_data.get("resource_monitoring", False)

--- a/rpmbuild/copr_rpmbuild/resource_monitor.py
+++ b/rpmbuild/copr_rpmbuild/resource_monitor.py
@@ -1,0 +1,208 @@
+import json
+import logging
+import os
+import re
+import threading
+import time
+
+log = logging.getLogger("__main__")
+
+SAMPLE_INTERVAL_SEC = 10
+GiB = 1024 ** 3
+
+
+def _read_int(path):
+    """Read a cgroup file containing a single integer."""
+    try:
+        with open(path) as f:
+            text = f.read().strip()
+            if text == "max":
+                return 0
+            return int(text)
+    except (OSError, ValueError):
+        return 0
+
+
+def _read_stat_field(path, field):
+    """Parse a 'key value' file (cpu.stat) and return the int for `field`."""
+    try:
+        with open(path) as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) == 2 and parts[0] == field:
+                    return int(parts[1])
+    except (OSError, ValueError):
+        pass
+
+    return 0
+
+
+def _read_io_total(path, field):
+    """
+    Parse io.stat (format: MAJ:MIN key=val key=val ...) and sum `field`
+    across all devices.
+    """
+    total = 0
+    try:
+        with open(path) as f:
+            for line in f:
+                for token in line.split():
+                    if token.startswith(field + "="):
+                        total += int(token.split("=", 1)[1])
+    except (OSError, ValueError):
+        pass
+    return total
+
+
+def _read_psi_total(path):
+    """
+    Parse a PSI pressure file and return the cumulative 'total' from
+    the 'some' line (microseconds).
+    """
+    try:
+        with open(path) as f:
+            for line in f:
+                if line.startswith("some "):
+                    match = re.search(r"total=(\d+)", line)
+                    if match:
+                        return int(match.group(1))
+    except (OSError, ValueError):
+        pass
+    return 0
+
+
+class CgroupSampler:
+    def __init__(self, cgroup_path, interval=SAMPLE_INTERVAL_SEC):
+        self.cgroup_path = cgroup_path
+        self.interval = interval
+        self.samples = []
+        self._prev_cpu_usec = None
+        self._prev_t = None
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        self._thread.join(timeout=5)
+
+    def _run(self):
+        while not self._stop_event.is_set():
+            try:
+                self.samples.append(self._take_sample())
+            except (OSError, ValueError):
+                log.debug("Resource sampling tick failed", exc_info=True)
+
+            self._stop_event.wait(self.interval)
+
+    def _cg(self, filename):
+        return os.path.join(self.cgroup_path, filename)
+
+    def _take_sample(self):
+        now = time.time()
+        cpu_usage = _read_stat_field(self._cg("cpu.stat"), "usage_usec")
+
+        cpu_pct = 0.0
+        if self._prev_cpu_usec is not None and self._prev_t is not None:
+            dt = now - self._prev_t
+            if dt > 0:
+                cpu_pct = (cpu_usage - self._prev_cpu_usec) / (dt * 1e6)
+
+        self._prev_cpu_usec = cpu_usage
+        self._prev_t = now
+
+        return {
+            "t": now,
+            "rss_bytes": _read_int(self._cg("memory.current")),
+            "swap_bytes": _read_int(self._cg("memory.swap.current")),
+            "cpu_usage_usec": cpu_usage,
+            "cpu_user_usec": _read_stat_field(
+                self._cg("cpu.stat"), "user_usec"),
+            "cpu_system_usec": _read_stat_field(
+                self._cg("cpu.stat"), "system_usec"),
+            "cpu_pct": round(cpu_pct, 4),
+            "io_rbytes": _read_io_total(self._cg("io.stat"), "rbytes"),
+            "io_wbytes": _read_io_total(self._cg("io.stat"), "wbytes"),
+            "psi_cpu_total": _read_psi_total(self._cg("cpu.pressure")),
+            "psi_mem_total": _read_psi_total(self._cg("memory.pressure")),
+            "psi_io_total": _read_psi_total(self._cg("io.pressure")),
+            "pids": _read_int(self._cg("pids.current")),
+        }
+
+    def compute_summary(self):
+        if not self.samples:
+            return {}
+
+        rss_values = [s["rss_bytes"] for s in self.samples]
+
+        # try reading it from kernel; if the cgroup was already
+        # killed, fall back to sampled max
+        memory_peak = _read_int(self._cg("memory.peak"))
+        if memory_peak == 0:
+            memory_peak = max(rss_values)
+
+        swap_peak = _read_int(self._cg("memory.swap.peak"))
+        if swap_peak == 0:
+            swap_values = [s["swap_bytes"] for s in self.samples]
+            swap_peak = max(swap_values)
+
+        effective_peak = memory_peak if memory_peak > 0 else max(rss_values)
+
+        sorted_rss = sorted(rss_values)
+        p95_idx = min(int(len(sorted_rss) * 0.95), len(sorted_rss) - 1)
+
+        high_threshold = effective_peak * 0.8
+        high_count = sum(1 for v in rss_values if v > high_threshold)
+
+        first = self.samples[0]
+        last = self.samples[-1]
+
+        cpu_user_delta = last["cpu_user_usec"] - first["cpu_user_usec"]
+        cpu_system_delta = last["cpu_system_usec"] - first["cpu_system_usec"]
+
+        io_read = last["io_rbytes"] - first["io_rbytes"]
+        io_write = last["io_wbytes"] - first["io_wbytes"]
+
+        cpu_pcts = [s["cpu_pct"] for s in self.samples]
+
+        return {
+            "peak_rss_gb": effective_peak / GiB,
+            "peak_sampled_rss_gb": max(rss_values) / GiB,
+            "swap_peak_gb": swap_peak / GiB,
+            "mean_rss_gb": (sum(rss_values) / len(rss_values)) / GiB,
+            "p95_rss_gb": sorted_rss[p95_idx] / GiB,
+            "sustained_high_rss_pct": high_count / len(rss_values),
+            "cpu_user_seconds": cpu_user_delta / 1e6,
+            "cpu_system_seconds": cpu_system_delta / 1e6,
+            "cpu_pct_mean": round(sum(cpu_pcts) / len(cpu_pcts), 4),
+            "cpu_pct_max": max(cpu_pcts),
+            "io_read_gb": max(io_read, 0) / GiB,
+            "io_write_gb": max(io_write, 0) / GiB,
+            "sample_count": len(self.samples),
+            "sample_interval_seconds": self.interval,
+        }
+
+
+def write_resource_results(resultdir, sampler):
+    try:
+        summary = sampler.compute_summary()
+        if summary:
+            stats_path = os.path.join(resultdir, "resource_stats.json")
+            with open(stats_path, "w") as f:
+                json.dump(summary, f, indent=4)
+            log.info("Resource stats written to %s", stats_path)
+    except Exception:
+        log.warning("Failed to write resource_stats.json", exc_info=True)
+
+    try:
+        if sampler.samples:
+            samples_path = os.path.join(resultdir, "resource_samples.jsonl")
+            with open(samples_path, "w") as f:
+                for sample in sampler.samples:
+                    f.write(json.dumps(sample) + "\n")
+            log.info("Resource samples (%d) written to %s",
+                     len(sampler.samples), samples_path)
+    except Exception:
+        log.warning("Failed to write resource_samples.jsonl", exc_info=True)

--- a/rpmbuild/mock.cfg.j2
+++ b/rpmbuild/mock.cfg.j2
@@ -20,6 +20,13 @@ config_opts['use_host_resolv'] = False
 {%- if isolation not in ["default", None] %}
 config_opts['isolation'] = '{{ isolation }}'
 {%- endif %}
+{%- if resource_monitoring %}
+# Keep systemd-nspawn containers inside the cgroup we are
+# already running in. Without this, resource sampling done from outside
+# of mock (e.g. via `systemd-run` wrapping the whole `mock` invocation)
+# would miss everything that runs through systemd-nspawn.
+config_opts['nspawn_args'] = config_opts.get('nspawn_args', []) + ['--keep-unit']
+{%- endif %}
 
 {%- for key, value in macros.items() %}
 config_opts['macros']['{{ key }}'] = '{{ value }}'


### PR DESCRIPTION
tldr; Do not merge.... since there was interest for collecting more data from builds, here's my experiment that I had planned to bring some day. The current system_monitor plugin in mock does not bring enough data, let's compare it with my solution here and potentionally discuss how to backport this to mock (I want initial discussion here to filter first potential bad decisions/ideas early)

this is experimental opt-in feature for sampling resource usage (memory, swap, CPU, i/o, PSI pressure, procces count) every N seconds, then alongside posting aggregate.

The motivation is to eventually feed this data to rpmeta to predict potentional bottleneck (whether build needs more CPU; i/o, ... and to what degree).

mock currently has system_monitor plugin, however that adds little (if any) benefitial value for rpmeta, as it only monitors peak ram, swap, and heaviest process. No CPU, I/O, network, ... to identify what is bottleneck (and for how long) we need periodic sampling (speaking of https://github.com/rpm-software-management/mock/pull/1748)

My idea on how to collect the data here is to wrap mock process itself with systemd-run to one named unit: `systemd-run --unit=XXX <opts>`, then sample the resulting cgroups. This catches every subprocesses with it.
One gotcha though: with isolation=nspawn, it escapes into its own cgroup instead, this is resolved via `--keep-unit`

I would like to hear you ideas on this approach, and whether you are fine with me trying to backport it to mock itself.
Also what you think of a strategy how to backport this: In mock it can't be wrapped with systemd-run though, instead it creates its own group on startup, move mock PID to it and use the ---keep-unit trick. It would also hook into the same lifecycle of hooks (logged then to state.log). This gets bootstrap, resolving deps, actual build and %check (with ability to tell when was which part I assume?). This would replace system_monitor current mechanism (or rather extend it to more hooks), which flaw is that it only catches one nspawn invocation - missing the whole dependency install, srpm rebuild for dynamic buildreqs and separate %check.

EDIT: this idea does not collect these yet, but I'd like to collect IOPS (rios/wios), disk space consumed (and potentionally network I/O during dependency resolution). This could be useful as well