### PR TITLE
Drop support for pyp2rpm

### DIFF
--- a/beaker-tests/Sanity/copr-cli-basic-operations/runtest-pypi.sh
+++ b/beaker-tests/Sanity/copr-cli-basic-operations/runtest-pypi.sh
@@ -41,10 +41,6 @@ rlJournalStart
     rlPhaseStartTest
         rlRun "copr-cli create --chroot $CHROOT $PROJECT"
 
-        # Submit pyp2rpm build directly.  Package is old and not buildable with
-        # pyp2spec (at least the last motionpaint version v1.52).
-        rlRun "copr-cli buildpypi $PROJECT --spec-generator pyp2rpm --template fedora --packagename motionpaint --pythonversions 3"
-
         # Submit pyp2spec build directly, generates python-pyp2spec package
         rlRun "copr-cli buildpypi $PROJECT --packagename $PYPI_PACKAGE --spec-generator pyp2spec"
 
@@ -64,30 +60,27 @@ rlJournalStart
         OUTPUT=output-file.log
         SOURCE_DICT=source-dict.json
 
-        # PyPI package creation, pyp2rpm building itself
-        rlRun "copr-cli add-package-pypi $PROJECT --name $PACKAGE_OVERRIDE --packagename pyp2rpm --spec-generator pyp2rpm --packageversion 1.5 --pythonversions 3"
+        # PyPI package creation, pyp2spec building itself
+        rlRun "copr-cli add-package-pypi $PROJECT --name $PACKAGE_OVERRIDE --packagename pyp2rpm --spec-generator pyp2spec --packageversion 1.0.4"
         rlRun "copr-cli get-package $PROJECT --name $PACKAGE_OVERRIDE > $OUTPUT"
         rlRun "cat $OUTPUT | jq '.source_dict' > $SOURCE_DICT"
         rlAssertEquals "package.name == \"$PACKAGE_OVERRIDE\"" `cat $OUTPUT | jq '.name'` "\"$PACKAGE_OVERRIDE\""
         rlAssertEquals "package.source_type == \"pypi\"" `cat $OUTPUT | jq '.source_type'` '"pypi"'
-        rlRun `cat $SOURCE_DICT | jq '.python_versions == ["3"]'` 0 "package.source_dict.python_versions == [\"3\"]"
         rlAssertEquals "package.source_dict.pypi_package_name == \"pyp2rpm\"" `cat $SOURCE_DICT | jq '.pypi_package_name'` '"pyp2rpm"'
-        rlAssertEquals "package.source_dict.pypi_package_version == \"bar\"" `cat $SOURCE_DICT | jq '.pypi_package_version'` '"1.5"'
-        rlAssertEquals "package.source_dict.spec_generator == \"pyp2rpm\"" `cat $SOURCE_DICT | jq '.spec_generator'` '"pyp2rpm"'
+        rlAssertEquals "package.source_dict.pypi_package_version == \"bar\"" `cat $SOURCE_DICT | jq '.pypi_package_version'` '"1.0.4"'
+        rlAssertEquals "package.source_dict.spec_generator == \"pyp2spec\"" `cat $SOURCE_DICT | jq '.spec_generator'` '"pyp2spec"'
 
         # PyPI package modification.
         # - reset the copr package to a different PyPI project
         # - reset (implicitly) to pyp2spec generator by default https://github.com/fedora-copr/copr/issues/3523
-        rlRun "copr-cli edit-package-pypi $PROJECT --name $PACKAGE_OVERRIDE --packagename motionpaint --packageversion 1.4 --pythonversions 3"
+        rlRun "copr-cli edit-package-pypi $PROJECT --name $PACKAGE_OVERRIDE --packagename pello"
         rlRun "copr-cli get-package $PROJECT --name $PACKAGE_OVERRIDE > $OUTPUT"
-        cat $OUTPUT | jq '.source_dict' > $SOURCE_DICT
+        jq '.source_dict' < "$OUTPUT" > "$SOURCE_DICT"
         rlAssertEquals "package.name == \"$PACKAGE_OVERRIDE\"" `cat $OUTPUT | jq '.name'` "\"$PACKAGE_OVERRIDE\""
         rlAssertEquals "package.source_type == \"pypi\"" `cat $OUTPUT | jq '.source_type'` '"pypi"'
