### PR TITLE
openshift: add probes for all services

### DIFF
--- a/openshift/helm/templates/backend.yaml
+++ b/openshift/helm/templates/backend.yaml
@@ -131,6 +131,11 @@ spec:
 {{ toYaml .Values.resources.backend.log | indent 12 }}
           command: ["/usr/bin/tini", "--"]
           args: ["/usr/bin/copr_run_logger.py"]
+          livenessProbe:
+            exec:
+              command: ["pgrep", "-f", "copr_run_logger"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
           volumeMounts:
             - name: config
               mountPath: /etc/copr
@@ -151,6 +156,11 @@ spec:
               mountPath: /var/lock/copr-backend
           command: ["/usr/bin/tini", "--"]
           args: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher-backend", "actions"]
+          livenessProbe:
+            exec:
+              command: ["pgrep", "-f", "copr-run-dispatcher"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
 
         - name: builds
           image: {{ .Values.copr_backend_image | quote }}
@@ -171,6 +181,11 @@ spec:
               value: /backend-home
           command: ["/usr/bin/tini", "--"]
           args: ["/run-backend", "--sign-host", "copr-keygen", "/usr/bin/copr-run-dispatcher-backend", "builds"]
+          livenessProbe:
+            exec:
+              command: ["pgrep", "-f", "copr-run-dispatcher"]
+            initialDelaySeconds: 10
+            periodSeconds: 30
 
       # start these containers on the same node with copr-backend-httpd!
       affinity:
@@ -256,6 +271,20 @@ spec:
           resources:
 {{ toYaml .Values.resources.backend.httpd | indent 12 }}
           command: ["nginx", "-g", "daemon off;"]
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: results
               mountPath: /opt/app-root/src

--- a/openshift/helm/templates/distgit.yaml
+++ b/openshift/helm/templates/distgit.yaml
@@ -117,6 +117,18 @@ spec:
           imagePullPolicy: IfNotPresent
           resources:
 {{ toYaml .Values.resources.distgit.httpd | indent 12 }}
+          readinessProbe:
+            tcpSocket:
+              port: 5001
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: 5001
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: distgit-copr-config
               mountPath: /etc/copr

--- a/openshift/helm/templates/frontend.yaml
+++ b/openshift/helm/templates/frontend.yaml
@@ -57,6 +57,26 @@ spec:
               protocol: TCP
           resources:
 {{ toYaml .Values.resources.frontend.app | indent 12 }}
+          startupProbe:
+            httpGet:
+              path: /
+              port: 5000
+            failureThreshold: 30
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 5000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 5000
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: copr-frontend-config
               mountPath: /etc/copr

--- a/openshift/helm/templates/keygen.yaml
+++ b/openshift/helm/templates/keygen.yaml
@@ -81,6 +81,16 @@ spec:
           ports:
             - containerPort: 5167
               protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 5167
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5167
+            initialDelaySeconds: 15
+            periodSeconds: 30
 
         - name: httpd
           image: {{ .Values.copr_keygen_image | quote }}
@@ -96,6 +106,17 @@ spec:
           ports:
             - containerPort: 5003
               protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 5003
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5003
+            initialDelaySeconds: 15
+            periodSeconds: 30
 
       volumes:
         - name: storage

--- a/openshift/helm/templates/postgres.yaml
+++ b/openshift/helm/templates/postgres.yaml
@@ -73,6 +73,12 @@ spec:
                   name: postgresql
           image: {{ .Values.postgresql_image | quote }}
           imagePullPolicy: IfNotPresent
+          startupProbe:
+            exec:
+              command:
+                - /usr/libexec/check-container
+            failureThreshold: 30
+            periodSeconds: 2
           livenessProbe:
             exec:
               command:

--- a/openshift/helm/templates/redis.yaml
+++ b/openshift/helm/templates/redis.yaml
@@ -45,11 +45,25 @@ spec:
       containers:
         - image: {{ .Values.redis_image | quote }}
           imagePullPolicy: IfNotPresent
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - test "$(redis-cli -h 127.0.0.1 ping)" == "PONG"
+            failureThreshold: 30
+            periodSeconds: 5
           livenessProbe:
-            initialDelaySeconds: 30
-            tcpSocket:
-              port: 6379
-            timeoutSeconds: 1
+            exec:
+              command:
+                - /bin/sh
+                - -i
+                - -c
+                - test "$(redis-cli -h 127.0.0.1 ping)" == "PONG"
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
           name: redis
           ports:
             - containerPort: 6379

--- a/openshift/helm/templates/resalloc.yaml
+++ b/openshift/helm/templates/resalloc.yaml
@@ -97,6 +97,17 @@ spec:
               value: /resalloc-home
 
           command: ["/usr/bin/resalloc-server"]
+          readinessProbe:
+            tcpSocket:
+              port: 49100
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 49100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
 
       volumes:
         - name: resalloc-config


### PR DESCRIPTION
add probes for all services since app-sre CI requires it for adding saas.yaml file (and thus creating copr instance)

some of the probes is just simple pgrep -f <copr process that should be running> but that just check if process exists, not if it is healthy. For purposes to satisfy CI, I am making this simple, and creating follow-up (#4454) issue to implement proper HTTP /healthz endpoints for this (that will be simple anyway since the endpoints are easy to implement, but it would require release...)