### PR TITLE
backend: resign when signing already signer rpm

### DIFF
--- a/backend/copr_backend/background_worker_build.py
+++ b/backend/copr_backend/background_worker_build.py
@@ -37,7 +37,7 @@ from copr_backend.helpers import (
 )
 from copr_backend.job import BuildJob
 from copr_backend.msgbus import MessageSender
-from copr_backend.sign import sign_rpms_in_dir, get_pubkey
+from copr_backend.sign import resign_rpms_in_dir, sign_rpms_in_dir, get_pubkey
 from copr_backend.sshcmd import SSHConnection, SSHConnectionError
 from copr_backend.vm_alloc import ResallocHostFactory
 from copr_backend.storage import storage_for_job
@@ -717,13 +717,15 @@ class BuildBackgroundWorker(BackendBackgroundWorker):
         self.log.info("Going to sign pkgs from source: %s in chroot: %s",
                       self.job.task_id, self.job.chroot_dir)
 
-        sign_rpms_in_dir(
+        # delsign on unsigned RPMs is a no-op (exit code 0)
+        action = resign_rpms_in_dir if self.job.prebuilt_rpm_urls else sign_rpms_in_dir
+        action(
             self.job.project_owner,
             self.job.project_name,
             os.path.join(self.job.chroot_dir, self.job.target_dir_name),
             self.job.chroot,
             opts=self.opts,
-            log=self.log
+            log=self.log,
         )
 
         self.log.info("Sign done")

--- a/backend/copr_backend/job.py
+++ b/backend/copr_backend/job.py
@@ -68,6 +68,7 @@ class BuildJob(object):
         self.pkg_release = None
 
         self.srpm_url = None
+        self.prebuilt_rpm_urls = None
         self.uses_devel_repo = None
         self.sandbox = None
 

--- a/backend/copr_backend/sign.py
+++ b/backend/copr_backend/sign.py
@@ -221,7 +221,8 @@ def create_user_keys(username, projectname, opts, try_indefinitely=False):
 
 
 def _unsign_one(path):
-    # Requires rpm-sign package
+    # Requires rpm-sign package.
+    # rpm --delsign on an unsigned RPM is a no-op (exit code 0).
     cmd = ["/usr/bin/rpm", "--delsign", path]
     handle = Popen(cmd, stdout=PIPE, stderr=PIPE, encoding="utf-8")
     stdout, stderr = handle.communicate()


### PR DESCRIPTION
this is noop for rpms that are not signed:
rpm --delsign ./path/to/rpm
exit code: 0

Fix #4465