### PR TITLE
backend: make get_package_by_prn work with Pulp domains

### DIFF
--- a/backend/copr_backend/pulp.py
+++ b/backend/copr_backend/pulp.py
@@ -450,7 +450,9 @@ class PulpClient:
         Get a detailed information about a package
         """
         pulp_id = prn.rsplit(":", 1)[1]
-        return self.get_by_href(f"/pulp/api/v3/content/rpm/packages/{pulp_id}/")
+        uri = f"/api/v3/content/rpm/packages/{pulp_id}/"
+        self.log.info("Pulp: get_by_prn: %s", uri)
+        return self.send("GET", uri)
 
     def create_distribution(self, name, repository, basepath=None):
         """


### PR DESCRIPTION
See #4472

I tested that PR only locally, where Pulp domains are disabled. On STG and production it fails because it tries to query e.g. this:

https://packages.redhat.com/pulp/api/v3/content/rpm/packages/01a05b15-7756-7f24-88f2-f09387e38465/

instead of this:

https://packages.redhat.com/api/pulp/public-copr/api/v3/content/rpm/packages/01a05b15-7756-7f24-88f2-f09387e38465/