### PR TITLE
backend: add script to set an attribute for all Pulp repositories

### DIFF
--- a/backend/run/copr-pulp-set-for-all
+++ b/backend/run/copr-pulp-set-for-all
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+
+"""
+Set retain_package_versions=0 on all Pulp RPM repositories.
+Rewrite to set any other attribute or make this general in the future.
+"""
+
+from urllib.parse import urlencode
+from copr_backend.pulp import PulpClient, PulpRequest
+
+
+def pulp_repositories(client):
+    """
+    Iterate over all Pulp RPM repositories.
+    """
+    limit = 100
+    offset = 0
+
+    while True:
+        query = urlencode({"limit": limit, "offset": offset})
+        response = client.send("GET", f"/api/v3/repositories/rpm/rpm/?{query}")
+        response.raise_for_status()
+        data = response.json()
+
+        repositories = data["results"]
+        yield from repositories
+        if not data["next"]:
+            break
+        offset += limit
+
+
+def main():
+    """
+    The main function.
+    """
+    client = PulpClient.create_from_config_file()
+    requests = []
+
+    for repository in pulp_repositories(client):
+        if repository.get("retain_package_versions") == 0:
+            continue
+
+        href = repository["pulp_href"]
+        requests.append(PulpRequest(
+            "PATCH",
+            client.config["base_url"] + href,
+            {"retain_package_versions": 0},
+            f"set retain_package_versions=0 on {repository['name']}",
+        ))
+
+    print(f"Going to update {len(requests)} repositories")
+    if not requests:
+        return
+
+    # We have a hardcoded attribute and value, so rather ask, in case somebody
+    # runs this accidentally
+    if input("Are you sure? [yes/no] ") != "yes":
+        print("Aborted")
+        return
+
+    client.deliver_and_wait(requests)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
See #4216
See #4071

Due to historical reasons, we have some projects that have `retain_package_versions` set to 5 and some projects that have it set to 0. More confusingly so, the inconsistency is on CoprChroot level and so that the cleanup can behave differently for two chroots within the same project.

    [copr@copr-be root][PROD]$ copr-pulp-query \
        --project @kernel-vanilla/mainline-wo-mergew \
        --chroot fedora-44-x86_64 \
        |grep retain_package_versions
     'retain_package_versions': 0,

    [copr@copr-be root][PROD]$ copr-pulp-query \
        --project @kernel-vanilla/mainline-wo-mergew \
        --chroot fedora-43-x86_64 \
        |grep retain_package_versions
     'retain_package_versions': 5,

Assisted-by: OpenAI Codex <codex@openai.com>