-        rlRun `cat $SOURCE_DICT | jq '.python_versions == ["3"]'` 0 "package.source_dict.python_versions == [\"3\"]"
-        rlAssertEquals "package.source_dict.pypi_package_name == \"motionpaint\"" `cat $SOURCE_DICT | jq '.pypi_package_name'` '"motionpaint"'
-        rlAssertEquals "package.source_dict.pypi_package_version == \"bar\"" `cat $SOURCE_DICT | jq '.pypi_package_version'` '"1.4"'
+        rlAssertEquals "package.source_dict.pypi_package_name == \"pello\"" `cat $SOURCE_DICT | jq '.pypi_package_name'` '"pello"'
         rlAssertEquals "package.source_dict.spec_template == \"\"" `cat $SOURCE_DICT | jq '.spec_template'` '""'
-        rlAssertEquals "package.source_dict.spec_generator == \"pyp2rpm\"" `cat $SOURCE_DICT | jq '.spec_generator'` '"pyp2spec"'
+        rlAssertEquals "package.source_dict.spec_generator == \"pyp2spec\"" `cat $SOURCE_DICT | jq '.spec_generator'` '"pyp2spec"'
 
         # PyPI package templates
         rlRun "copr-cli edit-package-pypi $PROJECT --name $PACKAGE_OVERRIDE --template fedora"
@@ -95,15 +88,15 @@ rlJournalStart
         cat $OUTPUT | jq '.source_dict' > $SOURCE_DICT
         rlAssertEquals "package.source_dict.spec_template == \"fedora\"" `cat $SOURCE_DICT | jq '.spec_template'` '"fedora"'
 
-        # build the package, but first reset back to pyp2rpm (otherwise # motionpaint fails to build)
-        OUTPUT=motionpaint-package.json
-        rlRun "copr-cli edit-package-pypi $PROJECT --name $PACKAGE_OVERRIDE --spec-generator pyp2rpm --packageversion 1.4 --pythonversions 3"
+        # build the package
+        OUTPUT=pello-package.json
+        rlRun "copr-cli edit-package-pypi $PROJECT --name $PACKAGE_OVERRIDE --spec-generator pyp2spec"
         rlRun "copr-cli build-package --name $PACKAGE_OVERRIDE $PROJECT -r $CHROOT"
         rlRun "copr-cli get-package $PROJECT --name $PACKAGE_OVERRIDE > $OUTPUT"
-        rlAssertEquals "check that motionpaint is used" "$(jq '.source_dict.pypi_package_name' < "$OUTPUT")" '"motionpaint"'
+        rlAssertEquals "check that pello is used" "$(jq '.source_dict.pypi_package_name' < "$OUTPUT")" '"pello"'
 
         ## Package listing
-        rlAssertEquals "len(package_list) == 4" `copr-cli list-packages $PROJECT | jq '. | length'` 4
+        rlAssertEquals "len(package_list) == 4" "$(copr-cli list-packages "$PROJECT" | jq '. | length')" 3
 
         # try to build copr-cli from pypi, broken now, uncomment once #3517 is fixed
         #rlRun "copr-cli add-package-pypi $PROJECT --name copr-cli --packagename copr-cli"

--- a/cli/copr_cli/main.py
+++ b/cli/copr_cli/main.py
@@ -1594,12 +1594,12 @@ def setup_parser():
         "--spec-generator",
         dest="spec_generator",
         help="Tool for generating specfile from a PyPI package",
-        choices=["pyp2rpm", "pyp2spec"],
+        choices=["pyp2spec"],
         default="pyp2spec",
     )
 
     parser_pypi_args_optional.add_argument("--template", "-t", dest="spec_template",
-                                         help="Spec template to be used to build srpm with pyp2rpm")
+                                         help="Spec template to be used to build srpm with pyp2spec")
 
     parser_pypi_args_parent = argparse.ArgumentParser(add_help=False, parents=[parser_pypi_args_optional])
     parser_pypi_args_parent.add_argument("--packagename", required=True, metavar="PYPINAME",

--- a/frontend/coprs_frontend/alembic/versions/43f9339a9e9a_switch_packages_to_pyp2spec.py
+++ b/frontend/coprs_frontend/alembic/versions/43f9339a9e9a_switch_packages_to_pyp2spec.py
@@ -1,0 +1,48 @@
+"""
+Switch packages to pyp2spec
+
+Revision ID: 43f9339a9e9a
+Create Date: 2026-09-10 11:11:34.114231
+"""
+# pylint: disable=invalid-name
+
+import json
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '43f9339a9e9a'
+down_revision = 'e31b4af2468c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    session = sa.orm.sessionmaker(bind=op.get_bind())()
+
+    sql = "SELECT id, source_json FROM package WHERE source_type=:source_type"
+    data = {"source_type": 5}
+    rows = session.execute(sa.text(sql), data).mappings()
+    for row in rows:
+        # This should never happen
+        if not row["source_json"]:
+            continue
+
+        source_dict = json.loads(row["source_json"])
+        if source_dict.get("spec_generator") != "pyp2rpm":
+            continue
+
+        source_dict["spec_generator"] = "pyp2spec"
+
+        sql = "UPDATE package SET source_json=:source_json WHERE id=:id"
+        data = {
+            "source_json": json.dumps(source_dict),
+            "id": row["id"],
+        }
+        session.execute(sa.text(sql), data)
+
+
+def downgrade():
+    # No way back
+    return

--- a/frontend/coprs_frontend/coprs/forms.py
+++ b/frontend/coprs_frontend/coprs/forms.py
@@ -1016,12 +1016,20 @@ class PackageFormPyPI(BasePackageForm):
             wtforms.validators.Optional(),
         ])
 
