### PR TITLE
backend: support both pulp_hrefs and PRNs

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -202,10 +202,13 @@ class BatchedAddRemoveContent:
                 "remove_content_units": list(rpms_to_remove),
                 "dirs_to_delete": list(dirs_to_delete)}
 
-    def _unique_nevras(self, pulp_hrefs):
+    def _unique_nevras(self, hrefs_or_prns):
         unique = {}
-        for pulp_href in pulp_hrefs:
-            data = self.client.get_by_href(pulp_href).json()
+        for href_or_prn in hrefs_or_prns:
+            if href_or_prn.startswith("prn:"):
+                data = self.client.get_package_by_prn(href_or_prn).json()
+            else:
+                data = self.client.get_by_href(href_or_prn).json()
 
             # We are intentionally leaving out epoch because Pulp cannot handle
             # two different epochs in one repository
@@ -223,7 +226,7 @@ class BatchedAddRemoveContent:
 
             build_id = int(data["pulp_labels"]["build_id"])
             if nevra not in unique or unique[nevra][1] < build_id:
-                unique[nevra] = (pulp_href, build_id)
+                unique[nevra] = (href_or_prn, build_id)
 
         self.log.info("Unique NEVRAs: %s", list(unique.keys()))
         return {x[0] for x in unique.values()}
@@ -441,6 +444,13 @@ class PulpClient:
         url = self.config["base_url"] + href
         self.log.info("Pulp: get_by_href: %s", href)
         return self.send("GET", url)
+
+    def get_package_by_prn(self, prn):
+        """
+        Get a detailed information about a package
+        """
+        pulp_id = prn.rsplit(":", 1)[1]
+        return self.get_by_href(f"/pulp/api/v3/content/rpm/packages/{pulp_id}/")
 
     def create_distribution(self, name, repository, basepath=None):
         """


### PR DESCRIPTION
The `copr-change-storage` script operates over PRNs, so it is currently failing with:

    Pulp: create_content: /api/v3/content/rpm/packages/upload/ /var/lib/copr/public_html/results/@freecad/nightly/fedora-30-x86_64/01465710-freecad/freecad-0.19-pre_21652.x86_64.rpm
    [5/5] Uploaded to Pulp: /var/lib/copr/public_html/results/@freecad/nightly/fedora-30-x86_64/01465710-freecad/freecad-0.19-pre_21652.x86_64.rpm
    Pulp: get_repository: /api/v3/repositories/rpm/rpm/?name=%40freecad%2Fnightly%2Ffedora-30-x86_64&offset=0&limit=1
    Pulp: get_by_href: prn:rpm.package:01a05b15-82cf-75e1-a816-0c216fcf9e31
    Retry request #1 on https://packages.redhat.comprn:rpm.package:01a05b15-82cf-75e1-a816-0c216fcf9e31: Requests error on https://packages.redhat.comprn:rpm.package:01a05b15-82cf-75e1-a816-0c216fcf9e31: Failed to parse: https://packages.redh
    at.comprn:rpm.package:01a05b15-82cf-75e1-a816-0c216fcf9e31
    Retry request #2 on https://packages.redhat.comprn:rpm.package:01a05b15-82cf-75e1-a816-0c216fcf9e31: Requests error on https://packages.redhat.comprn:rpm.package:01a05b15-82cf-75e1-a816-0c216fcf9e31: Failed to parse: https://packages.redh
    at.comprn:rpm.package:01a05b15-82cf-75e1-a816-0c216fcf9e31
    ...

This PR fixes that.