### PR TITLE
rpm upload: add opt-in SHA256 checksum verification

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-rpm-upload.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-rpm-upload.sh
@@ -79,6 +79,18 @@ rlJournalStart
             --enablerepo=\"copr:${FRONTEND_PUBLIC_HOST}:$(repo_owner):${PROJECTNAME}\" \
             $PACKAGE"
         rlAssertRpm "$PACKAGE"
+
+        # SHA256 checksum verification -- correct checksum should succeed
+        rlRun "CHECKSUM=\$(sha256sum $RPM_PATH | cut -d' ' -f1)"
+        rlRun -s "copr-cli uploadrpm --nowait --chroot $CHROOT \
+            --sha256 $CHECKSUM $PROJECT $RPM_PATH"
+        rlRun "parse_build_id"
+        rlRun "copr watch-build $BUILD_ID"
+
+        # SHA256 checksum verification -- wrong checksum should be rejected
+        rlRun "copr-cli uploadrpm --chroot $CHROOT \
+            --sha256 0000000000000000000000000000000000000000000000000000000000000000 \
+            $PROJECT $RPM_PATH" 1 "Upload with wrong SHA256 should fail"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -474,7 +474,8 @@ class Commands(object):
             build = self.client.build_proxy.create_from_rpm_upload(
                 ownername=username, projectname=projectname,
                 project_dirname=project_dirname, buildopts=buildopts,
-                path=args.rpm)
+                path=args.rpm,
+                sha256=getattr(args, "sha256", None))
         finally:
             if progress_callback:
                 progress_callback.finish()
@@ -1742,6 +1743,9 @@ def setup_parser():
              "skipping the SRPM build phase entirely")
     parser_upload_rpm.add_argument(
         "rpm", help="Local path to the already-built .rpm file to publish")
+    parser_upload_rpm.add_argument(
+        "--sha256", help="Expected SHA256 hex digest of the uploaded file; "
+        "the server rejects the build on mismatch")
     parser_upload_rpm.set_defaults(func="action_upload_rpm")
 
     # create the parser for the "buildpypi" command

--- a/frontend/coprs_frontend/coprs/forms.py
+++ b/frontend/coprs_frontend/coprs/forms.py
@@ -1502,6 +1502,7 @@ class BuildFormRpmUploadFactory:
         form.pkgs = MultipleFileField('rpms', validators=[
             FileRequired(),
             RpmValidator()])
+        form.sha256 = wtforms.StringField('sha256')
         return form
 
 

--- a/frontend/coprs_frontend/coprs/logic/builds_logic.py
+++ b/frontend/coprs_frontend/coprs/logic/builds_logic.py
@@ -1,3 +1,4 @@
+import hashlib
 import tempfile
 import shutil
 import json
@@ -51,6 +52,17 @@ log = app.logger
 PROCESSING_STATES = [StatusEnum(s) for s in [
     "running", "pending", "starting", "importing", "waiting",
 ]]
+
+
+def sha256_of_file(path):
+    """
+    Return sha256sum string for given filename path.
+    """
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 class BuildsLogic(object):
@@ -737,13 +749,14 @@ class BuildsLogic(object):
         return build
 
     @classmethod
-    def _save_uploaded_rpms(cls, form_files):
+    def _save_uploaded_rpms(cls, form_files, expected_sha256=None):
         """
         Save each uploaded file into a fresh STORAGE_DIR tmp directory.
 
         :return: (tmp_name, filenames)
         :raises BadRequest: if there isn't exactly one uploaded file, or if
-            its filename is invalid / not a ".rpm"
+            its filename is invalid / not a ".rpm", or if expected_sha256
+            doesn't match
         :raises InsufficientStorage
         """
         if len(form_files) != 1:
@@ -768,15 +781,20 @@ class BuildsLogic(object):
             tmp_name = os.path.basename(tmp)
             filenames = []
             for form_file, filename in zip(form_files, sanitized_names):
-                save_form_file_field_to(form_file, os.path.join(tmp, filename))
+                file_path = os.path.join(tmp, filename)
+                save_form_file_field_to(form_file, file_path)
+                if expected_sha256:
+                    actual = sha256_of_file(file_path)
+                    if expected_sha256.lower() != actual.lower():
+                        raise BadRequest(
+                            f"SHA256 mismatch for '{filename}': "
+                            f"expected {expected_sha256}, got {actual}")
                 filenames.append(filename)
             return tmp_name, filenames
-        except OSError as error:
+        except (OSError, BadRequest):
             if tmp:
                 shutil.rmtree(tmp)
-            raise InsufficientStorage(
-                f"Can not create storage directory for uploaded file(s): {error}"
-            ) from error
+            raise
 
     @classmethod
     def _find_or_create_rpm_upload_package(cls, user, copr, pkg_name, source_json):
@@ -796,11 +814,13 @@ class BuildsLogic(object):
             package = PackagesLogic.get(copr.id, pkg_name).first()
         return package
 
