### PR TITLE
rpmbuild: extract all sources not just specfile

### DIFF
--- a/rpmbuild/main.py
+++ b/rpmbuild/main.py
@@ -206,8 +206,8 @@ def build_srpm(args, config):
     log.info("Output: {0}".format(
         list(entry.name for entry in os.scandir(resultdir))))
 
-    # extract spec file from SRPM
-    cmd = f"rpm2archive -n < {locate_srpm(resultdir)} | tar xf - '*.spec'"
+    # extract spec file and additional sources from the SRPM
+    cmd = f"rpm2archive -n < {locate_srpm(resultdir)} | tar xf - '*'"
     subprocess.run(cmd, shell=True, check=False, cwd=resultdir)
 
     with open(os.path.join(resultdir, 'success'), "w") as success:


### PR DESCRIPTION
Fix #4325

The spec might do something like:

    Source4: macros.ruby
    %{load:%{SOURCE4}}

and therefore require the `Source4` to be available when trying to parse it using the `python3-specfile` library.