-    spec_generator = wtforms.SelectField(
+    spec_generator = wtforms.HiddenField(
         "Spec generator",
-        choices=[
-            ("pyp2rpm", "pyp2rpm"),
-            ("pyp2spec", "pyp2spec"),
-        ], default="pyp2spec")
+        default="pyp2spec",
+        validators=[
+            wtforms.validators.AnyOf(
+                ["pyp2spec"],
+                message=(
+                    "The only supported spec generator is pyp2spec now. "
+                    "The pyp2rpm is not maintained and therefore was "
+                    "deprecated in Copr as well."
+                )
+            ),
+        ],
+    )
 
     spec_template = wtforms.SelectField(
         "Spec template",

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/_builds_forms.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/_builds_forms.html
@@ -154,8 +154,7 @@
 
     {{ source_description(
          'This method uses '
-         '<a href="https://github.com/fedora-python/pyp2rpm">pyp2rpm</a> '
-         'or <a href="https://github.com/befeleme/pyp2spec">pyp2spec</a> '
+         '<a href="https://github.com/befeleme/pyp2spec">pyp2spec</a> '
          'to create the RPM for you automatically from PyPI - '
          'the Python Package Index. Please provide the package name.'
        )
@@ -164,33 +163,7 @@
     {{ render_field(form.pypi_package_name, placeholder="Package name in the Python Package Index.") }}
     {{ render_field(form.pypi_package_version, placeholder="Optional - Version of the package PyPI") }}
 
-    {{ render_field(
-         form.spec_generator,
-         info="Tool for generating specfile from a PyPI package. The options "
-               "are full-featured <strong>pyp2rpm</strong> with cross "
-               "distribution support, and <strong>pyp2spec</strong> that is "
-               "being actively developed and considered to be the future."
-       )
-    }}
-
-    {# End the previous instructions box #}
-      </div>
-    </div>
-
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
-          {{ counter('instructions') }}. Options specific for pyp2rpm
-        </h3>
-      </div>
-      <div class="panel-body">
-        {{ render_field(
-               form.spec_template,
-               placeholder="Distribution specific spec template",
-               info="Limited to <strong>pyp2rpm</strong> spec generator")
-        }}
-
-        {{ render_pypi_python_versions_field(form.python_versions) }}
+    {{ render_field(form.spec_generator, hidden=True) }}
 
   {{ copr_build_form_end(form, view, copr) }}
 {% endmacro %}

--- a/frontend/coprs_frontend/coprs/templates/coprs/detail/_package_forms.html
+++ b/frontend/coprs_frontend/coprs/templates/coprs/detail/_package_forms.html
@@ -91,32 +91,7 @@
     {{ copr_package_form_begin(form, view, copr, package) }}
     {{ render_field(form.pypi_package_name, placeholder="Package name in the Python Package Index.") }}
 
-    {{ render_field(
-         form.spec_generator,
-         info="Tool for generating specfile from a PyPI package. The options "
-               "are full-featured <strong>pyp2rpm</strong> with cross "
-               "distribution support, and <strong>pyp2spec</strong> that is "
-               "being actively developed and considered to be the future."
-       )
-    }}
-
-    {# End the previous instructions box #}
-      </div>
-    </div>
-
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
-          {{ counter('instructions') }}. Options specific for pyp2rpm
-        </h3>
-      </div>
-      <div class="panel-body">
-        {{ render_field(
-               form.spec_template,
-               placeholder="Distribution specific spec template",
-               info="Limited to <strong>pyp2rpm</strong> spec generator")
-        }}
-        {{ render_pypi_python_versions_field(form.python_versions) }}
+    {{ render_field(form.spec_generator, hidden=True) }}
 
     {{ render_generic_pkg_form(form) }}
     {{ render_anitya_autorebuild(form) }}

--- a/frontend/coprs_frontend/tests/test_anitya.py
+++ b/frontend/coprs_frontend/tests/test_anitya.py
@@ -31,7 +31,7 @@ class TestAnitya(CoprsTestCase):
                 project, "umap-pytorch",
                 options={
                     "webhook_rebuild": True,
-                    "spec_generator": "pyp2rpm",
+                    "spec_generator": "pyp2spec",
                 },
             )
             # This is not going to be rebuilt, the update is 2.1.7rc1
@@ -93,7 +93,7 @@ class TestAnitya(CoprsTestCase):
                     'pypi_package_name': 'umap-pytorch',
                     'pypi_package_version': '0.0.5',
                     'python_versions': ['3'],
-                    'spec_generator': 'pyp2rpm',
+                    'spec_generator': 'pyp2spec',
                     'spec_template': '',
                 }
             elif copr == "user1/bar":
@@ -111,7 +111,7 @@ class TestAnitya(CoprsTestCase):
                     'pypi_package_name': 'umap-pytorch',
                     'pypi_package_version': None,
                     'python_versions': ['3'],
-                    'spec_generator': 'pyp2rpm',
+                    'spec_generator': 'pyp2spec',
                     'spec_template': '',
                 }
             elif copr == "user1/inprogress-match":
@@ -130,7 +130,7 @@ class TestAnitya(CoprsTestCase):
                         'pypi_package_name': 'umap-pytorch',
                         'pypi_package_version': '0.0.5',
                         'python_versions': ['3'],
-                        'spec_generator': 'pyp2rpm',
+                        'spec_generator': 'pyp2spec',
                         'spec_template': '',
                     }
             else:

--- a/frontend/coprs_frontend/tests/test_apiv3/test_builds.py
+++ b/frontend/coprs_frontend/tests/test_apiv3/test_builds.py
@@ -264,6 +264,30 @@ class TestAPIv3Builds(CoprsTestCase):
         build = self.models.Build.query.first()
         assert {chroot.name for chroot in build.chroots} == expected
 
+    @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs",
+                             "f_mock_chroots", "f_db")
+    def test_v3_build_pypi(self):
+        user = self.models.User.query.filter_by(username="user2").first()
+        endpoint = "/api_3/build/create/pypi"
+        data = {
+            "ownername": "user2",
+            "projectname": "foocopr",
+            "pypi_package_name": "pyp2spec",
+            "pypi_package_version": None,
+            "spec_generator": "pyp2spec",
+            "spec_template": "",
+            "python_versions": ["3"],
+        }
+        response = self.post_api3_with_auth(endpoint, data, user)
+        assert response.status_code == 200
+        build = self.models.Build.query.first()
+        assert build.source_json_dict["spec_generator"] == "pyp2spec"
+
+        data["spec_generator"] = "pyp2rpm"
+        response = self.post_api3_with_auth(endpoint, data, user)
+        assert response.status_code == 400
+        assert "pyp2rpm is not maintained" in response.json["error"]
+
 
 def _fake_rpm_file(filename, content=b"fake rpm bytes"):
     return FileStorage(stream=BytesIO(content), filename=filename,

--- a/frontend/coprs_frontend/tests/test_packages.py
+++ b/frontend/coprs_frontend/tests/test_packages.py
@@ -1,0 +1,26 @@
+"""
+Test all kinds of package request via v3 API
+"""
+
+import pytest
+from tests.coprs_test_case import CoprsTestCase, TransactionDecorator
+
+
+class TestAPIv3Packages(CoprsTestCase):
+
+    @TransactionDecorator("u1")
+    @pytest.mark.usefixtures("f_users", "f_users_api", "f_coprs", "f_db")
+    def test_v3_package_pypi(self):
+        response = self.api3.create_pypi_package(
+            "foocopr",
+            "pello1",
+            options={"spec_generator": "pyp2spec"},
+        )
+        assert response.status_code == 200
+
+        with pytest.raises(AssertionError):
+            response = self.api3.create_pypi_package(
+                "foocopr",
+                "pello2",
+                options={"spec_generator": "pyp2rpm"},
+            )

--- a/rpmbuild/copr-rpmbuild.spec
+++ b/rpmbuild/copr-rpmbuild.spec
@@ -93,7 +93,6 @@ Recommends: python-srpm-macros
 Recommends: dist-git-client
 Suggests: tito
 Suggests: rubygem-gem2rpm
-Suggests: pyp2rpm
 Suggests: pyp2spec >= 0.10.0
 %endif
 
@@ -119,7 +118,6 @@ Requires: podman
 %if 0%{?openEuler} > 0 || 0%{?rhel} > 0
 # not supported
 %else
-Requires: pyp2rpm
 Requires: pyp2spec >= 0.10.0
 Requires: rubygem-gem2rpm
 Requires: fedora-review >= 0.8

--- a/rpmbuild/copr_rpmbuild/providers/pypi.py
+++ b/rpmbuild/copr_rpmbuild/providers/pypi.py
@@ -13,12 +13,12 @@ class PyPIProvider(Provider):
         source_json = self.source_dict
         self.pypi_package_version = source_json["pypi_package_version"]
         self.pypi_package_name = source_json["pypi_package_name"]
-        self.spec_generator = source_json.get("spec_generator", "pyp2rpm")
+        self.spec_generator = source_json.get("spec_generator", "pyp2spec")
         self.spec_template = source_json.get("spec_template", '')
         self.python_versions = source_json["python_versions"] or []
 
     def tool_presence_check(self):
-        if self.spec_generator not in ["pyp2rpm", "pyp2spec"]:
+        if self.spec_generator not in ["pyp2spec"]:
             msg = "Unsupported tool: {0}".format(self.spec_generator)
             raise RuntimeError(msg)
 
@@ -30,26 +30,7 @@ class PyPIProvider(Provider):
 
     def produce_srpm(self):
         self.tool_presence_check()
-
-        if self.spec_generator == "pyp2rpm":
-            self._produce_srpm_pyp2rpm()
-        else:
-            self._produce_srpm_pyp2spec()
-
-    def _produce_srpm_pyp2rpm(self):
-        cmd = ["pyp2rpm", self.pypi_package_name, "-t", self.spec_template,
-               "--srpm", "-d", self.resultdir]
-
-        for i, python_version in enumerate(self.python_versions):
-            if i == 0:
-                cmd += ["-b", str(python_version)]
-            else:
-                cmd += ["-p", str(python_version)]
-
-        if self.pypi_package_version:
-            cmd += ["-v", self.pypi_package_version]
-
-        return run_cmd(cmd)
+        self._produce_srpm_pyp2spec()
 
     def _produce_srpm_pyp2spec(self):
         os.chdir(self.resultdir)

--- a/rpmbuild/tests/test_pypi.py
+++ b/rpmbuild/tests/test_pypi.py
@@ -28,14 +28,21 @@ class TestPyPIProvider(TestCase):
        self.assertEqual(provider.spec_template, "epel7")
        self.assertEqual(provider.python_versions, [2, 3])
 
+    @mock.patch("copr_rpmbuild.providers.base.Provider.build_srpm_from_spec")
     @mock.patch("copr_rpmbuild.providers.pypi.run_cmd")
+    @mock.patch("copr_rpmbuild.providers.pypi.locate_spec")
+    @mock.patch('copr_rpmbuild.providers.base.os.chdir')
     @mock.patch('{0}.open'.format(builtins), new_callable=mock.mock_open)
     @mock.patch('copr_rpmbuild.providers.base.os.mkdir')
-    def test_produce_srpm(self, mock_mkdir, mock_open, run_cmd):
+    def test_produce_srpm(self, mock_mkdir, mock_open, _mock_chdir, locate_spec,
+                          pypi_run_cmd, build_srpm_from_spec):
+        locate_spec.return_value = "/foo/bar/motionpaint.spec"
         provider = PyPIProvider(self.source_json, self.config)
         provider.produce_srpm()
         assert_cmd = [
-            "pyp2rpm", "motionpaint", "-t", "epel7", "--srpm",
-            "-d", self.config.get("main", "resultdir"),
-            "-b", "2", "-p", "3", "-v", "1.52"]
-        run_cmd.assert_called_with(assert_cmd)
+            "pyp2spec", "motionpaint",
+            "--fedora-compliant", "--automode",
+            "-v", "1.52",
+        ]
+        pypi_run_cmd.assert_called_with(assert_cmd)
+        build_srpm_from_spec.assert_called_with("/foo/bar/motionpaint.spec")


### PR DESCRIPTION
See #4476
Fix RHBZ 2517932
Fix RHBZ 2517929

The pyp2rpm package is now retired in Fedora and it is probably not worth taking since the Python team is focusing on pyp2spec instead.