### PR TITLE
backend: add BuildTagCombinationLimit for multi-tag worker limits

### DIFF
--- a/backend/conf/copr-be.conf.example
+++ b/backend/conf/copr-be.conf.example
@@ -55,6 +55,10 @@ sleeptime=30
 # Maximum number of concurrently running tasks per a build tag.
 #builds_max_workers_tag=Power9=5,Power8=10
 
+# Maximum number of concurrently running tasks per a combination of tags.
+# Use '+' to join tags in a combination.
+#builds_max_workers_tag_combination=ppc64le+on_demand_powerful=5
+
 # Maximum number of concurrent background processes spawned for handling
 # actions.
 #actions_max_workers=10

--- a/backend/copr_backend/daemons/build_dispatcher.py
+++ b/backend/copr_backend/daemons/build_dispatcher.py
@@ -8,6 +8,7 @@ from copr_backend.rpm_builds import (
     ArchitectureWorkerLimit,
     ArchitectureUserWorkerLimit,
     BuildTagLimit,
+    BuildTagCombinationLimit,
     UserSSHLimit,
     BlockedOwnersLimit,
     RPMBuildWorkerManager,
@@ -86,7 +87,7 @@ class BuildDispatcher(BackendDispatcher):
         super().__init__(backend_opts)
         self.max_workers = backend_opts.builds_max_workers
 
-        for tag_type in ["arch", "tag", "arch_per_owner"]:
+        for tag_type in ["arch", "tag", "arch_per_owner", "tag_combination"]:
             match tag_type:
                 case "arch":
                     lclass = ArchitectureWorkerLimit
@@ -94,9 +95,14 @@ class BuildDispatcher(BackendDispatcher):
                     lclass = BuildTagLimit
                 case "arch_per_owner":
                     lclass = ArchitectureUserWorkerLimit
+                case "tag_combination":
+                    lclass = BuildTagCombinationLimit
             for tag, limit in backend_opts.builds_limits[tag_type].items():
                 self.log.info("setting %s(%s) limit to %s", tag_type, tag, limit)
-                self.limits.append(lclass(tag, limit))
+                if lclass is BuildTagCombinationLimit:
+                    self.limits.append(lclass(tag.split("+"), limit))
+                else:
+                    self.limits.append(lclass(tag, limit))
 
         for limit_type in ['sandbox', 'owner']:
             max_builders = backend_opts.builds_limits[limit_type]

--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -216,9 +216,9 @@ def _get_limits_conf(parser):
             "option.  Please use format: "
             "builds_max_workers_{0} = {1}1=COUNT,{1}2=COUNT")
     err2 = ("Duplicate left value '{}' in 'builds_max_workers_{}' configuration")
-    limits = {"arch": {}, "tag": {}, "arch_per_owner": {}}
+    limits = {"arch": {}, "tag": {}, "arch_per_owner": {}, "tag_combination": {}}
 
-    for config_type in ["arch", "tag", "arch_per_owner"]:
+    for config_type in ["arch", "tag", "arch_per_owner", "tag_combination"]:
         option = "builds_max_workers_{}".format(config_type)
         raw = _get_conf(parser, "backend", option, None)
         if raw:

--- a/backend/copr_backend/helpers.py
+++ b/backend/copr_backend/helpers.py
@@ -228,7 +228,7 @@ def _get_limits_conf(parser):
                     key, count = limit_spec.split("=")
                     key = key.strip()
                     count = int(count.strip())
-                    if not key or not count:
+                    if not key:
                         raise CoprBackendError("Empty '{}' spec".format(option))
                     if key in limits[config_type]:
                         raise CoprBackendError(err2.format(key, config_type))

--- a/backend/copr_backend/rpm_builds.py
+++ b/backend/copr_backend/rpm_builds.py
@@ -196,6 +196,19 @@ class BuildTagLimit(PredicateWorkerLimit):
         super().__init__(predicate, limit, name="tag_{}".format(tag))
 
 
