### PR TITLE
frontend: bind to LDAP via Kerberos keytab (SASL/GSSAPI)

### DIFF
--- a/frontend/copr-frontend.spec
+++ b/frontend/copr-frontend.spec
@@ -109,6 +109,7 @@ BuildRequires: python3dist(sphinxcontrib-httpdomain)
 BuildRequires: python3dist(whoosh)
 BuildRequires: python3dist(wtforms) >= 2.2.1
 BuildRequires: python3dist(python-ldap)
+BuildRequires: python3dist(gssapi)
 BuildRequires: python3dist(pyyaml)
 BuildRequires: python3dist(backoff) >= 1.9.0
 BuildRequires: python3dist(pygal)
@@ -164,6 +165,7 @@ Requires: python3dist(templated-dictionary)
 Requires: python3dist(wtforms) >= 2.2.1
 Requires: python3dist(pyzmq)
 Requires: python3dist(python-ldap)
+Requires: python3dist(gssapi)
 Requires: python3dist(backoff) >= 1.9.0
 Requires: python3dist(pygal)
 Requires: python3dist(xstatic-bootstrap-scss)

--- a/frontend/coprs_frontend/coprs/auth.py
+++ b/frontend/coprs_frontend/coprs/auth.py
@@ -2,9 +2,12 @@
 Authentication-related code for communication with FAS, Kerberos, LDAP, etc.
 """
 
+import os
 import time
 import flask
+import gssapi
 import ldap
+import ldap.sasl
 from coprs import app
 from coprs.exceptions import CoprHttpException, AccessRestricted
 from coprs.logic.users_logic import UsersLogic
@@ -267,11 +270,40 @@ class LDAP:
         """
         try:
             connect = ldap.initialize(self.url)
+            self._bind(connect)
             return connect.search_s(ou, ldap.SCOPE_ONELEVEL,
                                     ffilter, attrs)
         except ldap.SERVER_DOWN as ex:
             msg = ex.args[0]["desc"]
             raise CoprHttpException(msg) from ex
+
+    @staticmethod
+    def _bind(connect):
+        """
+        Bind to the LDAP server using a Kerberos ticket obtained from a
+        keytab (SASL/GSSAPI), if KRB5_KEYTAB is configured. Otherwise the
+        connection stays anonymous.
+        """
+        keytab = app.config.get("KRB5_KEYTAB")
+        if not keytab:
+            return
+
+        principal = app.config.get("KRB5_PRINCIPAL")
+        name = None
+        if principal:
+            gssapi.Name(principal, gssapi.NameType.kerberos_principal)
+
+        # Acquire a ticket from the keytab into a process-local memory
+        # ccache, and point Kerberos to it so that the SASL/GSSAPI bind
+        # below picks it up.
+        ccache = f"MEMORY:copr-ldap-{os.getpid()}"
+        gssapi.Credentials(
+            name=name, store={"client_keytab": keytab, "ccache": ccache},
+            usage="initiate")
+        os.environ["KRB5CCNAME"] = ccache
+
+        connect.sasl_interactive_bind_s("", ldap.sasl.gssapi())
+        app.logger.info("LDAP Authenticated over GSSAPI")
 
     def query_one(self, attrs, filters=None):
         """

--- a/frontend/coprs_frontend/coprs/auth.py
+++ b/frontend/coprs_frontend/coprs/auth.py
@@ -234,8 +234,26 @@ class LDAPGroups:
         groups = []
         for group in ldap_client.get_user_groups(username):
             group = group.decode("utf-8")
-            attrs = dict([tuple(x.split("=")) for x in group.split(",")])
-            groups.append(attrs["cn"])
+            # Various output types, filter those that we care about.
+            # cn=somenamegroup,cn=groups,cn=accounts,dc=domain,dc=example,dc=com
+            # ipaUniqueID=<UUID>,cn=hbac,dc=domain,dc=example,dc=com
+            # cn=somerole,cn=roles,cn=accounts,dc=domain,dc=example,dc=com
+            group_dn = ldap.dn.str2dn(group)
+            # Converts to:
+            # [[('cn', 'another-group-2', 1)],
+            # [('cn', 'groups', 1)],
+            # [('ou', 'foo', 1)],
+            # [('ou', 'bar', 1)],
+            # [('dc', 'company', 1)],
+            # [('dc', 'com', 1)]]
+            app.logger.debug("Considering memberOf: '%s'", group)
+            specifier, group_name, _ = group_dn[0][0]
+            if specifier != 'cn':
+                continue
+            specifier, group_category, _ = group_dn[1][0]
+            if specifier != 'cn' or group_category != "groups":
+                continue
+            groups.append(group_name)
         return groups
 
 
@@ -268,6 +286,7 @@ class LDAP:
         """
         Send a single request to a LDAP server
         """
+        app.logger.debug("LDAP query: attrs=%s ffilter=%s", attrs, ffilter)
         try:
             connect = ldap.initialize(self.url)
             self._bind(connect)

--- a/frontend/coprs_frontend/coprs/config.py
+++ b/frontend/coprs_frontend/coprs/config.py
@@ -168,6 +168,14 @@ class Config(object):
     # e.g. ou=users,dc=company,dc=com
     LDAP_SEARCH_STRING = None
 
+    # Path to a Kerberos keytab used for binding to the LDAP server via
+    # SASL/GSSAPI. When unset, LDAP is queried anonymously (no bind).
+    KRB5_KEYTAB = None
+
+    # Kerberos principal to use with KRB5_KEYTAB, e.g. copr/ldap@EXAMPLE.COM
+    # When unset, the keytab's default principal is used.
+    KRB5_PRINCIPAL = None
+
     # If a project has more package than this, normal users can't fork it.
     # Only admins can.
     FORK_PACKAGES_LIMIT = 1000

--- a/frontend/coprs_frontend/tests/test_auth.py
+++ b/frontend/coprs_frontend/tests/test_auth.py
@@ -23,10 +23,12 @@ class TestGroupAuth(CoprsTestCase):
         # Some internal values were redacted but otherwise it's a copy-pasted
         # response
         get_user_groups.return_value = [
-            b'cn=group1,ou=foo,dc=company,dc=com',
-            b'cn=group2,ou=bar,dc=company,dc=com',
-            b'cn=another-group,ou=baz,ou=qux,dc=company,dc=com',
-            b'cn=another-group-2,ou=foo,ou=bar,dc=company,dc=com'
+            b'cn=group1,cn=groups,ou=foo,dc=company,dc=com',
+            b'cn=group2,cn=groups,ou=bar,dc=company,dc=com',
+            b'cn=another-group,cn=groups,ou=baz,ou=qux,dc=company,dc=com',
+            b'ipaUniqueID=ba3ba98a-a12d-11f1-af9d-f691a8b0dc3a,cn=hbac,dc=domain,dc=example,dc=com',
+            b'cn=somerole,cn=roles,cn=accounts,dc=domain,dc=example,dc=com',
+            b'cn=another-group-2,cn=groups,ou=foo,ou=bar,dc=company,dc=com'
         ]
         user = mock.MagicMock()
         GroupAuth.update_user_groups(user, LDAPGroups.group_names(user.username))


### PR DESCRIPTION
Previously the LDAP client searched anonymously, with no bind at all. Add KRB5_KEYTAB/KRB5_PRINCIPAL config options; when KRB5_KEYTAB is set, acquire a ticket from the keytab and perform a SASL/GSSAPI bind before querying the LDAP server.

Assisted-by: Claude <noreply@anthropic.com>
Fixes: #4445