### PR TITLE
backend: don't upload zero bytes RPMs to Pulp

### DIFF
--- a/backend/run/copr-change-storage
+++ b/backend/run/copr-change-storage
@@ -178,6 +178,12 @@ def change_storage_for_project(project, dst, config):
                 to_upload = []
                 rpms = storage.find_build_results(resultdir)
                 for rpm in rpms:
+                    # It should never happen that a RPM package is 0 bytes, but
+                    # unfortunately sometimes it happened. Nobody knows why.
+                    if os.path.getsize(rpm) == 0:
+                        log.error("RPM package has zero bytes: %s", rpm)
+                        continue
+
                     # Was a package with this NEVRA already uploaded?
                     # We cannot simply uploaded.get(rpm) because the keys are
                     # full paths and we need to compare only basenames


### PR DESCRIPTION
Otherwise we get hit with an infinite loop of:

    Pulp: create_content: /api/v3/content/rpm/packages/upload/ /var/lib/copr/public_html/results/@freecad/nightly/fedora-30-aarch64/01121860-freecad/freecad-debuginfo-0.19-pre_18820.aarch64.rpm
    CFailed to create Pulp content for: /var/lib/copr/public_html/results/@freecad/nightly/fedora-30-aarch64/01121860-freecad/freecad-debuginfo-0.19-pre_18820.aarch64.rpm, Bad Request {"file":["The submitted file is empty."]} (attempt #595)