+class BuildTagCombinationLimit(PredicateWorkerLimit):
+    """
+    Limit the amount of concurrently running builds that match all tags
+    in the given set simultaneously.
+    """
+    def __init__(self, tagset, limit):
+        self._tagset = frozenset(tagset)
+        def predicate(x):
+            return self._tagset.issubset(x.tags)
+        super().__init__(predicate, limit,
+                         name="tag_combination_{}".format("+".join(sorted(tagset))))
+
+
 class RPMBuildWorkerManager(WorkerManager):
     """
     Manager taking care of background build workers.

--- a/backend/tests/test_config_reader.py
+++ b/backend/tests/test_config_reader.py
@@ -39,6 +39,7 @@ class TestBackendConfigReader:
         assert opts.destdir == "/tmp"
         assert opts.builds_limits == {'arch': {}, 'tag': {}, 'owner': 20,
                                       'sandbox': 10, 'arch_per_owner': {},
+                                      'tag_combination': {},
                                       'userssh': 2, 'blocked_owners': []}
 
     def test_correct_build_limits(self):
@@ -67,6 +68,7 @@ class TestBackendConfigReader:
                 'ppc64le': 11,
                 's390x': 5,
             },
+            'tag_combination': {},
             'userssh': 7,
             'blocked_owners': [],
         }

--- a/backend/tests/test_worker_limits.py
+++ b/backend/tests/test_worker_limits.py
@@ -14,6 +14,7 @@ from copr_backend.rpm_builds import (
     ArchitectureWorkerLimit,
     ArchitectureUserWorkerLimit,
     BuildTagLimit,
+    BuildTagCombinationLimit,
     BuildQueueTask,
 )
 
@@ -46,6 +47,20 @@ TASKS = [{
     "chroot": "fedora-31-aarch64",
     "project_owner": "bedrich",
     "sandbox": "sb2",
+}, {
+    "build_id": 5,
+    "task_id": "5-fedora-rawhide-ppc64le",
+    "chroot": "fedora-rawhide-ppc64le",
+    "project_owner": "bedrich",
+    "sandbox": "sb3",
+    "tags": ["ppc64le", "on_demand_powerful"],
+}, {
+    "build_id": 6,
+    "task_id": "6-fedora-rawhide-ppc64le",
+    "chroot": "fedora-rawhide-ppc64le",
+    "project_owner": "bedrich",
+    "sandbox": "sb3",
+    "tags": ["ppc64le"],
 }]
 
 class _QT(BackendQueueTask):
@@ -135,16 +150,52 @@ def test_worker_limit_info():
     assert ["limit info: " + limit.info() for limit in limits] == [
         "limit info: Unnamed 'PredicateWorkerLimit' limit, matching: w:7, "
         'w:7-fedora-rawhide-x86_64, w:7-fedora-32-x86_64, w:7-fedora-31-x86_64, '
-        'w:7-fedora-31-aarch64',
+        'w:7-fedora-31-aarch64, w:5-fedora-rawhide-ppc64le, w:6-fedora-rawhide-ppc64le',
         "limit info: 'allmatch', matching: w:7, w:7-fedora-rawhide-x86_64, "
-        'w:7-fedora-32-x86_64, w:7-fedora-31-x86_64, w:7-fedora-31-aarch64',
-        "limit info: Unnamed 'HashWorkerLimit' limit, counter: cecil=2, bedrich=3",
-        "limit info: 'sandbox', counter: sb1=1, sb2=3",
+        'w:7-fedora-32-x86_64, w:7-fedora-31-x86_64, w:7-fedora-31-aarch64, '
+        'w:5-fedora-rawhide-ppc64le, w:6-fedora-rawhide-ppc64le',
+        "limit info: Unnamed 'HashWorkerLimit' limit, counter: cecil=2, bedrich=5",
+        "limit info: 'sandbox', counter: sb1=1, sb2=3, sb3=2",
         "limit info: 'arch_x86_64', matching: w:7-fedora-rawhide-x86_64, w:7-fedora-32-x86_64, w:7-fedora-31-x86_64",
         "limit info: 'arch_aarch64', matching: w:7-fedora-31-aarch64",
         "limit info: 'arch_aarch64_owner', counter: aarch64_bedrich=1",
         "limit info: 'tag_special_requirement', matching: w:7-fedora-31-x86_64",
     ]
+
+def test_build_tag_combination_limit():
+    tagset = ["ppc64le", "on_demand_powerful"]
+    wl = BuildTagCombinationLimit(tagset, 2)
+    tasks = [BuildQueueTask(t) for t in TASKS]
+    # task[5] has both tags, task[6] has only ppc64le
+    both_tags = tasks[5]
+    one_tag = tasks[6]
+    no_tags = tasks[1]
+
+    assert wl.check(both_tags)
+    assert wl.check(one_tag)
+    assert wl.check(no_tags)
+
+    wl.worker_added("w1", both_tags)
+    assert wl.check(both_tags)
+    # one_tag doesn't match the combination, still allowed
+    assert wl.check(one_tag)
+
+    wl.worker_added("w2", both_tags)
+    # now we hit the limit for tasks matching both tags
+    assert not wl.check(both_tags)
+    # one_tag still doesn't match the combination
+    assert wl.check(one_tag)
+    assert wl.check(no_tags)
+
+    wl.clear()
+    assert wl.check(both_tags)
+
+
+def test_build_tag_combination_limit_info():
+    tagset = ["on_demand_powerful", "ppc64le"]
+    wl = BuildTagCombinationLimit(tagset, 3)
+    assert wl.info() == "'tag_combination_on_demand_powerful+ppc64le'"
+
 
 def test_string_counter():
     counter = StringCounter()


### PR DESCRIPTION
The existing BuildTagLimit only matches a single tag at a time, which doesn't allow limiting builds that carry a specific combination of tags (e.g. ppc64le + on_demand_powerful).  Add a new BuildTagCombinationLimit that checks whether all tags in a given set are present on a task, with the config option
builds_max_workers_tag_combination using '+' to join tag names.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>