+    # pylint: disable=too-many-arguments
     @classmethod
     def create_new_from_rpm_upload(cls, user, copr, chroot_names, form_files, *,
                                    copr_dirname=None, background=False,
                                    timeout=None, after_build_id=None,
-                                   with_build_id=None):
+                                   with_build_id=None,
+                                   expected_sha256=None):
         """
         Create a build that publishes built RPMs directly for one or more
         chroots, skipping the SRPM build and dist-git import phases
@@ -817,7 +837,7 @@ class BuildsLogic(object):
         users_logic.UsersLogic.raise_if_cant_build_in_copr(
             user, copr, "You don't have permissions to build in this copr.")
 
-        tmp_name, filenames = cls._save_uploaded_rpms(form_files)
+        tmp_name, filenames = cls._save_uploaded_rpms(form_files, expected_sha256)
 
         try:
             pkg_name = helpers.parse_package_name(filenames[0])

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/apiv3_builds.py
@@ -353,6 +353,7 @@ class CreateFromRpmUpload(Resource):
             timeout=form.timeout.data,
             after_build_id=form.after_build_id.data,
             with_build_id=form.with_build_id.data,
+            expected_sha256=form.sha256.data or None,
         )
         db.session.commit()
         return to_dict(build)

--- a/frontend/coprs_frontend/coprs/views/apiv3_ns/schema/schemas.py
+++ b/frontend/coprs_frontend/coprs/views/apiv3_ns/schema/schemas.py
@@ -781,6 +781,10 @@ class CreateBuildRpmUpload(_BuildDataCommon, _BuildOptionsBase, InputSchema):
         description="application/x-rpm files to publish directly, "
                     "skipping the SRPM build phase entirely",
     )
+    sha256: String = String(
+        description="Expected SHA256 hex digest of the uploaded file; "
+                    "the build is rejected on mismatch",
+    )
 
 
 @dataclass

--- a/frontend/coprs_frontend/tests/test_apiv3/test_builds.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_builds.py
@@ -359,6 +359,39 @@ class TestAPIv3BuildsRpmUpload(CoprsTestCase):
 
     @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs",
                              "f_mock_chroots", "f_db")
+    def test_rpm_upload_sha256_match(self):
+        user = self.models.User.query.filter_by(username="user2").first()
+        content = {
+            "ownername": "user2",
+            "projectname": "foocopr",
+            "chroots": "fedora-17-x86_64",
+            "pkgs": _fake_rpm_file("hello-2.8-1.fc43.x86_64.rpm"),
+            "sha256": "dae37be1717e714967b78e21ea9fdf00928a7652687d462f3ad631cde43d1a3d",
+        }
+        response = self.post_api3_with_auth_multipart(
+            "/api_3/build/create/rpm-upload", content, user)
+        assert response.status_code == 200
+        assert self.models.Build.query.first() is not None
+
+    @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs",
+                             "f_mock_chroots", "f_db")
+    def test_rpm_upload_sha256_mismatch(self):
+        user = self.models.User.query.filter_by(username="user2").first()
+        content = {
+            "ownername": "user2",
+            "projectname": "foocopr",
+            "chroots": "fedora-17-x86_64",
+            "pkgs": _fake_rpm_file("hello-2.8-1.fc43.x86_64.rpm"),
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        }
+        response = self.post_api3_with_auth_multipart(
+            "/api_3/build/create/rpm-upload", content, user)
+        assert response.status_code == 400
+        assert "SHA256 mismatch" in response.json["error"]
+        assert self.models.Build.query.first() is None
+
+    @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs",
+                             "f_mock_chroots", "f_db")
     def test_rpm_upload_disabled_feature(self):
         # the route is always registered (so a disabled feature gives a
         # clear error instead of a generic 404), but hidden from swagger

--- a/python/copr/test/client_v3/test_builds.py
+++ b/python/copr/test/client_v3/test_builds.py
@@ -54,4 +54,5 @@ def test_build_rpm_upload(send):
         assert args['endpoint'] == '/build/create/rpm-upload'
         assert args['data'] == {
             'ownername': 'praiskup', 'projectname': 'ping',
-            'project_dirname': None, 'chroots': ['fedora-40-x86_64']}
+            'project_dirname': None, 'chroots': ['fedora-40-x86_64'],
+            'sha256': None}

--- a/python/copr/v3/proxies/build.py
+++ b/python/copr/v3/proxies/build.py
@@ -150,7 +150,8 @@ class BuildProxy(BaseProxy):
         return self._create(endpoint, data, files=files, buildopts=buildopts)
 
     def create_from_rpm_upload(self, ownername, projectname, path, *,
-                               buildopts=None, project_dirname=None):
+                               buildopts=None, project_dirname=None,
+                               sha256=None):
         """
         Publish an already-built local RPM file directly, skipping the SRPM
         build and dist-git import phases entirely.
@@ -160,6 +161,7 @@ class BuildProxy(BaseProxy):
         :param str path: local path to the already-built .rpm file
         :param buildopts: http://python-copr.readthedocs.io/en/latest/client_v3/build_options.html
         :param str project_dirname:
+        :param str sha256: expected SHA256 hex digest of the uploaded file
         :return: Munch
         """
         endpoint = "/build/create/rpm-upload"
@@ -172,6 +174,7 @@ class BuildProxy(BaseProxy):
             "ownername": ownername,
             "projectname": projectname,
             "project_dirname": project_dirname,
+            "sha256": sha256,
         }
         files = {
             "pkgs": (os.path.basename(f.name), f, "application/x-rpm"),


### PR DESCRIPTION
The client can now send an expected SHA256 hex digest alongside the uploaded RPM file.  When provided, the server computes the checksum after saving and rejects the build with a clear error on mismatch.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>